### PR TITLE
Fix account confirmation recovery flow

### DIFF
--- a/backend.Tests/Auth/AccountConfirmationFlowTests.cs
+++ b/backend.Tests/Auth/AccountConfirmationFlowTests.cs
@@ -1,0 +1,494 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BudgetPlanner.Authentication;
+using BudgetPlanner.Configuration;
+using BudgetPlanner.Data;
+using BudgetPlanner.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Auth;
+
+public sealed class AccountConfirmationFlowTests
+{
+    private const string Password = "Password1!";
+
+    [Fact]
+    public async Task Register_creates_user_and_sends_one_confirmation_email()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/register",
+            new { email = "new@example.com", password = Password });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(await app.FindUserByEmailAsync("new@example.com"));
+        var sent = Assert.Single(app.EmailSender.Messages);
+        Assert.Equal("new@example.com", sent.ToEmail);
+        Assert.Contains("https://frontend.test/confirm-email?", sent.HtmlBody);
+    }
+
+    [Fact]
+    public async Task Register_email_failure_leaves_user_persisted_and_returns_recovery_response()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.DeliveryFailure);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/register",
+            new { email = "stranded@example.com", password = Password });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal("confirmation_email_delivery_failed", body.GetProperty("code").GetString());
+        var user = await app.FindUserByEmailAsync("stranded@example.com");
+        Assert.NotNull(user);
+        Assert.False(user.EmailConfirmed);
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Register_creation_failure_is_distinct_and_does_not_send_email()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/register",
+            new { email = "invalid@example.com", password = "weak" });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(JsonValueKind.Array, body.ValueKind);
+        Assert.Null(await app.FindUserByEmailAsync("invalid@example.com"));
+        Assert.Empty(app.EmailSender.Messages);
+    }
+
+    [Fact]
+    public async Task Resend_sends_confirmation_for_existing_unconfirmed_account()
+    {
+        await using var app = await TestApplication.StartAsync();
+        await app.CreateUserAsync("unconfirmed@example.com", confirmed: false);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email = "unconfirmed@example.com" });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(TestApplication.GenericResendMessage, body.GetProperty("message").GetString());
+        Assert.Single(app.EmailSender.Messages);
+    }
+
+    [Theory]
+    [InlineData("missing@example.com", false)]
+    [InlineData("confirmed@example.com", true)]
+    public async Task Resend_has_same_public_response_without_sending_when_not_eligible(
+        string email,
+        bool createConfirmedUser)
+    {
+        await using var app = await TestApplication.StartAsync();
+        if (createConfirmedUser)
+            await app.CreateUserAsync(email, confirmed: true);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(TestApplication.GenericResendMessage, body.GetProperty("message").GetString());
+        Assert.Empty(app.EmailSender.Messages);
+    }
+
+    [Fact]
+    public async Task Resend_does_not_reveal_delivery_failure()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.DeliveryFailure);
+        await app.CreateUserAsync("unconfirmed@example.com", confirmed: false);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email = "unconfirmed@example.com" });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(TestApplication.GenericResendMessage, body.GetProperty("message").GetString());
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Unexpected_email_boundary_exception_is_not_reported_as_delivery_failure()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.UnexpectedFailure);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            app.Client.PostAsJsonAsync(
+                "/api/auth/register",
+                new { email = "unexpected@example.com", password = Password }));
+
+        Assert.Equal("Simulated programming failure.", exception.Message);
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Email_boundary_cancellation_is_not_swallowed()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.Cancellation);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            app.Client.PostAsJsonAsync(
+                "/api/auth/register",
+                new { email = "cancelled@example.com", password = Password }));
+
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Registration_email_contains_valid_confirmation_link_that_confirms_account()
+    {
+        await using var app = await TestApplication.StartAsync();
+        var registration = await app.Client.PostAsJsonAsync(
+            "/api/auth/register",
+            new { email = "confirm@example.com", password = Password });
+        Assert.Equal(HttpStatusCode.OK, registration.StatusCode);
+
+        var sent = Assert.Single(app.EmailSender.Messages);
+        var href = Regex.Match(sent.HtmlBody, "href=\"([^\"]+)\"").Groups[1].Value;
+        var confirmationUri = new Uri(WebUtility.HtmlDecode(href));
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(confirmationUri.Query);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/confirm-email",
+            new { userId = query["userId"].ToString(), token = query["token"].ToString() });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var createdUser = await app.FindUserByEmailAsync("confirm@example.com");
+        Assert.NotNull(createdUser);
+        var confirmedUser = await app.FindUserByIdAsync(createdUser.Id);
+        Assert.NotNull(confirmedUser);
+        Assert.True(confirmedUser.EmailConfirmed);
+    }
+
+    [Fact]
+    public async Task Unconfirmed_user_cannot_log_in()
+    {
+        await using var app = await TestApplication.StartAsync();
+        await app.CreateUserAsync("unconfirmed@example.com", confirmed: false);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/login",
+            new { email = "unconfirmed@example.com", password = Password });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Confirmed_user_can_log_in()
+    {
+        await using var app = await TestApplication.StartAsync();
+        await app.CreateUserAsync("confirmed@example.com", confirmed: true);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/login",
+            new { email = "confirmed@example.com", password = Password });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fourth_resend_for_same_normalized_email_is_rate_limited()
+    {
+        await using var app = await TestApplication.StartAsync();
+        const string email = "target@example.com";
+
+        for (var attempt = 0; attempt < ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit; attempt++)
+        {
+            var allowed = await app.Client.PostAsJsonAsync(
+                "/api/auth/resend-confirmation",
+                new { email });
+            Assert.Equal(HttpStatusCode.Accepted, allowed.StatusCode);
+        }
+
+        var limited = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email });
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+    }
+
+    [Fact]
+    public async Task Email_casing_variations_share_one_rate_limit_bucket()
+    {
+        await using var app = await TestApplication.StartAsync();
+        var variants = new[]
+        {
+            "CaseSensitive@example.com",
+            "casesensitive@example.com",
+            "CASESENSITIVE@EXAMPLE.COM"
+        };
+
+        foreach (var email in variants)
+        {
+            var allowed = await app.Client.PostAsJsonAsync(
+                "/api/auth/resend-confirmation",
+                new { email });
+            Assert.Equal(HttpStatusCode.Accepted, allowed.StatusCode);
+        }
+
+        var limited = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email = "CaSeSeNsItIvE@Example.Com" });
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+    }
+
+    [Fact]
+    public async Task Different_email_addresses_have_independent_rate_limit_buckets()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        for (var attempt = 0; attempt < ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit; attempt++)
+        {
+            var allowed = await app.Client.PostAsJsonAsync(
+                "/api/auth/resend-confirmation",
+                new { email = "first@example.com" });
+            Assert.Equal(HttpStatusCode.Accepted, allowed.StatusCode);
+        }
+
+        var otherAddress = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email = "second@example.com" });
+
+        Assert.Equal(HttpStatusCode.Accepted, otherAddress.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("missing", 0)]
+    [InlineData("confirmed", 0)]
+    [InlineData("unconfirmed", 3)]
+    public async Task Account_states_have_same_rate_limit_mechanics(
+        string accountState,
+        int expectedDeliveryAttempts)
+    {
+        await using var app = await TestApplication.StartAsync();
+        const string email = "rate-limited@example.com";
+        if (accountState == "confirmed")
+            await app.CreateUserAsync(email, confirmed: true);
+        else if (accountState == "unconfirmed")
+            await app.CreateUserAsync(email, confirmed: false);
+
+        for (var attempt = 0; attempt < ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit; attempt++)
+        {
+            var allowed = await app.Client.PostAsJsonAsync(
+                "/api/auth/resend-confirmation",
+                new { email });
+            Assert.Equal(HttpStatusCode.Accepted, allowed.StatusCode);
+            var body = await allowed.Content.ReadFromJsonAsync<JsonElement>();
+            Assert.Equal(TestApplication.GenericResendMessage, body.GetProperty("message").GetString());
+        }
+
+        var limited = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email });
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+        Assert.Equal(expectedDeliveryAttempts, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Concurrent_resends_cannot_exceed_email_bucket_allowance()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        var requests = Enumerable.Range(0, 10).Select(_ =>
+            app.Client.PostAsJsonAsync(
+                "/api/auth/resend-confirmation",
+                new { email = "concurrent@example.com" }));
+        var responses = await Task.WhenAll(requests);
+
+        Assert.Equal(
+            ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit,
+            responses.Count(response => response.StatusCode == HttpStatusCode.Accepted));
+        Assert.Equal(
+            responses.Length - ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit,
+            responses.Count(response => response.StatusCode == HttpStatusCode.TooManyRequests));
+    }
+
+    [Fact]
+    public async Task Global_limiter_rejects_after_configured_process_allowance()
+    {
+        const int globalLimit = 5;
+        await using var app = await TestApplication.StartAsync(
+            limiterSettings: new LimiterTestSettings(globalLimit));
+
+        for (var attempt = 0; attempt < globalLimit; attempt++)
+        {
+            var allowed = await app.Client.PostAsJsonAsync(
+                "/api/auth/resend-confirmation",
+                new { email = $"global-{attempt}@example.com" });
+            Assert.Equal(HttpStatusCode.Accepted, allowed.StatusCode);
+        }
+
+        var limited = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email = "global-final@example.com" });
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+        Assert.Empty(app.EmailSender.Messages);
+    }
+
+    [Fact]
+    public async Task Global_rejection_skips_recipient_limiter_and_delivery()
+    {
+        var limiter = new RecordingConfirmationResendLimiter(acquireGlobal: false);
+        await using var app = await TestApplication.StartAsync(limiterOverride: limiter);
+        await app.CreateUserAsync("protected@example.com", confirmed: false);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email = "protected@example.com" });
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.Equal(1, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Overlong_email_is_rejected_before_any_limiter_acquisition()
+    {
+        var limiter = new RecordingConfirmationResendLimiter(acquireGlobal: true);
+        await using var app = await TestApplication.StartAsync(limiterOverride: limiter);
+        var email = $"{new string('a', 243)}@example.com";
+        Assert.True(email.Length > 254);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-email")]
+    public async Task Missing_whitespace_and_malformed_email_have_controlled_boundary_response(
+        string? email)
+    {
+        var limiter = new RecordingConfirmationResendLimiter(acquireGlobal: true);
+        await using var app = await TestApplication.StartAsync(limiterOverride: limiter);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { email });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Missing_email_property_has_controlled_boundary_response()
+    {
+        var limiter = new RecordingConfirmationResendLimiter(acquireGlobal: true);
+        await using var app = await TestApplication.StartAsync(limiterOverride: limiter);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/resend-confirmation",
+            new { });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Production_composition_resolves_issue_services_and_validated_options()
+    {
+        await using var app = await TestApplication.StartAsync();
+        using var scope = app.Services.CreateScope();
+        var services = scope.ServiceProvider;
+
+        Assert.NotNull(services.GetRequiredService<IAccountConfirmationService>());
+        Assert.NotNull(services.GetRequiredService<IConfirmationResendLimiter>());
+        Assert.Contains(
+            services.GetServices<IValidateOptions<EmailSettingsOptions>>(),
+            validator => validator is EmailSettingsOptionsValidator);
+        Assert.Contains(
+            services.GetServices<IValidateOptions<FrontendOptions>>(),
+            validator => validator is FrontendOptionsValidator);
+        Assert.Equal("sender@example.com", services.GetRequiredService<IOptions<EmailSettingsOptions>>().Value.FromEmail);
+        var limiterOptions = services.GetRequiredService<IOptions<ConfirmationResendLimiterOptions>>().Value;
+        Assert.Equal(60, limiterOptions.GlobalPermitLimit);
+        Assert.Equal(3, limiterOptions.RecipientPermitLimit);
+        Assert.Equal(
+            "Microsoft.EntityFrameworkCore.InMemory",
+            services.GetRequiredService<BudgetContext>().Database.ProviderName);
+    }
+}
+
+public sealed class AccountConfirmationConfigurationTests
+{
+    [Fact]
+    public void Email_configuration_rejects_missing_and_malformed_values()
+    {
+        var validator = new EmailSettingsOptionsValidator();
+
+        var empty = validator.Validate(null, new EmailSettingsOptions());
+        var malformed = validator.Validate(null, new EmailSettingsOptions
+        {
+            FromName = "Budget Planner",
+            FromEmail = "not-an-email",
+            SmtpServer = "smtp.example.com",
+            SmtpPort = 70000,
+            Username = "user",
+            Password = "password"
+        });
+        var valid = validator.Validate(null, new EmailSettingsOptions
+        {
+            FromName = "Budget Planner",
+            FromEmail = "sender@example.com",
+            SmtpServer = "smtp.example.com",
+            SmtpPort = 587,
+            Username = "user",
+            Password = "password"
+        });
+
+        Assert.True(empty.Failed);
+        Assert.True(malformed.Failed);
+        Assert.True(valid.Succeeded);
+    }
+
+    [Fact]
+    public void Frontend_configuration_requires_absolute_https_url_in_production()
+    {
+        var validator = new FrontendOptionsValidator(new TestHostEnvironment("Production"));
+
+        Assert.True(validator.Validate(null, new FrontendOptions()).Failed);
+        Assert.True(validator.Validate(null, new FrontendOptions { BaseUrl = "relative/path" }).Failed);
+        Assert.True(validator.Validate(null, new FrontendOptions { BaseUrl = "http://example.com" }).Failed);
+        Assert.True(validator.Validate(null, new FrontendOptions { BaseUrl = "https://example.com?bad=value" }).Failed);
+        Assert.True(validator.Validate(null, new FrontendOptions { BaseUrl = "https://example.com" }).Succeeded);
+    }
+}
+
+internal sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
+{
+    public string EnvironmentName { get; set; } = environmentName;
+    public string ApplicationName { get; set; } = "BudgetPlanner.Tests";
+    public string ContentRootPath { get; set; } = Directory.GetCurrentDirectory();
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}

--- a/backend.Tests/Auth/AccountConfirmationFlowTests.cs
+++ b/backend.Tests/Auth/AccountConfirmationFlowTests.cs
@@ -428,9 +428,14 @@ public sealed class AccountConfirmationFlowTests
             services.GetServices<IValidateOptions<EmailSettingsOptions>>(),
             validator => validator is EmailSettingsOptionsValidator);
         Assert.Contains(
+            services.GetServices<IValidateOptions<GoogleEmailOptions>>(),
+            validator => validator is GoogleEmailOptionsValidator);
+        Assert.Contains(
             services.GetServices<IValidateOptions<FrontendOptions>>(),
             validator => validator is FrontendOptionsValidator);
         Assert.Equal("sender@example.com", services.GetRequiredService<IOptions<EmailSettingsOptions>>().Value.FromEmail);
