### PR TITLE
Harden forgot-password recovery against enumeration and abuse

### DIFF
--- a/backend.Tests/Auth/ForgotPasswordFlowTests.cs
+++ b/backend.Tests/Auth/ForgotPasswordFlowTests.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BudgetPlanner.Authentication;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Auth;
+
+public sealed class ForgotPasswordFlowTests
+{
+    private const string ExistingEmail = "reset@example.com";
+
+    [Fact]
+    public async Task Existing_account_gets_neutral_response_and_working_reset_email()
+    {
+        await using var app = await TestApplication.StartAsync();
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+
+        var response = await PostForgotPasswordAsync(app, ExistingEmail);
+
+        await AssertNeutralSuccessAsync(response);
+        var sent = Assert.Single(app.EmailSender.Messages);
+        Assert.Equal(ExistingEmail, sent.ToEmail);
+        Assert.Equal("Reset your Budget Planner password", sent.Subject);
+
+        var href = Regex.Match(sent.HtmlBody, "href=\"([^\"]+)\"").Groups[1].Value;
+        var resetUri = new Uri(WebUtility.HtmlDecode(href));
+        var query = QueryHelpers.ParseQuery(resetUri.Query);
+        Assert.Equal(ExistingEmail, query["email"].ToString());
+
+        var reset = await app.Client.PostAsJsonAsync(
+            "/api/auth/reset-password",
+            new
+            {
+                email = query["email"].ToString(),
+                token = query["token"].ToString(),
+                newPassword = "NewPassword1!"
+            });
+
+        Assert.Equal(HttpStatusCode.OK, reset.StatusCode);
+    }
+
+    [Fact]
+    public async Task Missing_account_gets_same_neutral_response_without_email_attempt()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        var response = await PostForgotPasswordAsync(app, "missing@example.com");
+
+        await AssertNeutralSuccessAsync(response);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Expected_delivery_failure_gets_same_neutral_response()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.DeliveryFailure);
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+
+        var response = await PostForgotPasswordAsync(app, ExistingEmail);
+
+        await AssertNeutralSuccessAsync(response);
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-email")]
+    public async Task Invalid_email_is_rejected_before_limiter_or_email_work(string? email)
+    {
+        var limiter = new RecordingForgotPasswordLimiter(acquireGlobal: true);
+        await using var app = await TestApplication.StartAsync(forgotPasswordLimiterOverride: limiter);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/forgot-password",
+            new { email });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Missing_email_property_is_rejected_before_limiter_or_email_work()
+    {
+        var limiter = new RecordingForgotPasswordLimiter(acquireGlobal: true);
+        await using var app = await TestApplication.StartAsync(forgotPasswordLimiterOverride: limiter);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/forgot-password",
+            new { });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Overlong_email_is_rejected_before_limiter_or_email_work()
+    {
+        var limiter = new RecordingForgotPasswordLimiter(acquireGlobal: true);
+        await using var app = await TestApplication.StartAsync(forgotPasswordLimiterOverride: limiter);
+        var email = $"{new string('a', 243)}@example.com";
+        Assert.True(email.Length > 254);
+
+        var response = await PostForgotPasswordAsync(app, email);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Casing_variations_share_one_recipient_bucket()
+    {
+        await using var app = await TestApplication.StartAsync();
+        var variants = new[]
+        {
+            "CaseSensitive@example.com",
+            "casesensitive@example.com",
+            "CASESENSITIVE@EXAMPLE.COM"
+        };
+
+        foreach (var email in variants)
+            await AssertNeutralSuccessAsync(await PostForgotPasswordAsync(app, email));
+
+        var limited = await PostForgotPasswordAsync(app, "CaSeSeNsItIvE@Example.Com");
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+    }
+
+    [Fact]
+    public async Task Different_recipients_have_independent_buckets()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        for (var attempt = 0; attempt < ForgotPasswordLimiterOptions.DefaultRecipientPermitLimit; attempt++)
+            await AssertNeutralSuccessAsync(await PostForgotPasswordAsync(app, "first@example.com"));
+
+        await AssertNeutralSuccessAsync(await PostForgotPasswordAsync(app, "second@example.com"));
+    }
+
+    [Fact]
+    public async Task Global_limiter_rejects_after_configured_process_allowance()
+    {
+        const int globalLimit = 5;
+        await using var app = await TestApplication.StartAsync(
+            forgotPasswordLimiterSettings: new ForgotPasswordLimiterTestSettings(globalLimit));
+
+        for (var attempt = 0; attempt < globalLimit; attempt++)
+            await AssertNeutralSuccessAsync(await PostForgotPasswordAsync(app, $"global-{attempt}@example.com"));
+
+        var limited = await PostForgotPasswordAsync(app, "global-final@example.com");
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Theory]
+    [InlineData(false, 0)]
+    [InlineData(true, 3)]
+    public async Task Existing_and_missing_accounts_have_equivalent_limiter_mechanics(
+        bool existing,
+        int expectedEmailAttempts)
+    {
+        await using var app = await TestApplication.StartAsync();
+        const string email = "rate-limited@example.com";
+        if (existing)
+            await app.CreateUserAsync(email, confirmed: true);
+
+        for (var attempt = 0; attempt < ForgotPasswordLimiterOptions.DefaultRecipientPermitLimit; attempt++)
+            await AssertNeutralSuccessAsync(await PostForgotPasswordAsync(app, email));
+
+        var limited = await PostForgotPasswordAsync(app, email);
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+        Assert.Equal(expectedEmailAttempts, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Global_rejection_skips_recipient_and_downstream_work()
+    {
+        var limiter = new RecordingForgotPasswordLimiter(acquireGlobal: false);
+        await using var app = await TestApplication.StartAsync(forgotPasswordLimiterOverride: limiter);
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+
+        var response = await PostForgotPasswordAsync(app, ExistingEmail);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.Equal(1, limiter.GlobalAttempts);
+        Assert.Equal(0, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Recipient_rejection_skips_account_dependent_work()
+    {
+        var limiter = new RecordingForgotPasswordLimiter(acquireGlobal: true, acquireRecipient: false);
+        await using var app = await TestApplication.StartAsync(forgotPasswordLimiterOverride: limiter);
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+
+        var response = await PostForgotPasswordAsync(app, ExistingEmail);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.Equal(1, limiter.GlobalAttempts);
+        Assert.Equal(1, limiter.RecipientAttempts);
+        Assert.Equal(0, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Concurrent_requests_cannot_exceed_recipient_allowance()
+    {
+        await using var app = await TestApplication.StartAsync();
+
+        var responses = await Task.WhenAll(Enumerable.Range(0, 10).Select(_ =>
+            PostForgotPasswordAsync(app, "concurrent@example.com")));
+
+        Assert.Equal(
+            ForgotPasswordLimiterOptions.DefaultRecipientPermitLimit,
+            responses.Count(response => response.StatusCode == HttpStatusCode.OK));
+        Assert.Equal(
+            responses.Length - ForgotPasswordLimiterOptions.DefaultRecipientPermitLimit,
+            responses.Count(response => response.StatusCode == HttpStatusCode.TooManyRequests));
+    }
+
+    [Fact]
+    public async Task Unexpected_email_exception_propagates()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.UnexpectedFailure);
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            PostForgotPasswordAsync(app, ExistingEmail));
+
+        Assert.Equal("Simulated programming failure.", exception.Message);
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task Cancellation_propagates_and_request_token_reaches_email_boundary()
+    {
+        await using var app = await TestApplication.StartAsync(EmailFailureMode.Cancellation);
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+        using var cancellation = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            app.Client.PostAsJsonAsync(
+                "/api/auth/forgot-password",
+                new { email = ExistingEmail },
+                cancellation.Token));
+
+        Assert.Equal(1, app.EmailSender.AttemptCount);
+        Assert.True(app.EmailSender.ReceivedCancellableToken);
+    }
+
+    [Fact]
+    public async Task Production_composition_resolves_forgot_password_limiter_and_defaults()
+    {
+        await using var app = await TestApplication.StartAsync();
+        using var scope = app.Services.CreateScope();
+        var services = scope.ServiceProvider;
+
+        Assert.IsType<ForgotPasswordLimiter>(services.GetRequiredService<IForgotPasswordLimiter>());
+        var options = services.GetRequiredService<IOptions<ForgotPasswordLimiterOptions>>().Value;
+        Assert.Equal(60, options.GlobalPermitLimit);
+        Assert.Equal(3, options.RecipientPermitLimit);
+        Assert.Equal(TimeSpan.FromMinutes(1), options.Window);
+    }
+
+    private static Task<HttpResponseMessage> PostForgotPasswordAsync(
+        TestApplication app,
+        string email) =>
+        app.Client.PostAsJsonAsync("/api/auth/forgot-password", new { email });
+
+    private static async Task AssertNeutralSuccessAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(
+            TestApplication.GenericForgotPasswordMessage,
+            body.GetProperty("message").GetString());
+    }
+}

--- a/backend.Tests/Auth/TestApplication.cs
+++ b/backend.Tests/Auth/TestApplication.cs
@@ -23,19 +23,27 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
 
     public const string GenericResendMessage =
         "If an unconfirmed account exists for that email, a confirmation link has been sent.";
+    public const string GenericForgotPasswordMessage =
+        "If the email exists, a reset link was sent.";
 
     private readonly string _databaseName = $"confirmation-tests-{Guid.NewGuid()}";
     private readonly LimiterTestSettings? _limiterSettings;
     private readonly IConfirmationResendLimiter? _limiterOverride;
+    private readonly ForgotPasswordLimiterTestSettings? _forgotPasswordLimiterSettings;
+    private readonly IForgotPasswordLimiter? _forgotPasswordLimiterOverride;
 
     private TestApplication(
         EmailFailureMode emailFailureMode,
         LimiterTestSettings? limiterSettings,
-        IConfirmationResendLimiter? limiterOverride)
+        IConfirmationResendLimiter? limiterOverride,
+        ForgotPasswordLimiterTestSettings? forgotPasswordLimiterSettings,
+        IForgotPasswordLimiter? forgotPasswordLimiterOverride)
     {
         EmailSender = new FakeEmailService(emailFailureMode);
         _limiterSettings = limiterSettings;
         _limiterOverride = limiterOverride;
+        _forgotPasswordLimiterSettings = forgotPasswordLimiterSettings;
+        _forgotPasswordLimiterOverride = forgotPasswordLimiterOverride;
     }
 
     public HttpClient Client { get; private set; } = null!;
