### PR TITLE
Harden malformed auth token handling

### DIFF
--- a/backend.Tests/Auth/AccountConfirmationFlowTests.cs
+++ b/backend.Tests/Auth/AccountConfirmationFlowTests.cs
@@ -1,11 +1,13 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using BudgetPlanner.Authentication;
 using BudgetPlanner.Configuration;
 using BudgetPlanner.Data;
 using BudgetPlanner.Services;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -18,6 +20,7 @@ namespace BudgetPlanner.Tests.Auth;
 public sealed class AccountConfirmationFlowTests
 {
     private const string Password = "Password1!";
+    private const string MalformedToken = "A";
 
     [Fact]
     public async Task Register_creates_user_and_sends_one_confirmation_email()
@@ -176,6 +179,64 @@ public sealed class AccountConfirmationFlowTests
     }
 
     [Fact]
+    public async Task Malformed_confirmation_token_returns_identity_invalid_token()
+    {
+        Assert.Throws<FormatException>(() => WebEncoders.Base64UrlDecode(MalformedToken));
+        await using var app = await TestApplication.StartAsync();
+        var user = await app.CreateUserAsync("malformed-confirmation@example.com", confirmed: false);
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/confirm-email",
+            new { userId = user.Id, token = MalformedToken });
+
+        await AssertInvalidTokenAsync(response);
+    }
+
+    [Fact]
+    public async Task Decodable_identity_invalid_confirmation_token_returns_identity_invalid_token()
+    {
+        await using var app = await TestApplication.StartAsync();
+        var user = await app.CreateUserAsync("invalid-confirmation@example.com", confirmed: false);
+        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("not-an-identity-token"));
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/confirm-email",
+            new { userId = user.Id, token = encodedToken });
+
+        await AssertInvalidTokenAsync(response);
+    }
+
+    [Fact]
+    public async Task Confirmation_token_replay_preserves_current_identity_behavior()
+    {
+        await using var app = await TestApplication.StartAsync();
+        var (userId, token) = await RegisterAndReadConfirmationLinkAsync(app, "replay-confirmation@example.com");
+
+        var first = await app.Client.PostAsJsonAsync(
+            "/api/auth/confirm-email",
+            new { userId, token });
+        var replay = await app.Client.PostAsJsonAsync(
+            "/api/auth/confirm-email",
+            new { userId, token });
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, replay.StatusCode);
+    }
+
+    [Fact]
+    public async Task Expired_confirmation_token_returns_identity_invalid_token()
+    {
+        await using var app = await TestApplication.StartAsync(tokenLifespan: TimeSpan.FromTicks(-1));
+        var (userId, token) = await RegisterAndReadConfirmationLinkAsync(app, "expired-confirmation@example.com");
+
+        var response = await app.Client.PostAsJsonAsync(
+            "/api/auth/confirm-email",
+            new { userId, token });
+
+        await AssertInvalidTokenAsync(response);
+    }
+
+    [Fact]
     public async Task Unconfirmed_user_cannot_log_in()
     {
         await using var app = await TestApplication.StartAsync();
@@ -199,6 +260,31 @@ public sealed class AccountConfirmationFlowTests
             new { email = "confirmed@example.com", password = Password });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private static async Task<(string UserId, string Token)> RegisterAndReadConfirmationLinkAsync(
+        TestApplication app,
+        string email)
+    {
+        var registration = await app.Client.PostAsJsonAsync(
+            "/api/auth/register",
+            new { email, password = Password });
+        Assert.Equal(HttpStatusCode.OK, registration.StatusCode);
+
+        var sent = Assert.Single(app.EmailSender.Messages);
+        var href = Regex.Match(sent.HtmlBody, "href=\"([^\"]+)\"").Groups[1].Value;
+        var confirmationUri = new Uri(WebUtility.HtmlDecode(href));
+        var query = QueryHelpers.ParseQuery(confirmationUri.Query);
+        return (query["userId"].ToString(), query["token"].ToString());
+    }
+
+    private static async Task AssertInvalidTokenAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var errors = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var error = Assert.Single(errors.EnumerateArray());
+        Assert.Equal("InvalidToken", error.GetProperty("code").GetString());
+        Assert.Equal("Invalid token.", error.GetProperty("description").GetString());
     }
 
     [Fact]