+        Assert.Equal("test-client-id", services.GetRequiredService<IOptions<GoogleEmailOptions>>().Value.ClientId);
+        Assert.IsType<GmailApiClient>(services.GetRequiredService<IGmailApiClient>());
         var limiterOptions = services.GetRequiredService<IOptions<ConfirmationResendLimiterOptions>>().Value;
         Assert.Equal(60, limiterOptions.GlobalPermitLimit);
         Assert.Equal(3, limiterOptions.RecipientPermitLimit);
@@ -443,7 +448,7 @@ public sealed class AccountConfirmationFlowTests
 public sealed class AccountConfirmationConfigurationTests
 {
     [Fact]
-    public void Email_configuration_rejects_missing_and_malformed_values()
+    public void Sender_configuration_rejects_missing_and_malformed_values()
     {
         var validator = new EmailSettingsOptionsValidator();
 
@@ -451,25 +456,46 @@ public sealed class AccountConfirmationConfigurationTests
         var malformed = validator.Validate(null, new EmailSettingsOptions
         {
             FromName = "Budget Planner",
-            FromEmail = "not-an-email",
-            SmtpServer = "smtp.example.com",
-            SmtpPort = 70000,
-            Username = "user",
-            Password = "password"
+            FromEmail = "not-an-email"
         });
         var valid = validator.Validate(null, new EmailSettingsOptions
         {
             FromName = "Budget Planner",
-            FromEmail = "sender@example.com",
-            SmtpServer = "smtp.example.com",
-            SmtpPort = 587,
-            Username = "user",
-            Password = "password"
+            FromEmail = "sender@example.com"
         });
 
         Assert.True(empty.Failed);
         Assert.True(malformed.Failed);
         Assert.True(valid.Succeeded);
+    }
+
+    [Fact]
+    public void Google_email_configuration_requires_each_oauth_credential()
+    {
+        var validator = new GoogleEmailOptionsValidator();
+        var valid = new GoogleEmailOptions
+        {
+            ClientId = "client-id",
+            ClientSecret = "client-secret",
+            RefreshToken = "refresh-token"
+        };
+
+        Assert.True(validator.Validate(null, new GoogleEmailOptions
+        {
+            ClientSecret = valid.ClientSecret,
+            RefreshToken = valid.RefreshToken
+        }).Failed);
+        Assert.True(validator.Validate(null, new GoogleEmailOptions
+        {
+            ClientId = valid.ClientId,
+            RefreshToken = valid.RefreshToken
+        }).Failed);
+        Assert.True(validator.Validate(null, new GoogleEmailOptions
+        {
+            ClientId = valid.ClientId,
+            ClientSecret = valid.ClientSecret
+        }).Failed);
+        Assert.True(validator.Validate(null, valid).Succeeded);
     }
 
     [Fact]

--- a/backend.Tests/Auth/GmailEmailServiceTests.cs
+++ b/backend.Tests/Auth/GmailEmailServiceTests.cs
@@ -1,0 +1,117 @@
+using BudgetPlanner.Configuration;
+using BudgetPlanner.Services;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Auth;
+
+public sealed class GmailEmailServiceTests
+{
+    private static readonly EmailSettingsOptions SenderSettings = new()
+    {
+        FromName = "Budget Planner",
+        FromEmail = "budgetplanner26@gmail.com"
+    };
+
+    [Fact]
+    public async Task Send_constructs_base64url_mime_message_and_targets_authenticated_user()
+    {
+        var client = new RecordingGmailApiClient();
+        var service = CreateService(client);
+        using var cancellation = new CancellationTokenSource();
+
+        await service.SendEmailAsync(
+            "recipient@example.com",
+            "Confirm your account",
+            "<p>Confirm <strong>now</strong>.</p>",
+            cancellation.Token);
+
+        Assert.Equal("me", client.UserId);
+        Assert.Equal(cancellation.Token, client.CancellationToken);
+        Assert.NotNull(client.RawMessage);
+        Assert.DoesNotContain('+', client.RawMessage);
+        Assert.DoesNotContain('/', client.RawMessage);
+        Assert.DoesNotContain('=', client.RawMessage);
+
+        using var decoded = new MemoryStream(DecodeBase64Url(client.RawMessage));
+        var message = MimeMessage.Load(decoded);
+        Assert.Equal("Budget Planner", message.From.Mailboxes.Single().Name);
+        Assert.Equal("budgetplanner26@gmail.com", message.From.Mailboxes.Single().Address);
+        Assert.Equal("recipient@example.com", message.To.Mailboxes.Single().Address);
+        Assert.Equal("Confirm your account", message.Subject);
+        Assert.Equal("<p>Confirm <strong>now</strong>.</p>", message.HtmlBody?.TrimEnd());
+    }
+
+    [Fact]
+    public async Task Expected_provider_failure_becomes_email_delivery_exception()
+    {
+        var providerFailure = new HttpRequestException("Provider unavailable.");
+        var service = CreateService(new RecordingGmailApiClient(providerFailure));
+
+        var exception = await Assert.ThrowsAsync<EmailDeliveryException>(() =>
+            service.SendEmailAsync("recipient@example.com", "Subject", "<p>Body</p>"));
+
+        Assert.Same(providerFailure, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task Caller_cancellation_propagates_without_translation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var client = new RecordingGmailApiClient(new OperationCanceledException(cancellation.Token));
+        var service = CreateService(client);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.SendEmailAsync(
+                "recipient@example.com",
+                "Subject",
+                "<p>Body</p>",
+                cancellation.Token));
+
+    }
+
+    [Fact]
+    public async Task Unexpected_programming_exception_is_not_translated()
+    {
+        var programmingFailure = new InvalidOperationException("Unexpected defect.");
+        var service = CreateService(new RecordingGmailApiClient(programmingFailure));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendEmailAsync("recipient@example.com", "Subject", "<p>Body</p>"));
+
+        Assert.Same(programmingFailure, exception);
+    }
+
+    private static EmailService CreateService(IGmailApiClient client) =>
+        new(Options.Create(SenderSettings), client);
+
+    private static byte[] DecodeBase64Url(string rawMessage)
+    {
+        var padded = rawMessage.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - padded.Length % 4) % 4);
+        return Convert.FromBase64String(padded);
+    }
+}
+
+internal sealed class RecordingGmailApiClient(Exception? exception = null) : IGmailApiClient
+{
+    public string? UserId { get; private set; }
+    public string? RawMessage { get; private set; }
+    public CancellationToken CancellationToken { get; private set; }
+
+    public Task SendRawMessageAsync(
+        string userId,
+        string rawMessage,
+        CancellationToken cancellationToken = default)
+    {
+        UserId = userId;
+        RawMessage = rawMessage;
+        CancellationToken = cancellationToken;
+
+        return exception == null
+            ? Task.CompletedTask
+            : Task.FromException(exception);
+    }
+}