@@ -44,12 +52,16 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
     public static Task<TestApplication> StartAsync(
         EmailFailureMode emailFailureMode = EmailFailureMode.None,
         LimiterTestSettings? limiterSettings = null,
-        IConfirmationResendLimiter? limiterOverride = null)
+        IConfirmationResendLimiter? limiterOverride = null,
+        ForgotPasswordLimiterTestSettings? forgotPasswordLimiterSettings = null,
+        IForgotPasswordLimiter? forgotPasswordLimiterOverride = null)
     {
         var application = new TestApplication(
             emailFailureMode,
             limiterSettings,
-            limiterOverride);
+            limiterOverride,
+            forgotPasswordLimiterSettings,
+            forgotPasswordLimiterOverride);
         lock (HostStartupLock)
         {
             var originalEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
@@ -97,6 +109,21 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
             {
                 services.RemoveAll<IConfirmationResendLimiter>();
                 services.AddSingleton(_limiterOverride);
+            }
+
+            if (_forgotPasswordLimiterSettings != null)
+            {
+                services.Configure<ForgotPasswordLimiterOptions>(options =>
+                {
+                    options.GlobalPermitLimit = _forgotPasswordLimiterSettings.GlobalPermitLimit;
+                    options.RecipientPermitLimit = _forgotPasswordLimiterSettings.RecipientPermitLimit;
+                });
+            }
+
+            if (_forgotPasswordLimiterOverride != null)
+            {
+                services.RemoveAll<IForgotPasswordLimiter>();
+                services.AddSingleton(_forgotPasswordLimiterOverride);
             }
         });
     }
