### PR TITLE
Persist ASP.NET Data Protection keys across deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,35 @@ or backward-incompatible migrations require extra review and a verified Neon
 backup, branch, or other recovery plan appropriate to the active Neon plan before
 execution.
 
+## Data Protection key persistence
+
+ASP.NET Core Identity confirmation and password-reset tokens depend on the
+application's Data Protection key ring. Render Free has an ephemeral filesystem,
+so the backend uses the stable application name `BudgetPlanner` and persists the
+key ring in Neon's `DataProtectionKeys` table instead of the container filesystem.
+This lets outstanding tokens remain valid across normal restarts and redeploys,
+subject to their existing expiration and Identity security-stamp semantics.
+
+The V1 key XML is not additionally wrapped with an application-managed certificate.
+This deployment relies on Neon's platform encryption at rest, TLS, PostgreSQL
+access controls, Render secret storage for the connection string, and restricted
+Render/Neon account access. A principal or database dump that can logically read
+`DataProtectionKeys.Xml` may therefore obtain usable Data Protection master-key
+material. Treat database credentials and dumps as highly sensitive, never log or
+expose the key XML, and don't commit key material.
+
+Don't delete old Data Protection keys as routine cleanup. Deletion can permanently
+invalidate outstanding protected payloads. The first deployment that enables
+database persistence also can't rescue tokens generated with old ephemeral keys
+that have already been lost.
+
+Apply the migration that creates `DataProtectionKeys` and verify it in Neon before
+merging or deploying application code that uses database-backed keys. The current
+application can remain live while this additive migration is applied. Afterward,
+verify the migration history and table, deploy the matching commit, generate a
+fresh confirmation or reset token, restart/redeploy Render, and confirm that the
+pre-restart token still works.
+
 ### 3. Configure and run the frontend
 
 In a separate terminal:

--- a/backend.Tests/Auth/DataProtectionPersistenceTests.cs
+++ b/backend.Tests/Auth/DataProtectionPersistenceTests.cs
@@ -1,0 +1,276 @@
+using System.Xml.Linq;
+using System.Security.Cryptography;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Auth;
+
+[Collection("Environment variable tests")]
+public sealed class DataProtectionPersistenceTests
+{
+    [Fact]
+    public async Task Confirmation_token_survives_application_restart_and_replay_behavior_is_unchanged()
+    {
+        await RunWithTestEnvironmentAsync(async () =>
+        {
+            var persistence = new RestartPersistenceFixture();
+            var (userId, token) = await GenerateConfirmationTokenAsync(persistence);
+
+            using var restartedApp = persistence.CreateApplication();
+            var firstResult = await UseUserManagerAsync(restartedApp, async users =>
+            {
+                var user = await RequireUserAsync(users, userId);
+                return await users.ConfirmEmailAsync(user, token);
+            });
+            var replayResult = await UseUserManagerAsync(restartedApp, async users =>
+            {
+                var user = await RequireUserAsync(users, userId);
+                return await users.ConfirmEmailAsync(user, token);
+            });
+
+            Assert.True(firstResult.Succeeded);
+            Assert.True(replayResult.Succeeded);
+        });
+    }
+
+    [Fact]
+    public async Task Password_reset_token_survives_application_restart_and_remains_single_use()
+    {
+        await RunWithTestEnvironmentAsync(async () =>
+        {
+            var persistence = new RestartPersistenceFixture();
+            string userId;
+            string token;
+
+            using (var firstApp = persistence.CreateApplication())
+            {
+                (userId, token) = await UseUserManagerAsync(firstApp, async users =>
+                {
+                    var user = await CreateUserAsync(users, "restart-reset@example.com");
+                    return (user.Id, await users.GeneratePasswordResetTokenAsync(user));
+                });
+            }
+
+            using var restartedApp = persistence.CreateApplication();
+            var firstResult = await UseUserManagerAsync(restartedApp, async users =>
+            {
+                var user = await RequireUserAsync(users, userId);
+                return await users.ResetPasswordAsync(user, token, "NewPassword1!");
+            });
+            var replayResult = await UseUserManagerAsync(restartedApp, async users =>
+            {
+                var user = await RequireUserAsync(users, userId);
+                return await users.ResetPasswordAsync(user, token, "AnotherPassword1!");
+            });
+
+            Assert.True(firstResult.Succeeded);
+            Assert.False(replayResult.Succeeded);
+            Assert.Contains(replayResult.Errors, error => error.Code == "InvalidToken");
+        });
+    }
+
+    [Fact]
+    public async Task Expired_confirmation_token_remains_expired_after_application_restart()
+    {
+        await RunWithTestEnvironmentAsync(async () =>
+        {
+            var persistence = new RestartPersistenceFixture(TimeSpan.FromTicks(-1));
+            var (userId, token) = await GenerateConfirmationTokenAsync(persistence);
+
+            using var restartedApp = persistence.CreateApplication();
+            var result = await UseUserManagerAsync(restartedApp, async users =>
+            {
+                var user = await RequireUserAsync(users, userId);
+                return await users.ConfirmEmailAsync(user, token);
+            });
+
+            Assert.False(result.Succeeded);
+            Assert.Contains(result.Errors, error => error.Code == "InvalidToken");
+        });
+    }
+
+    [Fact]
+    public async Task Restart_test_uses_isolated_in_memory_database_and_ef_key_repository()
+    {
+        await RunWithTestEnvironmentAsync(() =>
+        {
+            var persistence = new RestartPersistenceFixture();
+            using var app = persistence.CreateApplication();
+            using var scope = app.Services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var keyOptions = app.Services.GetRequiredService<IOptions<KeyManagementOptions>>().Value;
+
+            Assert.Equal("Microsoft.EntityFrameworkCore.InMemory", context.Database.ProviderName);
+            Assert.IsType<EntityFrameworkCoreXmlRepository<BudgetContext>>(keyOptions.XmlRepository);
+            var configuredConnection = app.Services.GetRequiredService<IConfiguration>()
+                .GetConnectionString("DefaultConnection");
+            Assert.DoesNotContain("neon", configuredConnection ?? string.Empty,
+                StringComparison.OrdinalIgnoreCase);
+            return Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task Inaccessible_key_repository_fails_without_ephemeral_fallback()
+    {
+        await RunWithTestEnvironmentAsync(async () =>
+        {
+            var persistence = new RestartPersistenceFixture(failKeyRepository: true);
+            using var app = persistence.CreateApplication();
+
+            var exception = await Assert.ThrowsAsync<CryptographicException>(() =>
+                UseUserManagerAsync(app, async users =>
+                {
+                    var user = await CreateUserAsync(users, "failing-keys@example.com");
+                    return await users.GenerateEmailConfirmationTokenAsync(user);
+                }));
+
+            var repositoryException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Equal(ThrowingXmlRepository.ErrorMessage, repositoryException.Message);
+        });
+    }
+
+    private static async Task<(string UserId, string Token)> GenerateConfirmationTokenAsync(
+        RestartPersistenceFixture persistence)
+    {
+        using var firstApp = persistence.CreateApplication();
+        return await UseUserManagerAsync(firstApp, async users =>
+        {
+            var user = await CreateUserAsync(users, $"restart-confirmation-{Guid.NewGuid()}@example.com");
+            return (user.Id, await users.GenerateEmailConfirmationTokenAsync(user));
+        });
+    }
+
+    private static async Task<ApplicationUser> CreateUserAsync(
+        UserManager<ApplicationUser> users,
+        string email)
+    {
+        var user = new ApplicationUser { UserName = email, Email = email };
+        var result = await users.CreateAsync(user, "Password1!");
+        Assert.True(result.Succeeded, string.Join(", ", result.Errors.Select(error => error.Description)));
+        return user;
+    }
+
+    private static async Task<ApplicationUser> RequireUserAsync(
+        UserManager<ApplicationUser> users,
+        string userId)
+    {
+        var user = await users.FindByIdAsync(userId);
+        Assert.NotNull(user);
+        return user;
+    }
+
+    private static async Task<TResult> UseUserManagerAsync<TResult>(
+        RestartPersistenceApplication app,
+        Func<UserManager<ApplicationUser>, Task<TResult>> action)
+    {
+        using var scope = app.Services.CreateScope();
+        return await action(scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>());
+    }
+
+    private static async Task RunWithTestEnvironmentAsync(Func<Task> test)
+    {
+        var originalEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var originalJwtKey = Environment.GetEnvironmentVariable("Jwt__Key");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
+            Environment.SetEnvironmentVariable(
+                "Jwt__Key",
+                "test-only-signing-key-that-is-at-least-thirty-two-bytes-long");
+            await test();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", originalEnvironment);
+            Environment.SetEnvironmentVariable("Jwt__Key", originalJwtKey);
+        }
+    }
+}
+
+internal sealed class RestartPersistenceFixture(
+    TimeSpan? tokenLifespan = null,
+    bool failKeyRepository = false)
+{
+    private readonly string _databaseName = $"data-protection-restart-{Guid.NewGuid()}";
+    private readonly InMemoryDatabaseRoot _databaseRoot = new();
+
+    public RestartPersistenceApplication CreateApplication() =>
+        new(_databaseName, _databaseRoot, tokenLifespan, failKeyRepository);
+}
+
+internal sealed class RestartPersistenceApplication(
+    string databaseName,
+    InMemoryDatabaseRoot databaseRoot,
+    TimeSpan? tokenLifespan,
+    bool failKeyRepository) : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<BudgetContext>>();
+            services.RemoveAll<IDbContextOptionsConfiguration<BudgetContext>>();
+            services.AddDbContext<BudgetContext>(options =>
+                options.UseInMemoryDatabase(databaseName, databaseRoot));
+
+            if (tokenLifespan != null)
+            {
+                services.Configure<DataProtectionTokenProviderOptions>(options =>
+                    options.TokenLifespan = tokenLifespan.Value);
+            }
+
+            if (failKeyRepository)
+            {
+                services.PostConfigure<KeyManagementOptions>(options =>
+                    options.XmlRepository = new ThrowingXmlRepository());
+            }
+        });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(configuration =>
+            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=unused-by-tests",
+                ["Jwt:Key"] = "test-only-signing-key-that-is-at-least-thirty-two-bytes-long",
+                ["EmailSettings:FromName"] = "Budget Planner Tests",
+                ["EmailSettings:FromEmail"] = "sender@example.com",
+                ["GoogleEmail:ClientId"] = "test-client-id",
+                ["GoogleEmail:ClientSecret"] = "test-client-secret",
+                ["GoogleEmail:RefreshToken"] = "test-refresh-token",
+                ["Frontend:BaseUrl"] = "https://frontend.test"
+            }));
+
+        return base.CreateHost(builder);
+    }
+}
+
+internal sealed class ThrowingXmlRepository : IXmlRepository
+{
+    public const string ErrorMessage = "Test Data Protection key repository is inaccessible.";
+
+    public IReadOnlyCollection<XElement> GetAllElements() =>
+        throw new InvalidOperationException(ErrorMessage);
+
+    public void StoreElement(XElement element, string friendlyName) =>
+        throw new InvalidOperationException(ErrorMessage);
+}

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -1,15 +1,17 @@
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using BudgetPlanner.Models;
 
 namespace BudgetPlanner.Data;
 