--- a/backend.Tests/Auth/TestApplication.cs
+++ b/backend.Tests/Auth/TestApplication.cs
@@ -1,0 +1,235 @@
+using System.Collections.Concurrent;
+using BudgetPlanner.Authentication;
+using BudgetPlanner.Configuration;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using BudgetPlanner.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Tests.Auth;
+
+internal sealed class TestApplication : WebApplicationFactory<Program>
+{
+    private static readonly object HostStartupLock = new();
+
+    public const string GenericResendMessage =
+        "If an unconfirmed account exists for that email, a confirmation link has been sent.";
+
+    private readonly string _databaseName = $"confirmation-tests-{Guid.NewGuid()}";
+    private readonly LimiterTestSettings? _limiterSettings;
+    private readonly IConfirmationResendLimiter? _limiterOverride;
+
+    private TestApplication(
+        EmailFailureMode emailFailureMode,
+        LimiterTestSettings? limiterSettings,
+        IConfirmationResendLimiter? limiterOverride)
+    {
+        EmailSender = new FakeEmailService(emailFailureMode);
+        _limiterSettings = limiterSettings;
+        _limiterOverride = limiterOverride;
+    }
+
+    public HttpClient Client { get; private set; } = null!;
+    public FakeEmailService EmailSender { get; }
+
+    public static Task<TestApplication> StartAsync(
+        EmailFailureMode emailFailureMode = EmailFailureMode.None,
+        LimiterTestSettings? limiterSettings = null,
+        IConfirmationResendLimiter? limiterOverride = null)
+    {
+        var application = new TestApplication(
+            emailFailureMode,
+            limiterSettings,
+            limiterOverride);
+        lock (HostStartupLock)
+        {
+            var originalEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            var originalJwtKey = Environment.GetEnvironmentVariable("Jwt__Key");
+            try
+            {
+                Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
+                Environment.SetEnvironmentVariable(
+                    "Jwt__Key",
+                    "test-only-signing-key-that-is-at-least-thirty-two-bytes-long");
+                application.Client = application.CreateClient();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", originalEnvironment);
+                Environment.SetEnvironmentVariable("Jwt__Key", originalJwtKey);
+            }
+        }
+        return Task.FromResult(application);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<BudgetContext>>();
+            services.RemoveAll<IDbContextOptionsConfiguration<BudgetContext>>();
+            services.AddDbContext<BudgetContext>(options =>
+                options.UseInMemoryDatabase(_databaseName));
+
+            services.RemoveAll<IEmailService>();
+            services.AddSingleton<IEmailService>(EmailSender);
+
+            if (_limiterSettings != null)
+            {
+                services.Configure<ConfirmationResendLimiterOptions>(options =>
+                {
+                    options.GlobalPermitLimit = _limiterSettings.GlobalPermitLimit;
+                    options.RecipientPermitLimit = _limiterSettings.RecipientPermitLimit;
+                });
+            }
+
+            if (_limiterOverride != null)
+            {
+                services.RemoveAll<IConfirmationResendLimiter>();
+                services.AddSingleton(_limiterOverride);
+            }
+        });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(configuration =>
+            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=unused-by-tests",
+                ["Jwt:Key"] = "test-only-signing-key-that-is-at-least-thirty-two-bytes-long",
+                ["EmailSettings:FromName"] = "Budget Planner Tests",
+                ["EmailSettings:FromEmail"] = "sender@example.com",
+                ["EmailSettings:SmtpServer"] = "smtp.example.com",
+                ["EmailSettings:SmtpPort"] = "587",
+                ["EmailSettings:Username"] = "test-user",
+                ["EmailSettings:Password"] = "test-password",
+                ["Frontend:BaseUrl"] = "https://frontend.test"
+            }));
+
+        return base.CreateHost(builder);
+    }
+
+    public async Task<ApplicationUser> CreateUserAsync(string email, bool confirmed)
+    {
+        using var scope = Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = new ApplicationUser { UserName = email, Email = email };
+        var createResult = await users.CreateAsync(user, "Password1!");
+        if (!createResult.Succeeded)
+            throw new InvalidOperationException(string.Join(", ", createResult.Errors.Select(error => error.Description)));
+
+        if (confirmed)
+        {
+            var token = await users.GenerateEmailConfirmationTokenAsync(user);
+            var confirmResult = await users.ConfirmEmailAsync(user, token);
+            if (!confirmResult.Succeeded)
+                throw new InvalidOperationException("Unable to confirm test user.");
+        }
+
+        return user;
+    }
+
+    public async Task<ApplicationUser?> FindUserByEmailAsync(string email)
+    {
+        using var scope = Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        return await users.FindByEmailAsync(email);
+    }
+
+    public async Task<ApplicationUser?> FindUserByIdAsync(string userId)
+    {
+        using var scope = Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        return await users.FindByIdAsync(userId);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            Client?.Dispose();
+        base.Dispose(disposing);
+    }
+}
+
+internal enum EmailFailureMode
+{
+    None,
+    DeliveryFailure,
+    UnexpectedFailure,
+    Cancellation
+}
+
+internal sealed record LimiterTestSettings(
+    int GlobalPermitLimit,
+    int RecipientPermitLimit = ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit);
+
+internal sealed class RecordingConfirmationResendLimiter(
+    bool acquireGlobal,
+    bool acquireRecipient = true) : IConfirmationResendLimiter
+{
+    private int _globalAttempts;
+    private int _recipientAttempts;
+
+    public int GlobalAttempts => _globalAttempts;
+    public int RecipientAttempts => _recipientAttempts;
+    public ConcurrentQueue<string> RecipientEmails { get; } = new();
+
+    public bool TryAcquireGlobal()
+    {
+        Interlocked.Increment(ref _globalAttempts);
+        return acquireGlobal;
+    }
+
+    public bool TryAcquireRecipient(string requestedEmail)
+    {
+        Interlocked.Increment(ref _recipientAttempts);
+        RecipientEmails.Enqueue(requestedEmail);
+        return acquireRecipient;
+    }
+}
+
+internal sealed class FakeEmailService(EmailFailureMode failureMode) : IEmailService
+{
+    private int _attemptCount;
+    private readonly ConcurrentQueue<SentEmail> _messages = new();
+
+    public int AttemptCount => _attemptCount;
+    public IReadOnlyCollection<SentEmail> Messages => _messages.ToArray();
+
+    public Task SendEmailAsync(
+        string toEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _attemptCount);
+
+        switch (failureMode)
+        {
+            case EmailFailureMode.DeliveryFailure:
+                throw new EmailDeliveryException(
+                    "Simulated delivery failure.",
+                    new IOException("Simulated provider failure."));
+            case EmailFailureMode.UnexpectedFailure:
+                throw new InvalidOperationException("Simulated programming failure.");
+            case EmailFailureMode.Cancellation:
+                throw new OperationCanceledException(cancellationToken);
+        }
+
+        _messages.Enqueue(new SentEmail(toEmail, subject, htmlBody));
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed record SentEmail(string ToEmail, string Subject, string HtmlBody);

--- a/backend.Tests/Auth/TestApplication.cs
+++ b/backend.Tests/Auth/TestApplication.cs
@@ -110,10 +110,9 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
                 ["Jwt:Key"] = "test-only-signing-key-that-is-at-least-thirty-two-bytes-long",
                 ["EmailSettings:FromName"] = "Budget Planner Tests",
                 ["EmailSettings:FromEmail"] = "sender@example.com",
-                ["EmailSettings:SmtpServer"] = "smtp.example.com",
-                ["EmailSettings:SmtpPort"] = "587",
-                ["EmailSettings:Username"] = "test-user",
-                ["EmailSettings:Password"] = "test-password",
+                ["GoogleEmail:ClientId"] = "test-client-id",
+                ["GoogleEmail:ClientSecret"] = "test-client-secret",
+                ["GoogleEmail:RefreshToken"] = "test-refresh-token",
                 ["Frontend:BaseUrl"] = "https://frontend.test"
             }));
 