@@ -173,9 +200,38 @@ internal sealed record LimiterTestSettings(
     int GlobalPermitLimit,
     int RecipientPermitLimit = ConfirmationResendLimiterOptions.DefaultRecipientPermitLimit);
 
+internal sealed record ForgotPasswordLimiterTestSettings(
+    int GlobalPermitLimit,
+    int RecipientPermitLimit = ForgotPasswordLimiterOptions.DefaultRecipientPermitLimit);
+
 internal sealed class RecordingConfirmationResendLimiter(
     bool acquireGlobal,
     bool acquireRecipient = true) : IConfirmationResendLimiter
+{
+    private int _globalAttempts;
+    private int _recipientAttempts;
+
+    public int GlobalAttempts => _globalAttempts;
+    public int RecipientAttempts => _recipientAttempts;
+    public ConcurrentQueue<string> RecipientEmails { get; } = new();
+
+    public bool TryAcquireGlobal()
+    {
+        Interlocked.Increment(ref _globalAttempts);
+        return acquireGlobal;
+    }
+
+    public bool TryAcquireRecipient(string requestedEmail)
+    {
+        Interlocked.Increment(ref _recipientAttempts);
+        RecipientEmails.Enqueue(requestedEmail);
+        return acquireRecipient;
+    }
+}
+
+internal sealed class RecordingForgotPasswordLimiter(
+    bool acquireGlobal,
+    bool acquireRecipient = true) : IForgotPasswordLimiter
 {
     private int _globalAttempts;
     private int _recipientAttempts;
@@ -202,9 +258,11 @@ internal sealed class FakeEmailService(EmailFailureMode failureMode) : IEmailSer
 {
     private int _attemptCount;
     private readonly ConcurrentQueue<SentEmail> _messages = new();
+    private int _receivedCancellableToken;
 
     public int AttemptCount => _attemptCount;
     public IReadOnlyCollection<SentEmail> Messages => _messages.ToArray();
+    public bool ReceivedCancellableToken => Volatile.Read(ref _receivedCancellableToken) == 1;
 
     public Task SendEmailAsync(
         string toEmail,
@@ -213,6 +271,8 @@ internal sealed class FakeEmailService(EmailFailureMode failureMode) : IEmailSer
         CancellationToken cancellationToken = default)
     {
         Interlocked.Increment(ref _attemptCount);
+        if (cancellationToken.CanBeCanceled)
+            Interlocked.Exchange(ref _receivedCancellableToken, 1);
 
         switch (failureMode)
         {

--- a/backend/Authentication/ForgotPasswordLimiter.cs
+++ b/backend/Authentication/ForgotPasswordLimiter.cs
@@ -1,0 +1,71 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace BudgetPlanner.Authentication;
+
+public interface IForgotPasswordLimiter
+{
+    bool TryAcquireGlobal();
+    bool TryAcquireRecipient(string requestedEmail);
+}
+
+public sealed class ForgotPasswordLimiterOptions
+{
+    public const int DefaultGlobalPermitLimit = 60;
+    public const int DefaultRecipientPermitLimit = 3;
+
+    public int GlobalPermitLimit { get; set; } = DefaultGlobalPermitLimit;
+    public int RecipientPermitLimit { get; set; } = DefaultRecipientPermitLimit;
+    public TimeSpan Window { get; set; } = TimeSpan.FromMinutes(1);
+}
+
+public sealed class ForgotPasswordLimiter : IForgotPasswordLimiter, IDisposable
+{
+    private static readonly ILookupNormalizer EmailNormalizer = new UpperInvariantLookupNormalizer();
+
+    private readonly FixedWindowRateLimiter _globalLimiter;
+    private readonly PartitionedRateLimiter<string> _recipientLimiter;
+
+    public ForgotPasswordLimiter(IOptions<ForgotPasswordLimiterOptions> options)
+    {
+        var settings = options.Value;
+        _globalLimiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = settings.GlobalPermitLimit,
+            Window = settings.Window,
+            QueueLimit = 0,
+            AutoReplenishment = true
+        });
+        _recipientLimiter = PartitionedRateLimiter.Create<string, string>(normalizedEmail =>
+            RateLimitPartition.GetFixedWindowLimiter(
+                normalizedEmail,
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = settings.RecipientPermitLimit,
+                    Window = settings.Window,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                }));
+    }
+
+    public bool TryAcquireGlobal()
+    {
+        using var lease = _globalLimiter.AttemptAcquire();
+        return lease.IsAcquired;
+    }
+
+    public bool TryAcquireRecipient(string requestedEmail)
+    {
+        var normalizedEmail = EmailNormalizer.NormalizeEmail(
+            requestedEmail.Trim()) ?? string.Empty;
+        using var lease = _recipientLimiter.AttemptAcquire(normalizedEmail);
+        return lease.IsAcquired;
+    }
+
+    public void Dispose()
+    {
+        _globalLimiter.Dispose();
+        _recipientLimiter.Dispose();
+    }
+}

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -21,19 +21,22 @@ public class AuthController : ControllerBase
     private readonly IEmailService _emailService;
     private readonly IAccountConfirmationService _accountConfirmationService;
     private readonly IConfirmationResendLimiter _confirmationResendLimiter;
+    private readonly IForgotPasswordLimiter _forgotPasswordLimiter;
 
     public AuthController(
         UserManager<ApplicationUser> userManager,
         IConfiguration configuration,
         IEmailService emailService,
         IAccountConfirmationService accountConfirmationService,
-        IConfirmationResendLimiter confirmationResendLimiter)
+        IConfirmationResendLimiter confirmationResendLimiter,
+        IForgotPasswordLimiter forgotPasswordLimiter)
     {
         _userManager = userManager;
         _configuration = configuration;
         _emailService = emailService;
         _accountConfirmationService = accountConfirmationService;
         _confirmationResendLimiter = confirmationResendLimiter;
+        _forgotPasswordLimiter = forgotPasswordLimiter;
     }
 
     [HttpPost("register")]
