### PR TITLE
Move production database migrations out of app startup

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "9.0.7",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -144,6 +144,75 @@ The default HTTP development URL is:
 http://localhost:5298
 ```
 
+## Production Database Migrations
+
+Normal backend startup never creates or updates the database schema. Production
+migrations are a separate administrator operation and must be completed deliberately
+from the exact reviewed application commit.
+
+Never commit a production connection string. For schema migrations, obtain a
+direct, non-pooled Neon PostgreSQL connection string and provide it only through
+the `BUDGETPLANNER_MIGRATION_CONNECTION` environment variable in the authorized
+operator's local session.
+
+### Review and apply a migration
+
+1. Check out the exact reviewed commit that contains the migration.
+2. Restore the repository-pinned EF Core tool and build the backend:
+
+   ```bash
+   dotnet tool restore
+   dotnet build backend/backend.csproj --configuration Release
+   ```
+
+3. Set `BUDGETPLANNER_MIGRATION_CONNECTION` in the current shell to the direct
+   Neon connection string. Do not pass credentials on the command line or store
+   them in a tracked file.
+4. Generate an idempotent SQL script for inspection without applying it:
+
+   ```bash
+   dotnet ef migrations script --idempotent \
+     --project backend \
+     --startup-project backend \
+     --context BudgetContext \
+     --configuration Release \
+     --no-build \
+     --output /tmp/budget-planner-migration.sql
+   ```
+
+5. Inspect the entire generated script, confirm the target database and expected
+   migration range, and obtain any additional review or recovery point required
+   for destructive operations.
+6. Apply pending migrations deliberately:
+
+   ```bash
+   dotnet ef database update \
+     --project backend \
+     --startup-project backend \
+     --context BudgetContext \
+     --configuration Release \
+     --no-build
+   ```
+
+7. Verify the expected migration IDs in the production database's
+   `__EFMigrationsHistory` table.
+8. Deploy the corresponding application commit to Render and smoke-test a
+   database-backed backend request.
+9. Unset `BUDGETPLANNER_MIGRATION_CONNECTION` and remove the generated script
+   when it is no longer required.
+
+Apply schema changes before deploying application code that requires them. Keep
+migrations backward-compatible with the currently running application whenever
+possible. Render Free does not provide pre-deploy commands or one-off jobs, so do
+not move migration execution into the Docker start command or normal application
+startup.
+
+Rolling back an application deployment does not roll back the database schema.
+Prefer a forward corrective migration once production data has changed. Destructive
+or backward-incompatible migrations require extra review and a verified Neon
+backup, branch, or other recovery plan appropriate to the active Neon plan before
+execution.
+
 ### 3. Configure and run the frontend
 
 In a separate terminal:

--- a/backend.Tests/Migrations/MigrationStartupTests.cs
+++ b/backend.Tests/Migrations/MigrationStartupTests.cs
@@ -1,0 +1,129 @@
+using BudgetPlanner.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Migrations;
+
+[Collection("Environment variable tests")]
+public sealed class MigrationStartupTests
+{
+    private static readonly object EnvironmentLock = new();
+
+    [Fact]
+    public void Production_style_startup_does_not_apply_database_migrations()
+    {
+        lock (EnvironmentLock)
+        {
+            var testConfiguration = new Dictionary<string, string>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "Production",
+                ["ConnectionStrings__DefaultConnection"] = "Host=unused-by-tests",
+                ["Jwt__Key"] = "test-only-signing-key-that-is-at-least-thirty-two-bytes-long",
+                ["EmailSettings__FromName"] = "Budget Planner Tests",
+                ["EmailSettings__FromEmail"] = "sender@example.com",
+                ["GoogleEmail__ClientId"] = "test-client-id",
+                ["GoogleEmail__ClientSecret"] = "test-client-secret",
+                ["GoogleEmail__RefreshToken"] = "test-refresh-token",
+                ["Frontend__BaseUrl"] = "https://frontend.test"
+            };
+            var originalValues = testConfiguration.Keys.ToDictionary(
+                key => key,
+                Environment.GetEnvironmentVariable);
+
+            try
+            {
+                foreach (var (key, value) in testConfiguration)
+                    Environment.SetEnvironmentVariable(key, value);
+
+                using var app = new ProductionStyleTestApplication();
+                using var client = app.CreateClient();
+
+                Assert.NotNull(client);
+            }
+            finally
+            {
+                foreach (var (key, value) in originalValues)
+                    Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Design_time_factory_rejects_missing_migration_connection(string? connectionString)
+    {
+        var originalValue = Environment.GetEnvironmentVariable(
+            BudgetContextFactory.MigrationConnectionEnvironmentVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                BudgetContextFactory.MigrationConnectionEnvironmentVariable,
+                connectionString);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new BudgetContextFactory().CreateDbContext([]));
+
+            Assert.Contains(
+                BudgetContextFactory.MigrationConnectionEnvironmentVariable,
+                exception.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                BudgetContextFactory.MigrationConnectionEnvironmentVariable,
+                originalValue);
+        }
+    }
+
+    [Fact]
+    public void Design_time_factory_configures_npgsql_from_migration_connection()
+    {
+        var originalValue = Environment.GetEnvironmentVariable(
+            BudgetContextFactory.MigrationConnectionEnvironmentVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                BudgetContextFactory.MigrationConnectionEnvironmentVariable,
+                "Host=localhost;Database=budget_planner_test;Username=test;Password=test");
+
+            using var context = new BudgetContextFactory().CreateDbContext([]);
+
+            Assert.Equal("Npgsql.EntityFrameworkCore.PostgreSQL", context.Database.ProviderName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                BudgetContextFactory.MigrationConnectionEnvironmentVariable,
+                originalValue);
+        }
+    }
+}
+
+[CollectionDefinition("Environment variable tests", DisableParallelization = true)]
+public sealed class EnvironmentVariableTestCollection;
+
+internal sealed class ProductionStyleTestApplication : WebApplicationFactory<Program>
+{
+    private readonly string _databaseName = $"startup-tests-{Guid.NewGuid()}";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Production");
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<BudgetContext>>();
+            services.RemoveAll<IDbContextOptionsConfiguration<BudgetContext>>();
+            services.AddDbContext<BudgetContext>(options =>
+                options.UseInMemoryDatabase(_databaseName));
+        });
+    }
+}

--- a/backend/Data/BudgetContextFactory.cs
+++ b/backend/Data/BudgetContextFactory.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace BudgetPlanner.Data;
+
+public sealed class BudgetContextFactory : IDesignTimeDbContextFactory<BudgetContext>
+{
+    public const string MigrationConnectionEnvironmentVariable =
+        "BUDGETPLANNER_MIGRATION_CONNECTION";
+
+    public BudgetContext CreateDbContext(string[] args)
+    {
+        var connectionString = Environment.GetEnvironmentVariable(
+            MigrationConnectionEnvironmentVariable);
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"Set {MigrationConnectionEnvironmentVariable} to a PostgreSQL connection string before running migration commands.");
+        }
+
+        var options = new DbContextOptionsBuilder<BudgetContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+
+        return new BudgetContext(options);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -126,14 +126,6 @@ builder.Services.AddSingleton<IForgotPasswordLimiter, ForgotPasswordLimiter>();
 
 var app = builder.Build();
 
-// Integration tests use isolated infrastructure and must never execute production migrations.
-if (!app.Environment.IsEnvironment("Testing"))
-{
-    using var scope = app.Services.CreateScope();
-    var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
-    db.Database.Migrate();
-}
-
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Problem

The backend previously called `Database.Migrate()` during every non-test application startup, coupling normal Render starts and restarts to production schema mutation.

## Solution

- removes runtime migration execution from normal application startup
- adds a repository-local pinned `dotnet-ef` tool
- adds a design-time `BudgetContextFactory`
- isolates migration credentials behind `BUDGETPLANNER_MIGRATION_CONNECTION`
- documents a deliberate migration procedure for Render Free + Neon
- preserves existing migrations unchanged
- does not change production schema in this PR

## Production verification

Before publication, production Neon `__EFMigrationsHistory` was verified to contain:

- `20260425230906_InitialCreate`
- `20260426013407_FixMoneyPrecision`

Both are recorded with EF ProductVersion 9.0.7.

## Verification

- startup regression proved old runtime migration behavior
- focused migration tests: 5/5 PASS
- full backend tests: 68/68 PASS
- Release backend build: PASS
- 0 warnings
- 0 errors
- repository-local `dotnet-ef` restore: PASS
- no pending EF model changes
- idempotent SQL generation: PASS
- no production migrations executed
- git diff --check: PASS

Closes #9