--- a/backend.Tests/backend.Tests.csproj
+++ b/backend.Tests/backend.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../backend/backend.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/backend/Authentication/ConfirmationResendLimiter.cs
+++ b/backend/Authentication/ConfirmationResendLimiter.cs
@@ -1,0 +1,71 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Authentication;
+
+public interface IConfirmationResendLimiter
+{
+    bool TryAcquireGlobal();
+    bool TryAcquireRecipient(string requestedEmail);
+}
+
+public sealed class ConfirmationResendLimiterOptions
+{
+    public const int DefaultGlobalPermitLimit = 60;
+    public const int DefaultRecipientPermitLimit = 3;
+
+    public int GlobalPermitLimit { get; set; } = DefaultGlobalPermitLimit;
+    public int RecipientPermitLimit { get; set; } = DefaultRecipientPermitLimit;
+    public TimeSpan Window { get; set; } = TimeSpan.FromMinutes(1);
+}
+
+public sealed class ConfirmationResendLimiter : IConfirmationResendLimiter, IDisposable
+{
+    private static readonly ILookupNormalizer EmailNormalizer = new UpperInvariantLookupNormalizer();
+
+    private readonly FixedWindowRateLimiter _globalLimiter;
+    private readonly PartitionedRateLimiter<string> _recipientLimiter;
+
+    public ConfirmationResendLimiter(IOptions<ConfirmationResendLimiterOptions> options)
+    {
+        var settings = options.Value;
+        _globalLimiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = settings.GlobalPermitLimit,
+            Window = settings.Window,
+            QueueLimit = 0,
+            AutoReplenishment = true
+        });
+        _recipientLimiter = PartitionedRateLimiter.Create<string, string>(normalizedEmail =>
+            RateLimitPartition.GetFixedWindowLimiter(
+                normalizedEmail,
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = settings.RecipientPermitLimit,
+                    Window = settings.Window,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                }));
+    }
+
+    public bool TryAcquireGlobal()
+    {
+        using var lease = _globalLimiter.AttemptAcquire();
+        return lease.IsAcquired;
+    }
+
+    public bool TryAcquireRecipient(string requestedEmail)
+    {
+        var normalizedEmail = EmailNormalizer.NormalizeEmail(
+            requestedEmail?.Trim() ?? string.Empty) ?? string.Empty;
+        using var lease = _recipientLimiter.AttemptAcquire(normalizedEmail);
+        return lease.IsAcquired;
+    }
+
+    public void Dispose()
+    {
+        _globalLimiter.Dispose();
+        _recipientLimiter.Dispose();
+    }
+}