--- a/backend.Tests/Auth/ForgotPasswordFlowTests.cs
+++ b/backend.Tests/Auth/ForgotPasswordFlowTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using BudgetPlanner.Authentication;
@@ -13,6 +14,7 @@ namespace BudgetPlanner.Tests.Auth;
 public sealed class ForgotPasswordFlowTests
 {
     private const string ExistingEmail = "reset@example.com";
+    private const string MalformedToken = "A";
 
     [Fact]
     public async Task Existing_account_gets_neutral_response_and_working_reset_email()
@@ -42,6 +44,54 @@ public sealed class ForgotPasswordFlowTests
             });
 
         Assert.Equal(HttpStatusCode.OK, reset.StatusCode);
+    }
+
+    [Fact]
+    public async Task Malformed_reset_token_returns_identity_invalid_token()
+    {
+        Assert.Throws<FormatException>(() => WebEncoders.Base64UrlDecode(MalformedToken));
+        await using var app = await TestApplication.StartAsync();
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+
+        var response = await PostResetPasswordAsync(app, ExistingEmail, MalformedToken);
+
+        await AssertInvalidTokenAsync(response);
+    }
+
+    [Fact]
+    public async Task Decodable_identity_invalid_reset_token_returns_identity_invalid_token()
+    {
+        await using var app = await TestApplication.StartAsync();
+        await app.CreateUserAsync(ExistingEmail, confirmed: true);
+        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("not-an-identity-token"));
+
+        var response = await PostResetPasswordAsync(app, ExistingEmail, encodedToken);
+
+        await AssertInvalidTokenAsync(response);
+    }
+
+    [Fact]
+    public async Task Successfully_used_reset_token_cannot_be_reused()
+    {
+        await using var app = await TestApplication.StartAsync();
+        var token = await CreateResetTokenAsync(app, ExistingEmail);
+
+        var first = await PostResetPasswordAsync(app, ExistingEmail, token);
+        var replay = await PostResetPasswordAsync(app, ExistingEmail, token, "AnotherPassword1!");
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        await AssertInvalidTokenAsync(replay);
+    }
+
+    [Fact]
+    public async Task Expired_reset_token_returns_identity_invalid_token()
+    {
+        await using var app = await TestApplication.StartAsync(tokenLifespan: TimeSpan.FromTicks(-1));
+        var token = await CreateResetTokenAsync(app, ExistingEmail, confirmed: false);
+
+        var response = await PostResetPasswordAsync(app, ExistingEmail, token);
+
+        await AssertInvalidTokenAsync(response);
     }
 
     [Fact]
@@ -277,6 +327,39 @@ public sealed class ForgotPasswordFlowTests
         TestApplication app,
         string email) =>
         app.Client.PostAsJsonAsync("/api/auth/forgot-password", new { email });
+
+    private static Task<HttpResponseMessage> PostResetPasswordAsync(
+        TestApplication app,
+        string email,
+        string token,
+        string newPassword = "NewPassword1!") =>
+        app.Client.PostAsJsonAsync(
+            "/api/auth/reset-password",
+            new { email, token, newPassword });
+
+    private static async Task<string> CreateResetTokenAsync(
+        TestApplication app,
+        string email,
+        bool confirmed = true)
+    {
+        await app.CreateUserAsync(email, confirmed);
+        var forgot = await PostForgotPasswordAsync(app, email);
+        await AssertNeutralSuccessAsync(forgot);
+
+        var sent = Assert.Single(app.EmailSender.Messages);
+        var href = Regex.Match(sent.HtmlBody, "href=\"([^\"]+)\"").Groups[1].Value;
+        var resetUri = new Uri(WebUtility.HtmlDecode(href));
+        return QueryHelpers.ParseQuery(resetUri.Query)["token"].ToString();
+    }
+
+    private static async Task AssertInvalidTokenAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var errors = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var error = Assert.Single(errors.EnumerateArray());
+        Assert.Equal("InvalidToken", error.GetProperty("code").GetString());
+        Assert.Equal("Invalid token.", error.GetProperty("description").GetString());
+    }
 
     private static async Task AssertNeutralSuccessAsync(HttpResponseMessage response)
     {

--- a/backend.Tests/Auth/TestApplication.cs
+++ b/backend.Tests/Auth/TestApplication.cs
@@ -31,19 +31,22 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
     private readonly IConfirmationResendLimiter? _limiterOverride;
     private readonly ForgotPasswordLimiterTestSettings? _forgotPasswordLimiterSettings;
     private readonly IForgotPasswordLimiter? _forgotPasswordLimiterOverride;
+    private readonly TimeSpan? _tokenLifespan;
 
     private TestApplication(
         EmailFailureMode emailFailureMode,
         LimiterTestSettings? limiterSettings,
         IConfirmationResendLimiter? limiterOverride,
         ForgotPasswordLimiterTestSettings? forgotPasswordLimiterSettings,
-        IForgotPasswordLimiter? forgotPasswordLimiterOverride)
+        IForgotPasswordLimiter? forgotPasswordLimiterOverride,
+        TimeSpan? tokenLifespan)
     {
         EmailSender = new FakeEmailService(emailFailureMode);
         _limiterSettings = limiterSettings;
         _limiterOverride = limiterOverride;
         _forgotPasswordLimiterSettings = forgotPasswordLimiterSettings;
         _forgotPasswordLimiterOverride = forgotPasswordLimiterOverride;
+        _tokenLifespan = tokenLifespan;
     }
 
     public HttpClient Client { get; private set; } = null!;
