### PR TITLE
Add automated backend CI for pull requests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,32 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend build and tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore backend.Tests/backend.Tests.csproj
+
+      - name: Build backend
+        run: dotnet build backend/backend.csproj --configuration Release --no-restore
+
+      - name: Run backend tests
+        run: dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-restore


### PR DESCRIPTION
## Problem

Backend verification currently depends on local/Codex execution. GitHub does not independently build the ASP.NET Core backend or run the backend test suite before merge.

## Solution

- adds a GitHub Actions backend CI workflow for pull requests targeting `main`
- uses an Ubuntu GitHub-hosted runner
- installs .NET 9
- restores backend/test dependencies
- builds the backend in Release configuration
- runs the complete backend test suite
- uses read-only repository permissions
- requires no production secrets or external services

## Local verification

- dependency restore: PASS
- backend Release build: PASS, 0 warnings/errors
- backend tests: 55/55 PASS
- workflow diff check: PASS

## Acceptance gate

The workflow must successfully run on this pull request. Local verification alone is not sufficient acceptance evidence.

Closes #6