--- a/backend/Configuration/EmailSettingsOptions.cs
+++ b/backend/Configuration/EmailSettingsOptions.cs
@@ -9,10 +9,6 @@ public sealed class EmailSettingsOptions
 
     public string FromName { get; init; } = string.Empty;
     public string FromEmail { get; init; } = string.Empty;
-    public string SmtpServer { get; init; } = string.Empty;
-    public int SmtpPort { get; init; }
-    public string Username { get; init; } = string.Empty;
-    public string Password { get; init; } = string.Empty;
 }
 
 public sealed class EmailSettingsOptionsValidator : IValidateOptions<EmailSettingsOptions>
@@ -24,17 +20,11 @@ public sealed class EmailSettingsOptionsValidator : IValidateOptions<EmailSettin
         if (string.IsNullOrWhiteSpace(options.FromName))
             failures.Add("EmailSettings:FromName is required.");
         if (string.IsNullOrWhiteSpace(options.FromEmail) ||
-            !MailboxAddress.TryParse(options.FromEmail, out _))
+            !MailboxAddress.TryParse(options.FromEmail, out var mailbox) ||
+            !mailbox.Address.Contains('@', StringComparison.Ordinal) ||
+            mailbox.Address.StartsWith('@') ||
+            mailbox.Address.EndsWith('@'))
             failures.Add("EmailSettings:FromEmail must be a valid email address.");
-        if (string.IsNullOrWhiteSpace(options.SmtpServer))
-            failures.Add("EmailSettings:SmtpServer is required.");
-        if (options.SmtpPort is < 1 or > 65535)
-            failures.Add("EmailSettings:SmtpPort must be between 1 and 65535.");
-        if (string.IsNullOrWhiteSpace(options.Username))
-            failures.Add("EmailSettings:Username is required.");
-        if (string.IsNullOrWhiteSpace(options.Password))
-            failures.Add("EmailSettings:Password is required.");
-
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);

--- a/backend/Configuration/EmailSettingsOptions.cs
+++ b/backend/Configuration/EmailSettingsOptions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace BudgetPlanner.Configuration;
+
+public sealed class EmailSettingsOptions
+{
+    public const string SectionName = "EmailSettings";
+
+    public string FromName { get; init; } = string.Empty;
+    public string FromEmail { get; init; } = string.Empty;
+    public string SmtpServer { get; init; } = string.Empty;
+    public int SmtpPort { get; init; }
+    public string Username { get; init; } = string.Empty;
+    public string Password { get; init; } = string.Empty;
+}
+
+public sealed class EmailSettingsOptionsValidator : IValidateOptions<EmailSettingsOptions>
+{
+    public ValidateOptionsResult Validate(string? name, EmailSettingsOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.FromName))
+            failures.Add("EmailSettings:FromName is required.");
+        if (string.IsNullOrWhiteSpace(options.FromEmail) ||
+            !MailboxAddress.TryParse(options.FromEmail, out _))
+            failures.Add("EmailSettings:FromEmail must be a valid email address.");
+        if (string.IsNullOrWhiteSpace(options.SmtpServer))
+            failures.Add("EmailSettings:SmtpServer is required.");
+        if (options.SmtpPort is < 1 or > 65535)
+            failures.Add("EmailSettings:SmtpPort must be between 1 and 65535.");
+        if (string.IsNullOrWhiteSpace(options.Username))
+            failures.Add("EmailSettings:Username is required.");
+        if (string.IsNullOrWhiteSpace(options.Password))
+            failures.Add("EmailSettings:Password is required.");
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/backend/Configuration/FrontendOptions.cs
+++ b/backend/Configuration/FrontendOptions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Configuration;
+
+public sealed class FrontendOptions
+{
+    public const string SectionName = "Frontend";
+
+    public string BaseUrl { get; init; } = string.Empty;
+}
+
+public sealed class FrontendOptionsValidator(IHostEnvironment environment)
+    : IValidateOptions<FrontendOptions>
+{
+    public ValidateOptionsResult Validate(string? name, FrontendOptions options)
+    {
+        if (!Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment))
+        {
+            return ValidateOptionsResult.Fail(
+                "Frontend:BaseUrl must be an absolute HTTP or HTTPS URL without a query or fragment.");
+        }
+
+        if (environment.IsProduction() && uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return ValidateOptionsResult.Fail(
+                "Frontend:BaseUrl must use HTTPS in production.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/backend/Configuration/GoogleEmailOptions.cs
+++ b/backend/Configuration/GoogleEmailOptions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Configuration;
+
+public sealed class GoogleEmailOptions
+{
+    public const string SectionName = "GoogleEmail";
+
+    public string ClientId { get; init; } = string.Empty;
+    public string ClientSecret { get; init; } = string.Empty;
+    public string RefreshToken { get; init; } = string.Empty;
+}
+
+public sealed class GoogleEmailOptionsValidator : IValidateOptions<GoogleEmailOptions>
+{
+    public ValidateOptionsResult Validate(string? name, GoogleEmailOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.ClientId))
+            failures.Add("GoogleEmail:ClientId is required.");
+        if (string.IsNullOrWhiteSpace(options.ClientSecret))
+            failures.Add("GoogleEmail:ClientSecret is required.");
+        if (string.IsNullOrWhiteSpace(options.RefreshToken))
+            failures.Add("GoogleEmail:RefreshToken is required.");
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -1,8 +1,10 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System.ComponentModel.DataAnnotations;
 using BudgetPlanner.Models;
 using BudgetPlanner.Services;
+using BudgetPlanner.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
@@ -17,19 +19,27 @@ public class AuthController : ControllerBase
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IConfiguration _configuration;
     private readonly IEmailService _emailService;
+    private readonly IAccountConfirmationService _accountConfirmationService;
+    private readonly IConfirmationResendLimiter _confirmationResendLimiter;
 
     public AuthController(
         UserManager<ApplicationUser> userManager,
         IConfiguration configuration,
-        IEmailService emailService)
+        IEmailService emailService,
+        IAccountConfirmationService accountConfirmationService,
+        IConfirmationResendLimiter confirmationResendLimiter)
     {
         _userManager = userManager;
         _configuration = configuration;
         _emailService = emailService;
+        _accountConfirmationService = accountConfirmationService;
+        _confirmationResendLimiter = confirmationResendLimiter;
     }
 
     [HttpPost("register")]
-    public async Task<IActionResult> Register(RegisterRequest request)
+    public async Task<IActionResult> Register(
+        RegisterRequest request,
+        CancellationToken cancellationToken)
     {
         var user = new ApplicationUser
         {
@@ -42,43 +52,60 @@ public class AuthController : ControllerBase
         if (!result.Succeeded)
             return BadRequest(result.Errors);
 
-        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
-
-        var frontendBaseUrl = _configuration["Frontend:BaseUrl"];
-
-        var confirmationLink =
-            $"{frontendBaseUrl}/confirm-email?userId={user.Id}&token={encodedToken}";
-
-        await _emailService.SendEmailAsync(
-            request.Email,
-            "Confirm your Budget Planner account",
-            $"""
-            <div style="background:#0f172a; padding:40px 20px; font-family:Arial, sans-serif;">
-              <div style="max-width:500px; margin:auto; background:#020617; border-radius:14px; padding:24px; border:1px solid #1f2933;">
-
-                <h2 style="color:#e5e7eb; margin:0 0 10px;">Budget Planner</h2>
-
-                <p style="color:rgba(255,255,255,0.7); margin:0 0 20px;">
-                  Confirm your email to finish creating your account.
-                </p>
-
-                <a href="{confirmationLink}"
-                   style="display:inline-block; padding:12px 20px; background:#2e6dd3; color:white; text-decoration:none; border-radius:12px; font-weight:600;">
-                  Confirm Email
-                </a>
-
-                <p style="color:rgba(255,255,255,0.5); margin-top:25px; font-size:13px;">
-                  If you didn’t create this account, you can safely ignore this email.
-                </p>
-              </div>
-            </div>
-            """
-        );
+        try
+        {
+            await _accountConfirmationService.SendConfirmationEmailAsync(
+                user,
+                ConfirmationEmailReason.Registration,
+                cancellationToken);
+        }
+        catch (EmailDeliveryException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                code = "confirmation_email_delivery_failed",
+                message = "Your account was created, but we couldn't send the confirmation email. Please request a new confirmation email."
+            });
+        }
 
         return Ok(new
         {
             message = "User registered successfully. Please check your email to confirm your account."
+        });
+    }
+
+    [HttpPost("resend-confirmation")]
+    public async Task<IActionResult> ResendConfirmation(
+        ResendConfirmationRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!_confirmationResendLimiter.TryAcquireGlobal())
+            return StatusCode(StatusCodes.Status429TooManyRequests);
+
+        if (!_confirmationResendLimiter.TryAcquireRecipient(request.Email!))
+            return StatusCode(StatusCodes.Status429TooManyRequests);
+
+        var user = await _userManager.FindByEmailAsync(request.Email!);
+
+        if (user != null && !await _userManager.IsEmailConfirmedAsync(user))
+        {
+            try
+            {
+                await _accountConfirmationService.SendConfirmationEmailAsync(
+                    user,
+                    ConfirmationEmailReason.Resend,
+                    cancellationToken);
+            }
+            catch (EmailDeliveryException)
+            {
+                // Preserve the same public response for missing, confirmed, and
+                // delivery-failed accounts to avoid account enumeration.
+            }
+        }
+
+        return Accepted(new
+        {
+            message = "If an unconfirmed account exists for that email, a confirmation link has been sent."
         });
     }
 