@@ -154,51 +157,62 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("forgot-password")]
-    public async Task<IActionResult> ForgotPassword(ForgotPasswordRequest request)
+    public async Task<IActionResult> ForgotPassword(
+        ForgotPasswordRequest request,
+        CancellationToken cancellationToken)
     {
-        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (!_forgotPasswordLimiter.TryAcquireGlobal())
+            return StatusCode(StatusCodes.Status429TooManyRequests);
 
-        if (user == null)
+        if (!_forgotPasswordLimiter.TryAcquireRecipient(request.Email!))
+            return StatusCode(StatusCodes.Status429TooManyRequests);
+
+        var user = await _userManager.FindByEmailAsync(request.Email!);
+
+        if (user != null)
         {
-            return Ok(new
+            var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+            var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
+
+            var frontendBaseUrl = _configuration["Frontend:BaseUrl"];
+
+            var resetLink =
+                $"{frontendBaseUrl}/reset-password?email={Uri.EscapeDataString(request.Email!)}&token={encodedToken}";
+
+            try
             {
-                message = "If the email exists, a reset link was sent."
-            });
+                await _emailService.SendEmailAsync(
+                    request.Email!,
+                    "Reset your Budget Planner password",
+                    $"""
+                    <div style="background:#0f172a; padding:40px 20px; font-family:Arial, sans-serif;">
+                      <div style="max-width:500px; margin:auto; background:#020617; border-radius:14px; padding:24px; border:1px solid #1f2933;">
+
+                        <h2 style="color:#e5e7eb; margin:0 0 10px;">Budget Planner</h2>
+
+                        <p style="color:rgba(255,255,255,0.7); margin:0 0 20px;">
+                          Reset your password using the button below.
+                        </p>
+
+                        <a href="{resetLink}"
+                           style="display:inline-block; padding:12px 20px; background:#ef4444; color:white; text-decoration:none; border-radius:12px; font-weight:600;">
+                          Reset Password
+                        </a>
+
+                        <p style="color:rgba(255,255,255,0.5); margin-top:25px; font-size:13px;">
+                          If you didn’t request this, you can ignore this email.
+                        </p>
+                      </div>
+                    </div>
+                    """,
+                    cancellationToken);
+            }
+            catch (EmailDeliveryException)
+            {
+                // Preserve the same public response for missing and
+                // delivery-failed accounts to reduce account enumeration.
+            }
         }