@@ -54,14 +57,16 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
         LimiterTestSettings? limiterSettings = null,
         IConfirmationResendLimiter? limiterOverride = null,
         ForgotPasswordLimiterTestSettings? forgotPasswordLimiterSettings = null,
-        IForgotPasswordLimiter? forgotPasswordLimiterOverride = null)
+        IForgotPasswordLimiter? forgotPasswordLimiterOverride = null,
+        TimeSpan? tokenLifespan = null)
     {
         var application = new TestApplication(
             emailFailureMode,
             limiterSettings,
             limiterOverride,
             forgotPasswordLimiterSettings,
-            forgotPasswordLimiterOverride);
+            forgotPasswordLimiterOverride,
+            tokenLifespan);
         lock (HostStartupLock)
         {
             var originalEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
@@ -95,6 +100,12 @@ internal sealed class TestApplication : WebApplicationFactory<Program>
 
             services.RemoveAll<IEmailService>();
             services.AddSingleton<IEmailService>(EmailSender);
+
+            if (_tokenLifespan != null)
+            {
+                services.Configure<DataProtectionTokenProviderOptions>(options =>
+                    options.TokenLifespan = _tokenLifespan.Value);
+            }
 
             if (_limiterSettings != null)
             {

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -145,8 +145,8 @@ public class AuthController : ControllerBase
         if (user == null)
             return BadRequest("Invalid user");
 
-        var tokenBytes = WebEncoders.Base64UrlDecode(request.Token);
-        var decodedToken = Encoding.UTF8.GetString(tokenBytes);
+        if (!TryDecodeIdentityToken(request.Token, out var decodedToken))
+            return BadRequest(new[] { _userManager.ErrorDescriber.InvalidToken() });
 
         var result = await _userManager.ConfirmEmailAsync(user, decodedToken);
 
@@ -228,8 +228,8 @@ public class AuthController : ControllerBase
         if (user == null)
             return BadRequest("Invalid request");
 
-        var tokenBytes = WebEncoders.Base64UrlDecode(request.Token);
-        var decodedToken = Encoding.UTF8.GetString(tokenBytes);
+        if (!TryDecodeIdentityToken(request.Token, out var decodedToken))
+            return BadRequest(new[] { _userManager.ErrorDescriber.InvalidToken() });
 
         var result = await _userManager.ResetPasswordAsync(
             user,
@@ -241,6 +241,21 @@ public class AuthController : ControllerBase
             return BadRequest(result.Errors);
 
         return Ok(new { message = "Password reset successfully" });
+    }
+
+    private static bool TryDecodeIdentityToken(string encodedToken, out string decodedToken)
+    {
+        try
+        {
+            var tokenBytes = WebEncoders.Base64UrlDecode(encodedToken);
+            decodedToken = Encoding.UTF8.GetString(tokenBytes);
+            return true;
+        }
+        catch (FormatException)
+        {
+            decodedToken = string.Empty;
+            return false;
+        }
     }
 
     private string GenerateJwtToken(ApplicationUser user)


### PR DESCRIPTION
## Problem

Malformed Base64URL confirmation or password-reset tokens could throw `FormatException` before ASP.NET Identity evaluated them, causing an unexpected server failure.

## Solution

- safely handles malformed confirmation and reset tokens
- catches only the decoder's `FormatException`
- maps malformed input to Identity's existing `InvalidToken` response
- preserves existing confirmation/reset token semantics
- preserves confirmation replay behavior
- preserves reset-token single-use behavior
- does not change token generation, lifetimes, Gmail, JWTs, rate limits, migrations, or Data Protection

## Test evidence

Test-first red phase:
- malformed confirmation token: failed with unhandled FormatException
- malformed reset token: failed with unhandled FormatException

Final verification:
- focused auth tests: 15/15 PASS
- full backend tests: 63/63 PASS
- Release backend build: PASS
- 0 warnings
- 0 errors
- git diff --check: PASS

Closes #8