@@ -233,6 +260,8 @@ public class AuthController : ControllerBase
 
 public record RegisterRequest(string Email, string Password);
 public record LoginRequest(string Email, string Password);
+public record ResendConfirmationRequest(
+    [Required, StringLength(254), EmailAddress] string? Email);
 public record ConfirmEmailRequest(string UserId, string Token);
 public record ForgotPasswordRequest(string Email);
 public record ResetPasswordRequest(string Email, string Token, string NewPassword);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -7,6 +7,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using BudgetPlanner.Services;
+using BudgetPlanner.Authentication;
+using BudgetPlanner.Configuration;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,6 +27,18 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddControllers();
+
+builder.Services
+    .AddOptions<EmailSettingsOptions>()
+    .Bind(builder.Configuration.GetSection(EmailSettingsOptions.SectionName))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<EmailSettingsOptions>, EmailSettingsOptionsValidator>();
+
+builder.Services
+    .AddOptions<FrontendOptions>()
+    .Bind(builder.Configuration.GetSection(FrontendOptions.SectionName))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<FrontendOptions>, FrontendOptionsValidator>();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
@@ -96,11 +111,16 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<IEmailService, EmailService>();
+builder.Services.AddScoped<IAccountConfirmationService, AccountConfirmationService>();
+builder.Services.AddOptions<ConfirmationResendLimiterOptions>();
+builder.Services.AddSingleton<IConfirmationResendLimiter, ConfirmationResendLimiter>();
 
 var app = builder.Build();
 
-using (var scope = app.Services.CreateScope())
+// Integration tests use isolated infrastructure and must never execute production migrations.
+if (!app.Environment.IsEnvironment("Testing"))
 {
+    using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
     db.Database.Migrate();
 }
@@ -121,3 +141,5 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -35,6 +35,12 @@ builder.Services
 builder.Services.AddSingleton<IValidateOptions<EmailSettingsOptions>, EmailSettingsOptionsValidator>();
 
 builder.Services
+    .AddOptions<GoogleEmailOptions>()
+    .Bind(builder.Configuration.GetSection(GoogleEmailOptions.SectionName))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<GoogleEmailOptions>, GoogleEmailOptionsValidator>();
+
+builder.Services
     .AddOptions<FrontendOptions>()
     .Bind(builder.Configuration.GetSection(FrontendOptions.SectionName))
     .ValidateOnStart();
@@ -110,6 +116,7 @@ builder.Services.AddAuthentication(options =>
 });
 
 builder.Services.AddAuthorization();
+builder.Services.AddSingleton<IGmailApiClient, GmailApiClient>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<IAccountConfirmationService, AccountConfirmationService>();
 builder.Services.AddOptions<ConfirmationResendLimiterOptions>();

--- a/backend/Services/AccountConfirmationService.cs
+++ b/backend/Services/AccountConfirmationService.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Text;
+using BudgetPlanner.Configuration;
+using BudgetPlanner.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Services;
+
+public sealed class AccountConfirmationService(
+    UserManager<ApplicationUser> userManager,
+    IEmailService emailService,
+    IOptions<FrontendOptions> frontendOptions,
+    ILogger<AccountConfirmationService> logger) : IAccountConfirmationService
+{
+    public async Task SendConfirmationEmailAsync(
+        ApplicationUser user,
+        ConfirmationEmailReason reason,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
+        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
+        var confirmationUrl = QueryHelpers.AddQueryString(
+            $"{frontendOptions.Value.BaseUrl.TrimEnd('/')}/confirm-email",
+            new Dictionary<string, string?>
+            {
+                ["userId"] = user.Id,
+                ["token"] = encodedToken
+            });
+
+        logger.LogInformation(
+            "Attempting confirmation email delivery for user {UserId}; reason {Reason}",
+            user.Id,
+            reason);
+
+        try
+        {
+            await emailService.SendEmailAsync(
+                user.Email ?? throw new InvalidOperationException("User email is missing."),
+                "Confirm your Budget Planner account",
+                BuildEmailBody(WebUtility.HtmlEncode(confirmationUrl)),
+                cancellationToken);
+
+            logger.LogInformation(
+                "Confirmation email accepted by the SMTP server for user {UserId}; reason {Reason}",
+                user.Id,
+                reason);
+        }
+        catch (EmailDeliveryException exception)
+        {
+            logger.LogError(
+                exception,
+                "Confirmation email delivery failed for user {UserId}; reason {Reason}",
+                user.Id,
+                reason);
+            throw;
+        }
+    }
+
+    private static string BuildEmailBody(string confirmationUrl) =>
+        $"""
+        <div style="background:#0f172a; padding:40px 20px; font-family:Arial, sans-serif;">
+          <div style="max-width:500px; margin:auto; background:#020617; border-radius:14px; padding:24px; border:1px solid #1f2933;">
+            <h2 style="color:#e5e7eb; margin:0 0 10px;">Budget Planner</h2>
+            <p style="color:rgba(255,255,255,0.7); margin:0 0 20px;">
+              Confirm your email to finish creating your account.
+            </p>
+            <a href="{confirmationUrl}"
+               style="display:inline-block; padding:12px 20px; background:#2e6dd3; color:white; text-decoration:none; border-radius:12px; font-weight:600;">
+              Confirm Email
+            </a>
+            <p style="color:rgba(255,255,255,0.5); margin-top:25px; font-size:13px;">
+              If you didn’t create this account, you can safely ignore this email.
+            </p>
+          </div>
+        </div>
+        """;
+}

--- a/backend/Services/AccountConfirmationService.cs
+++ b/backend/Services/AccountConfirmationService.cs
@@ -43,7 +43,7 @@ public sealed class AccountConfirmationService(
                 cancellationToken);
 
             logger.LogInformation(
-                "Confirmation email accepted by the SMTP server for user {UserId}; reason {Reason}",
+                "Confirmation email accepted by the email provider for user {UserId}; reason {Reason}",
                 user.Id,
                 reason);
         }