-
-        var token = await _userManager.GeneratePasswordResetTokenAsync(user);
-        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
-
-        var frontendBaseUrl = _configuration["Frontend:BaseUrl"];
-
-        var resetLink =
-            $"{frontendBaseUrl}/reset-password?email={Uri.EscapeDataString(request.Email)}&token={encodedToken}";
-
-        await _emailService.SendEmailAsync(
-            request.Email,
-            "Reset your Budget Planner password",
-            $"""
-            <div style="background:#0f172a; padding:40px 20px; font-family:Arial, sans-serif;">
-              <div style="max-width:500px; margin:auto; background:#020617; border-radius:14px; padding:24px; border:1px solid #1f2933;">
-
-                <h2 style="color:#e5e7eb; margin:0 0 10px;">Budget Planner</h2>
-
-                <p style="color:rgba(255,255,255,0.7); margin:0 0 20px;">
-                  Reset your password using the button below.
-                </p>
-
-                <a href="{resetLink}"
-                   style="display:inline-block; padding:12px 20px; background:#ef4444; color:white; text-decoration:none; border-radius:12px; font-weight:600;">
-                  Reset Password
-                </a>
-
-                <p style="color:rgba(255,255,255,0.5); margin-top:25px; font-size:13px;">
-                  If you didn’t request this, you can ignore this email.
-                </p>
-              </div>
-            </div>
-            """
-        );
 
         return Ok(new
         {
@@ -263,5 +277,6 @@ public record LoginRequest(string Email, string Password);
 public record ResendConfirmationRequest(
     [Required, StringLength(254), EmailAddress] string? Email);
 public record ConfirmEmailRequest(string UserId, string Token);
-public record ForgotPasswordRequest(string Email);
+public record ForgotPasswordRequest(
+    [Required, StringLength(254), EmailAddress] string? Email);
 public record ResetPasswordRequest(string Email, string Token, string NewPassword);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -121,6 +121,8 @@ builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<IAccountConfirmationService, AccountConfirmationService>();
 builder.Services.AddOptions<ConfirmationResendLimiterOptions>();
 builder.Services.AddSingleton<IConfirmationResendLimiter, ConfirmationResendLimiter>();
+builder.Services.AddOptions<ForgotPasswordLimiterOptions>();
+builder.Services.AddSingleton<IForgotPasswordLimiter, ForgotPasswordLimiter>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Problem

The forgot-password endpoint lacked bounded input validation and abuse controls, and expected email-delivery failures could produce publicly distinguishable behavior for existing versus missing accounts.

## Solution

- validates forgot-password email input before endpoint work
- adds independent process-wide and normalized-recipient rate limiting
- applies global limiting before recipient limiting and account lookup
- preserves the same neutral success response for existing, missing, and expected-delivery-failure cases
- catches only expected `EmailDeliveryException`
- forwards request cancellation to email delivery
- preserves ASP.NET Identity password-reset token semantics
- adds focused integration coverage through the real application composition

## Verification

- backend build: PASS, 0 warnings/errors
- focused forgot-password tests: 20/20 PASS
- full backend tests: 55/55 PASS
- frontend lint: PASS with one pre-existing `useBudgetLimits.js` warning
- frontend build: PASS
- staged `git diff --check`: PASS

## Security / operational notes

- public response/status equivalence reduces direct account-enumeration exposure
- synchronous email delivery still leaves a residual timing-based enumeration signal
- rate limiting is process-local and therefore independent per application instance
- confirmation-resend and forgot-password quotas remain independent

Closes #4