### PR TITLE
refactor: establish transactions page ownership

### DIFF
--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
-import ExpensesPage from "../features/expenses/components/ExpensesPage";
+import TransactionsPage from "../features/transactions/pages/TransactionsPage";
 import AuthPage from "../features/auth/components/AuthPage";
 import ConfirmEmailPage from "../features/auth/components/ConfirmEmailPage";
 import ForgotPasswordPage from "../features/auth/components/ForgotPasswordPage";
@@ -44,7 +44,7 @@ export default function App() {
       <Route element={<ProtectedRoute isAuthenticated={isLoggedIn} />}>
         <Route element={<AppShell email={localStorage.getItem("email")} onLogout={handleLogout} />}>
           <Route path="/overview" element={<OverviewPage />} />
-          <Route path="/transactions" element={<ExpensesPage />} />
+          <Route path="/transactions" element={<TransactionsPage />} />
           <Route path="/budgets" element={(
             <CompatibilityPage
               title="Budgets"

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import { ThemeProvider } from '../shared/theme/ThemeProvider'
 
-vi.mock('../features/expenses/components/ExpensesPage', () => ({
+vi.mock('../features/transactions/pages/TransactionsPage', () => ({
   default: () => <h1>Transactions workspace</h1>,
 }))
 
@@ -174,5 +174,19 @@ describe('application routes and shell', () => {
     renderAt('/investing')
     expect(screen.getByRole('heading', { name: 'Not connected yet' })).toBeInTheDocument()
     await waitFor(() => expect(fetchSpy).not.toHaveBeenCalled())
+  })
+
+  it.each([
+    ['/budgets', 'Open budget limits'],
+    ['/analytics', 'Open spending chart'],
+  ])('keeps %s compatibility functionality reachable through Transactions', async (path, actionLabel) => {
+    const user = userEvent.setup()
+    localStorage.setItem('token', 'jwt-value')
+    renderAt(path)
+
+    await user.click(screen.getByRole('link', { name: actionLabel }))
+
+    expect(await screen.findByRole('heading', { name: 'Transactions workspace' })).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent('/transactions')
   })
 })

--- a/frontend/src/features/budgetLimits/hooks/useBudgetLimits.test.js
+++ b/frontend/src/features/budgetLimits/hooks/useBudgetLimits.test.js
@@ -1,0 +1,42 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { budgetLimitsApi } from '../api/budgetLimitsApi'
+import { useBudgetLimits } from './useBudgetLimits'
+
+vi.mock('../api/budgetLimitsApi', () => ({
+  budgetLimitsApi: {
+    getByMonth: vi.fn(),
+    upsert: vi.fn(),
+    remove: vi.fn(),
+  },
+}))
+
+describe('budget-limit refresh behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    budgetLimitsApi.getByMonth.mockResolvedValue({ data: [] })
+  })
+
+  it('upserts and refreshes the currently selected month', async () => {
+    const payload = { category: 'food', limitAmount: 100, monthYear: '2026-08-01T05:00:00.000Z' }
+    const { result } = renderHook(() => useBudgetLimits('2026-08'))
+    await waitFor(() => expect(budgetLimitsApi.getByMonth).toHaveBeenCalledWith('2026-08'))
+
+    await act(() => result.current.upsertLimit(payload))
+
+    expect(budgetLimitsApi.upsert).toHaveBeenCalledWith(payload)
+    expect(budgetLimitsApi.getByMonth).toHaveBeenCalledTimes(2)
+    expect(budgetLimitsApi.getByMonth).toHaveBeenLastCalledWith('2026-08')
+  })
+
+  it('deletes and refreshes the currently selected month', async () => {
+    const { result } = renderHook(() => useBudgetLimits('2026-08'))
+    await waitFor(() => expect(budgetLimitsApi.getByMonth).toHaveBeenCalledWith('2026-08'))
+
+    await act(() => result.current.deleteLimit(12))
+
+    expect(budgetLimitsApi.remove).toHaveBeenCalledWith(12)
+    expect(budgetLimitsApi.getByMonth).toHaveBeenCalledTimes(2)
+    expect(budgetLimitsApi.getByMonth).toHaveBeenLastCalledWith('2026-08')
+  })
+})

--- a/frontend/src/features/expenses/hooks/useExpenses.test.js
+++ b/frontend/src/features/expenses/hooks/useExpenses.test.js
@@ -1,0 +1,66 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { expensesApi } from '../api/expensesApi'
+import { useExpenses } from './useExpenses'
+
+vi.mock('../api/expensesApi', () => ({
+  expensesApi: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}))
+
+describe('expense refresh behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    expensesApi.getAll.mockResolvedValue({ data: [] })
+  })
+
+  it('fetches expenses on initial mount', async () => {
+    const { result } = renderHook(() => useExpenses())
+
+    await waitFor(() => expect(expensesApi.getAll).toHaveBeenCalledOnce())
+    expect(result.current.expenses).toEqual([])
+  })
+
+  it('creates through the existing API and refreshes expenses', async () => {
+    const payload = { description: 'coffee', amount: 4, date: '2026-08-14', category: 'food' }
+    expensesApi.getAll
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [{ id: 1, ...payload }] })
+    const { result } = renderHook(() => useExpenses())
+    await waitFor(() => expect(expensesApi.getAll).toHaveBeenCalledOnce())
+
+    await act(() => result.current.addExpense(payload))
+
+    expect(expensesApi.create).toHaveBeenCalledWith(payload)
+    expect(expensesApi.getAll).toHaveBeenCalledTimes(2)
+    expect(result.current.expenses).toEqual([{ id: 1, ...payload }])
+  })
+
+  it('updates through the existing API and refreshes expenses', async () => {
+    const payload = { id: 7, description: 'lunch', amount: 12.35, date: '2026-08-14', category: 'food' }
+    expensesApi.getAll.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({ data: [payload] })
+    const { result } = renderHook(() => useExpenses())
+    await waitFor(() => expect(expensesApi.getAll).toHaveBeenCalledOnce())
+
+    await act(() => result.current.updateExpense(7, payload))
+
+    expect(expensesApi.update).toHaveBeenCalledWith(7, payload)
+    expect(expensesApi.getAll).toHaveBeenCalledTimes(2)
+    expect(result.current.expenses).toEqual([payload])
+  })
+
+  it('deletes through the existing API and refreshes expenses', async () => {
+    expensesApi.getAll.mockResolvedValue({ data: [] })
+    const { result } = renderHook(() => useExpenses())
+    await waitFor(() => expect(expensesApi.getAll).toHaveBeenCalledOnce())
+
+    await act(() => result.current.deleteExpense(9))
+
+    expect(expensesApi.remove).toHaveBeenCalledWith(9)
+    expect(expensesApi.getAll).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -1,22 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
-import { useExpenses } from "../hooks/useExpenses";
+import { useExpenses } from "../../expenses/hooks/useExpenses";
 import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
 
 import { getMonthYear } from "../../../shared/utils/monthYear";
-import { filterExpenses } from "../utils/filterExpenses";
+import { filterExpenses } from "../../expenses/utils/filterExpenses";
 import { computeMonthlyTotalsByCategory } from "../../budgetLimits/utils/totalsByCategory";
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import { normalizeText, isDefaultCategory } from "../../../utils/text";
 
 import SpendingChart from "../../../charts/components/SpendingChart";
 import BudgetLimitsPanel from "../../budgetLimits/components/BudgetLimitsPanel";
-import ExpenseForm from "./ExpenseForm";
-import ExpenseFilters from "./ExpenseFilters";
-import ExpenseList from "./ExpenseList";
+import ExpenseForm from "../../expenses/components/ExpenseForm";
+import ExpenseFilters from "../../expenses/components/ExpenseFilters";
+import ExpenseList from "../../expenses/components/ExpenseList";
 import Card from "../../../shared/ui/Card";
 const ENTRIES_PER_PAGE = 10;
 
-export default function ExpensesPage() {
+export default function TransactionsPage() {
   const {
     expenses,
     loading: expensesLoading,
@@ -159,7 +159,7 @@ export default function ExpensesPage() {
       <header className="page-header">
         <div>
           <p className="page-header__eyebrow">Your finances</p>
-          <h1>Budget Planner</h1>
+          <h1>Transactions</h1>
           <p className="muted">Track spending and keep monthly limits in view.</p>
         </div>
       </header>

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import ExpensesPage from './ExpensesPage'
-import { useExpenses } from '../hooks/useExpenses'
+import TransactionsPage from './TransactionsPage'
+import { useExpenses } from '../../expenses/hooks/useExpenses'
 import { useBudgetLimits } from '../../budgetLimits/hooks/useBudgetLimits'
 
-vi.mock('../hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
+vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
 vi.mock('../../budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
 vi.mock('../../budgetLimits/components/BudgetLimitsPanel', () => ({
   default: () => <div data-testid="budget-panel" />,
@@ -38,7 +38,7 @@ describe('existing expense workflows', () => {
     const user = userEvent.setup()
     const addExpense = vi.fn().mockResolvedValue(undefined)
     useExpenses.mockReturnValue({ ...baseExpensesHook, addExpense })
-    render(<ExpensesPage />)
+    render(<TransactionsPage />)
 
     await user.type(screen.getByPlaceholderText('Description'), '  Dinner With Friends  ')
     await user.type(screen.getByPlaceholderText('Amount'), '12.50')
@@ -58,7 +58,7 @@ describe('existing expense workflows', () => {
     const user = userEvent.setup()
     const addExpense = vi.fn().mockResolvedValue(undefined)
     useExpenses.mockReturnValue({ ...baseExpensesHook, addExpense })
-    render(<ExpensesPage />)
+    render(<TransactionsPage />)
 
     await user.type(screen.getByPlaceholderText('Description'), 'Prescription')
     await user.type(screen.getByPlaceholderText('Amount'), '8')
@@ -86,7 +86,7 @@ describe('existing expense workflows', () => {
         category: 'medical',
       }],
     })
-    render(<ExpensesPage />)
+    render(<TransactionsPage />)
 
     const row = screen.getByText('Medical').closest('tr')
     await user.click(within(row).getByRole('button', { name: 'Edit' }))
@@ -122,7 +122,7 @@ describe('existing expense workflows', () => {
         category: 'food',
       })),
     })
-    render(<ExpensesPage />)
+    render(<TransactionsPage />)
 
     expect(screen.getAllByRole('row')).toHaveLength(11)
     await user.click(screen.getByRole('button', { name: 'Show More' }))
@@ -131,5 +131,14 @@ describe('existing expense workflows', () => {
     await user.type(screen.getByPlaceholderText('Search description or category...'), 'expense')
     await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(11))
     expect(screen.getByRole('button', { name: 'Show More' })).toBeInTheDocument()
+  })
+
+  it('keeps expense, budget-limit, and spending-chart workflows composed together', () => {
+    render(<TransactionsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Transactions' })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Description')).toBeInTheDocument()
+    expect(screen.getByTestId('budget-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('spending-chart')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

PR 14D establishes `TransactionsPage` as the explicit route-level owner of `/transactions` for Issue #14.

- moves the existing `ExpensesPage` coordinator to `features/transactions/pages/TransactionsPage.jsx`
- preserves established transaction behavior while keeping Expense terminology in the existing domain, API, hooks, and backend
- retains expense fetching, CRUD, normalization, custom-category handling, filtering, date behavior, Show More, and mutation refresh behavior
- temporarily keeps Budget Limits and the Spending vs Budget Limits chart composed inside Transactions pending child phases 14E and 14F
- keeps the `/budgets` and `/analytics` compatibility routes directing users to `/transactions`
- adds expense initial-fetch and create/update/delete refresh characterization
- adds budget-limit upsert/delete selected-month refresh characterization
- preserves known characterized filtering, date, category, and per-addition rounding behavior without correcting those quirks

This is child PR **14D** for #14.

## Verification

- targeted tests: **32/32 PASS**
- full frontend tests: **68/68 PASS**
- frontend lint: **PASS — 0 errors, 1 pre-existing warning**
- frontend production build: **PASS**
- backend tests: **73/73 PASS**
- `git diff --check`: **PASS**

A repeated graphical review is not required because this PR changes no CSS, shell, theme, navigation, or responsive-layout code. The intentional heading change to **Transactions** was reviewed.

## Scope boundaries

- no backend changes
- no API changes
- no schema changes
- no dependency changes
- no lockfile changes
- no CSS, theme, AppShell, or navigation changes
- no 14E or 14F implementation