--- a/backend/Services/EmailDeliveryException.cs
+++ b/backend/Services/EmailDeliveryException.cs
@@ -1,0 +1,9 @@
+namespace BudgetPlanner.Services;
+
+public sealed class EmailDeliveryException : Exception
+{
+    public EmailDeliveryException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -1,14 +1,14 @@
-using System.Net.Sockets;
-using MailKit;
-using MailKit.Net.Smtp;
-using MailKit.Security;
 using MimeKit;
 using BudgetPlanner.Configuration;
+using Google;
+using Google.Apis.Auth.OAuth2.Responses;
 using Microsoft.Extensions.Options;
 
 namespace BudgetPlanner.Services;
 
-public class EmailService(IOptions<EmailSettingsOptions> emailSettings) : IEmailService
+public class EmailService(
+    IOptions<EmailSettingsOptions> emailSettings,
+    IGmailApiClient gmailApiClient) : IEmailService
 {
     public async Task SendEmailAsync(
         string toEmail,
@@ -32,27 +32,23 @@ public class EmailService(IOptions<EmailSettingsOptions> emailSettings) : IEmail
             HtmlBody = htmlBody
         }.ToMessageBody();
 
-        using var client = new SmtpClient();
+        using var stream = new MemoryStream();
+        await message.WriteToAsync(stream, cancellationToken);
+        var rawMessage = Convert.ToBase64String(stream.ToArray())
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
 
         try
         {
-            await client.ConnectAsync(
-                settings.SmtpServer,
-                settings.SmtpPort,
-                SecureSocketOptions.StartTls,
-                cancellationToken
-            );
-
-            await client.AuthenticateAsync(
-                settings.Username,
-                settings.Password,
-                cancellationToken
-            );
-
-            await client.SendAsync(message, cancellationToken);
-            await client.DisconnectAsync(true, cancellationToken);
+            await gmailApiClient.SendRawMessageAsync(
+                "me",
+                rawMessage,
+                cancellationToken);
         }
-        catch (Exception exception) when (IsExpectedDeliveryFailure(exception))
+        catch (Exception exception) when (
+            IsExpectedDeliveryFailure(exception) &&
+            !(exception is OperationCanceledException && cancellationToken.IsCancellationRequested))
         {
             throw new EmailDeliveryException(
                 "The email provider did not accept the message.",
@@ -61,14 +57,10 @@ public class EmailService(IOptions<EmailSettingsOptions> emailSettings) : IEmail
     }
 
     private static bool IsExpectedDeliveryFailure(Exception exception) =>
-        exception is SmtpCommandException
-            or SmtpProtocolException
-            or ServiceNotConnectedException
-            or ServiceNotAuthenticatedException
-            or SocketException
+        exception is GoogleApiException
+            or TokenResponseException
+            or HttpRequestException
             or IOException
-            or System.Security.Authentication.AuthenticationException
-            or MailKit.Security.AuthenticationException
             or TimeoutException
-            or SslHandshakeException;
+            or OperationCanceledException;
 }

--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -1,26 +1,27 @@
+using System.Net.Sockets;
+using MailKit;
 using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
+using BudgetPlanner.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace BudgetPlanner.Services;
 
-public class EmailService : IEmailService
+public class EmailService(IOptions<EmailSettingsOptions> emailSettings) : IEmailService
 {
-    private readonly IConfiguration _configuration;
-
-    public EmailService(IConfiguration configuration)
+    public async Task SendEmailAsync(
+        string toEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken = default)
     {
-        _configuration = configuration;
-    }
-
-    public async Task SendEmailAsync(string toEmail, string subject, string htmlBody)
-    {
-        var emailSettings = _configuration.GetSection("EmailSettings");
+        var settings = emailSettings.Value;
 
         var message = new MimeMessage();
         message.From.Add(new MailboxAddress(
-            emailSettings["FromName"],
-            emailSettings["FromEmail"]
+            settings.FromName,
+            settings.FromEmail
         ));
 
         message.To.Add(MailboxAddress.Parse(toEmail));
@@ -33,18 +34,41 @@ public class EmailService : IEmailService
 
         using var client = new SmtpClient();
 
-        await client.ConnectAsync(
-            emailSettings["SmtpServer"],
-            int.Parse(emailSettings["SmtpPort"]!),
-            SecureSocketOptions.StartTls
-        );
+        try
+        {
+            await client.ConnectAsync(
+                settings.SmtpServer,
+                settings.SmtpPort,
+                SecureSocketOptions.StartTls,
+                cancellationToken
+            );
 
-        await client.AuthenticateAsync(
-            emailSettings["Username"],
-            emailSettings["Password"]
-        );
+            await client.AuthenticateAsync(
+                settings.Username,
+                settings.Password,
+                cancellationToken
+            );
 
-        await client.SendAsync(message);
-        await client.DisconnectAsync(true);
+            await client.SendAsync(message, cancellationToken);
+            await client.DisconnectAsync(true, cancellationToken);
+        }
+        catch (Exception exception) when (IsExpectedDeliveryFailure(exception))
+        {
+            throw new EmailDeliveryException(
+                "The email provider did not accept the message.",
+                exception);
+        }
     }
+
+    private static bool IsExpectedDeliveryFailure(Exception exception) =>
+        exception is SmtpCommandException
+            or SmtpProtocolException
+            or ServiceNotConnectedException
+            or ServiceNotAuthenticatedException
+            or SocketException
+            or IOException
+            or System.Security.Authentication.AuthenticationException
+            or MailKit.Security.AuthenticationException
+            or TimeoutException
+            or SslHandshakeException;
 }

--- a/backend/Services/GmailApiClient.cs
+++ b/backend/Services/GmailApiClient.cs
@@ -1,0 +1,57 @@
+using BudgetPlanner.Configuration;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Gmail.v1;
+using Google.Apis.Gmail.v1.Data;
+using Google.Apis.Services;
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Services;
+
+public sealed class GmailApiClient : IGmailApiClient, IDisposable
+{
+    private readonly GoogleAuthorizationCodeFlow _flow;
+    private readonly GmailService _gmailService;
+
+    public GmailApiClient(IOptions<GoogleEmailOptions> googleEmailOptions)
+    {
+        var settings = googleEmailOptions.Value;
+        _flow = new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
+        {
+            ClientSecrets = new ClientSecrets
+            {
+                ClientId = settings.ClientId,
+                ClientSecret = settings.ClientSecret
+            },
+            Scopes = [GmailService.Scope.GmailSend]
+        });
+        var credential = new UserCredential(
+            _flow,
+            "me",
+            new TokenResponse { RefreshToken = settings.RefreshToken });
+
+        _gmailService = new GmailService(new BaseClientService.Initializer
+        {
+            HttpClientInitializer = credential,
+            ApplicationName = "Budget Planner"
+        });
+    }
+
+    public async Task SendRawMessageAsync(
+        string userId,
+        string rawMessage,
+        CancellationToken cancellationToken = default)
+    {
+        var request = _gmailService.Users.Messages.Send(
+            new Message { Raw = rawMessage },
+            userId);
+        await request.ExecuteAsync(cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _gmailService.Dispose();
+        _flow.Dispose();
+    }
+}

--- a/backend/Services/IAccountConfirmationService.cs
+++ b/backend/Services/IAccountConfirmationService.cs
@@ -1,0 +1,17 @@
+using BudgetPlanner.Models;
+
+namespace BudgetPlanner.Services;
+
+public enum ConfirmationEmailReason
+{
+    Registration,
+    Resend
+}
+
+public interface IAccountConfirmationService
+{
+    Task SendConfirmationEmailAsync(
+        ApplicationUser user,
+        ConfirmationEmailReason reason,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/Services/IEmailService.cs
+++ b/backend/Services/IEmailService.cs
@@ -2,5 +2,9 @@ namespace BudgetPlanner.Services;
 
 public interface IEmailService
 {
-    Task SendEmailAsync(string toEmail, string subject, string htmlBody);
+    Task SendEmailAsync(
+        string toEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken = default);
 }

--- a/backend/Services/IGmailApiClient.cs
+++ b/backend/Services/IGmailApiClient.cs
@@ -1,0 +1,9 @@
+namespace BudgetPlanner.Services;
+
+public interface IGmailApiClient
+{
+    Task SendRawMessageAsync(
+        string userId,
+        string rawMessage,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -7,11 +7,12 @@
   },
   "EmailSettings": {
     "FromName": "",
-    "FromEmail": "",
-    "SmtpServer": "",
-    "SmtpPort": 587,
-    "Username": "",
-    "Password": ""
+    "FromEmail": ""
+  },
+  "GoogleEmail": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "RefreshToken": ""
   },
   "Frontend": {
     "BaseUrl": ""

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Google.Apis.Gmail.v1" Version="1.75.0.4225" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="MimeKit" Version="4.16.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/frontend/src/features/auth/components/AuthPage.jsx
+++ b/frontend/src/features/auth/components/AuthPage.jsx
@@ -10,6 +10,8 @@ export default function AuthPage({ onLogin }) {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [resendMessage, setResendMessage] = useState("");
+  const [isResending, setIsResending] = useState(false);
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -25,6 +27,7 @@ export default function AuthPage({ onLogin }) {
         await authApi.register({ email, password });
         alert("Account created. Please confirm your email before logging in.");
         setMode("login");
+        setResendMessage("");
         setPassword("");
         setConfirmPassword("");
         return;
@@ -41,18 +44,49 @@ export default function AuthPage({ onLogin }) {
 
       const errorData = err.response?.data;
 
+      if (errorData?.code === "confirmation_email_delivery_failed") {
+        setMode("login");
+        setPassword("");
+        setConfirmPassword("");
+        setResendMessage(errorData.message);
+        return;
+      }
+
       if (Array.isArray(errorData)) {
         alert(errorData.map((e) => e.description).join("\n"));
       } else if (typeof errorData === "string") {
         alert(errorData);
+      } else if (typeof errorData?.message === "string") {
+        alert(errorData.message);
       } else {
         alert(err.message || "Something went wrong.");
       }
     }
   }
 
+  async function handleResendConfirmation() {
+    if (!email || isResending) return;
+
+    setIsResending(true);
+    setResendMessage("");
+
+    try {
+      const response = await authApi.resendConfirmation({ email });
+      setResendMessage(response.data.message);
+    } catch (err) {
+      if (err.response?.status === 429) {
+        setResendMessage("Too many requests. Please wait before trying again.");
+      } else {
+        setResendMessage("Unable to request another confirmation email right now.");
+      }
+    } finally {
+      setIsResending(false);
+    }
+  }
+
   function switchMode() {
     setMode(mode === "login" ? "register" : "login");
+    setResendMessage("");
     setPassword("");
     setConfirmPassword("");
   }
@@ -142,6 +176,20 @@ export default function AuthPage({ onLogin }) {
             ? "Need an account? Register"
             : "Already have an account? Log in"}
         </button>
+
+        {mode === "login" && (
+          <>
+            <button
+              type="button"
+              className="button-ghost"
+              onClick={handleResendConfirmation}
+              disabled={!email || isResending}
+            >
+              {isResending ? "Requesting..." : "Resend confirmation email"}
+            </button>
+            {resendMessage && <p className="auth-help">{resendMessage}</p>}
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/features/auth/components/ConfirmEmailPage.jsx
+++ b/frontend/src/features/auth/components/ConfirmEmailPage.jsx
@@ -49,9 +49,10 @@ export default function ConfirmEmailPage() {
 
         {status === "error" && (
           <>
-            <h2 className="h2">Link Already Used</h2>
+            <h2 className="h2">Unable to Confirm Email</h2>
             <p className="auth-help">
-              This email may already be confirmed. Try logging in.
+              This confirmation link is invalid, expired, or already used. Try
+              logging in or request a new confirmation email.
             </p>
           </>
         )}

--- a/frontend/src/shared/api/authApi.js
+++ b/frontend/src/shared/api/authApi.js
@@ -4,6 +4,9 @@ export const authApi = {
   register: (payload) => client.post("/api/auth/register", payload),
   login: (payload) => client.post("/api/auth/login", payload),
 
+  resendConfirmation: (payload) =>
+    client.post("/api/auth/resend-confirmation", payload),
+
   confirmEmail: (payload) =>
     client.post("/api/auth/confirm-email", payload),
 


### PR DESCRIPTION
### Problem

Registration persisted the ASP.NET Identity user before attempting confirmation-email delivery. If delivery failed—or the message was never received—the account remained unconfirmed, login remained blocked, and the application provided no supported recovery path.

Release verification also established that the existing Gmail SMTP transport could not operate on Render Free: connecting to `smtp.gmail.com:587` timed out before SMTP authentication because the platform blocks outbound SMTP ports. This was a transport/platform incompatibility, not a Gmail credential failure.

### Solution

- Added a reusable account-confirmation email/link service shared by registration and resend.
- Added controlled partial-success registration behavior when the account is created but expected email delivery fails.
- Added an enumeration-safe resend-confirmation endpoint.
- Added a 60 requests/minute process-wide resend gate to bound total workload and recipient-partition creation.
- Added a 3 requests/minute gate per normalized recipient email.
- Added a validated 254-character email request boundary before limiter acquisition.
- Added minimal frontend resend recovery UX.
- Replaced misleading confirmation errors with neutral invalid, expired, or already-used messaging.
- Added typed email, Google OAuth, and frontend URL configuration with startup validation.
- Replaced MailKit/Gmail SMTP delivery with the Gmail API over HTTPS.
- Added unattended OAuth refresh-token authentication using only the `gmail.send` scope.
- Added Gmail `users.messages.send` delivery for authenticated user `me`.
- Added standards-compliant MIME construction and Gmail-compatible base64url encoding.
- Retained the narrow `EmailDeliveryException` boundary for expected provider, OAuth, and network failures.
- Preserved the requirement that email must be confirmed before login.

### Infrastructure rationale

Render Free blocks outbound SMTP ports, while the Gmail API communicates over HTTPS and is compatible with the intended zero-cost deployment architecture. Before application implementation, a direct Gmail API send was independently proven successful using the narrowly scoped OAuth setup. No OAuth credentials or token values are included in this repository or PR.

### Configuration

The backend requires these runtime settings:

- `GoogleEmail__ClientId`
- `GoogleEmail__ClientSecret`
- `GoogleEmail__RefreshToken`
- `EmailSettings__FromName`
- `EmailSettings__FromEmail`
- `Frontend__BaseUrl`

SMTP host, port, username, and password settings are no longer required by the application.

### Tests

35 backend tests include the previously approved account-confirmation/recovery integration suite and focused Gmail transport/configuration coverage. The integration suite exercises the real production `Program` via `WebApplicationFactory<Program>`, replacing only PostgreSQL with isolated EF Core InMemory storage and email delivery with deterministic fakes. The exact `Testing` environment guard prevents production migrations during these tests.

Final validation:

- `dotnet build` — PASS, 0 warnings/errors
- `dotnet test` — PASS, 35/35
- `npm run lint` — PASS, with one pre-existing out-of-scope `useBudgetLimits` warning
- `npm run build` — PASS
- `git diff --check main` — PASS

### Deployment / operational notes

- Gmail API credentials must remain valid and non-revoked.
- `EmailSettings__FromEmail` must correspond to the authenticated Gmail sender or a valid configured send-as identity.
- Gmail API acceptance does not guarantee inbox placement.
- Refresh-token revocation, Gmail quota, and delivery observability remain operational concerns.
- Rate limiting is process-local and intentionally not distributed in this issue.
- No database migration or schema change is included.

### Follow-up work

- Forgot-password enumeration behavior
- Malformed token hardening
- Migration-at-startup policy
- Data Protection persistence
- Distributed limiting if horizontally scaled
- Gmail/email delivery observability
- Existing `useBudgetLimits` warning
- npm audit findings
- Unrelated JWT/session issue
- Unrelated date/timezone issue

Closes #1