-public class BudgetContext : IdentityDbContext<ApplicationUser>
+public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtectionKeyContext
 {
     public BudgetContext(DbContextOptions<BudgetContext> options) : base(options) {}
 
     public DbSet<Expense> Expenses { get; set; }
     public DbSet<BudgetLimit> BudgetLimits { get; set; }
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/Migrations/20260812213613_PersistDataProtectionKeys.Designer.cs
+++ b/backend/Migrations/20260812213613_PersistDataProtectionKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260812213613_PersistDataProtectionKeys")]
+    partial class PersistDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260812213613_PersistDataProtectionKeys.cs
+++ b/backend/Migrations/20260812213613_PersistDataProtectionKeys.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersistDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -2,6 +2,7 @@ using System.Text;
 using BudgetPlanner.Data;
 using BudgetPlanner.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -77,6 +78,10 @@ builder.Services.AddSwaggerGen(options =>
 
 builder.Services.AddDbContext<BudgetContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services
+    .AddDataProtection()
+    .SetApplicationName("BudgetPlanner")
+    .PersistKeysToDbContext<BudgetContext>();
 builder.Services
     .AddIdentity<ApplicationUser, IdentityRole>(options =>
     {

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.75.0.4225" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />


### PR DESCRIPTION
## Problem

ASP.NET Core Identity confirmation and password-reset tokens depend on the ASP.NET Data Protection key ring.

Render Free uses ephemeral local storage, so keys stored on the instance filesystem can disappear after restarts or redeploys, causing otherwise valid outstanding tokens to become invalid.

## Solution

- persists ASP.NET Data Protection keys through EF Core
- stores the shared key ring in Neon/PostgreSQL
- uses the existing BudgetContext
- sets the stable application name `BudgetPlanner`
- adds the additive `DataProtectionKeys` schema migration
- preserves existing Identity token semantics
- keeps runtime database migrations disabled
- documents the residual V1 risk that persisted Data Protection XML is not additionally application-level encrypted

## Test evidence

Red phase:
- token created using one ephemeral key repository failed after application recreation using a different ephemeral key repository

Final verification:
- focused Data Protection persistence tests: 5/5 PASS
- full backend tests: 73/73 PASS
- Release build: PASS
- 0 warnings
- no pending EF model changes
- idempotent migration SQL reviewed
- no production database accessed
- no production migration applied
- git diff --check: PASS

## Deployment gate

DO NOT merge this PR until:

1. the new migration has received final review;
2. `20260812213613_PersistDataProtectionKeys` has been deliberately applied to production Neon while the old application remains live;
3. the migration is verified in `__EFMigrationsHistory`;
4. the `DataProtectionKeys` table is verified.

Closes #10