### PR TITLE
Extract dedicated Budgets page

### DIFF
--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
 import TransactionsPage from "../features/transactions/pages/TransactionsPage";
+import BudgetsPage from "../features/budgetLimits/pages/BudgetsPage";
 import AuthPage from "../features/auth/components/AuthPage";
 import ConfirmEmailPage from "../features/auth/components/ConfirmEmailPage";
 import ForgotPasswordPage from "../features/auth/components/ForgotPasswordPage";
@@ -45,13 +46,7 @@ export default function App() {
         <Route element={<AppShell email={localStorage.getItem("email")} onLogout={handleLogout} />}>
           <Route path="/overview" element={<OverviewPage />} />
           <Route path="/transactions" element={<TransactionsPage />} />
-          <Route path="/budgets" element={(
-            <CompatibilityPage
-              title="Budgets"
-              description="Budget limits remain available with transactions until their dedicated page is extracted."
-              actionLabel="Open budget limits"
-            />
-          )} />
+          <Route path="/budgets" element={<BudgetsPage />} />
           <Route path="/analytics" element={(
             <CompatibilityPage
               title="Analytics"

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -9,6 +9,10 @@ vi.mock('../features/transactions/pages/TransactionsPage', () => ({
   default: () => <h1>Transactions workspace</h1>,
 }))
 
+vi.mock('../features/budgetLimits/pages/BudgetsPage', () => ({
+  default: () => <h1>Budgets workspace</h1>,
+}))
+
 vi.mock('../features/auth/components/AuthPage', () => ({
   default: () => <h1>Authentication content</h1>,
 }))
@@ -71,7 +75,7 @@ describe('application routes and shell', () => {
   it.each([
     ['/overview', 'Welcome back'],
     ['/transactions', 'Transactions workspace'],
-    ['/budgets', 'Budgets'],
+    ['/budgets', 'Budgets workspace'],
     ['/analytics', 'Analytics'],
     ['/investing', 'Investing'],
     ['/settings', 'Settings'],
@@ -176,15 +180,20 @@ describe('application routes and shell', () => {
     await waitFor(() => expect(fetchSpy).not.toHaveBeenCalled())
   })
 
-  it.each([
-    ['/budgets', 'Open budget limits'],
-    ['/analytics', 'Open spending chart'],
-  ])('keeps %s compatibility functionality reachable through Transactions', async (path, actionLabel) => {
+  it('renders the dedicated Budgets surface without redirecting to Transactions', async () => {
+    localStorage.setItem('token', 'jwt-value')
+    renderAt('/budgets')
+
+    expect(await screen.findByRole('heading', { name: 'Budgets workspace' })).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent('/budgets')
+  })
+
+  it('keeps Analytics compatibility functionality reachable through Transactions', async () => {
     const user = userEvent.setup()
     localStorage.setItem('token', 'jwt-value')
-    renderAt(path)
+    renderAt('/analytics')
 
-    await user.click(screen.getByRole('link', { name: actionLabel }))
+    await user.click(screen.getByRole('link', { name: 'Open spending chart' }))
 
     expect(await screen.findByRole('heading', { name: 'Transactions workspace' })).toBeInTheDocument()
     expect(screen.getByTestId('location')).toHaveTextContent('/transactions')

--- a/frontend/src/features/budgetLimits/pages/BudgetsPage.jsx
+++ b/frontend/src/features/budgetLimits/pages/BudgetsPage.jsx
@@ -1,0 +1,44 @@
+import { useMemo, useState } from "react";
+import { useExpenses } from "../../expenses/hooks/useExpenses";
+import { useBudgetLimits } from "../hooks/useBudgetLimits";
+import { computeMonthlyTotalsByCategory } from "../utils/totalsByCategory";
+import { getMonthYear } from "../../../shared/utils/monthYear";
+import BudgetLimitsPanel from "../components/BudgetLimitsPanel";
+
+export default function BudgetsPage() {
+  const { expenses } = useExpenses();
+  const [limitMonthYear, setLimitMonthYear] = useState(getMonthYear(new Date()));
+  const {
+    budgetLimits,
+    loading: limitsLoading,
+    upsertLimit,
+    deleteLimit,
+  } = useBudgetLimits(limitMonthYear);
+
+  const totalsByCategory = useMemo(
+    () => computeMonthlyTotalsByCategory(expenses, limitMonthYear),
+    [expenses, limitMonthYear]
+  );
+
+  return (
+    <div className="container">
+      <header className="page-header">
+        <div>
+          <p className="page-header__eyebrow">Plan your spending</p>
+          <h1>Budgets</h1>
+          <p className="muted">Set monthly category limits and track how much you have used.</p>
+        </div>
+      </header>
+
+      <BudgetLimitsPanel
+        limitMonthYear={limitMonthYear}
+        setLimitMonthYear={setLimitMonthYear}
+        budgetLimits={budgetLimits}
+        limitsLoading={limitsLoading}
+        totalsByCategory={totalsByCategory}
+        upsertLimit={upsertLimit}
+        deleteLimit={deleteLimit}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/budgetLimits/pages/BudgetsPage.test.jsx
+++ b/frontend/src/features/budgetLimits/pages/BudgetsPage.test.jsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BudgetsPage from './BudgetsPage'
+import { useExpenses } from '../../expenses/hooks/useExpenses'
+import { useBudgetLimits } from '../hooks/useBudgetLimits'
+
+vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
+vi.mock('../hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
+vi.mock('../components/BudgetLimitsPanel', () => ({
+  default: ({ limitMonthYear, setLimitMonthYear, totalsByCategory, upsertLimit, deleteLimit }) => (
+    <div data-testid="budget-panel">
+      <span data-testid="budget-month">{limitMonthYear}</span>
+      <span data-testid="budget-totals">{JSON.stringify(totalsByCategory)}</span>
+      <button onClick={() => setLimitMonthYear('2026-07')}>Choose July</button>
+      <button onClick={() => upsertLimit({ category: 'food' })}>Upsert</button>
+      <button onClick={() => deleteLimit(7)}>Delete</button>
+    </div>
+  ),
+}))
+
+describe('Budgets page ownership', () => {
+  const upsertLimit = vi.fn()
+  const deleteLimit = vi.fn()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
+    useExpenses.mockReturnValue({
+      expenses: [
+        { category: 'food', amount: 12.34, date: new Date(2026, 7, 2).toISOString() },
+        { category: 'bills', amount: 50, date: new Date(2026, 6, 2).toISOString() },
+      ],
+    })
+    useBudgetLimits.mockReturnValue({
+      budgetLimits: [],
+      loading: false,
+      upsertLimit,
+      deleteLimit,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('owns the current budget month, monthly totals, and budget mutations', () => {
+    render(<BudgetsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Budgets' })).toBeInTheDocument()
+    expect(screen.getByTestId('budget-month')).toHaveTextContent('2026-08')
+    expect(screen.getByTestId('budget-totals')).toHaveTextContent('{"food":12.34}')
+    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-08')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upsert' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(upsertLimit).toHaveBeenCalledWith({ category: 'food' })
+    expect(deleteLimit).toHaveBeenCalledWith(7)
+  })
+
+  it('updates budget-limit and spending dependencies when the owned month changes', () => {
+    render(<BudgetsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose July' }))
+
+    expect(screen.getByTestId('budget-month')).toHaveTextContent('2026-07')
+    expect(screen.getByTestId('budget-totals')).toHaveTextContent('{"bills":50}')
+    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-07')
+  })
+})

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -9,11 +9,11 @@ import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import { normalizeText, isDefaultCategory } from "../../../utils/text";
 
 import SpendingChart from "../../../charts/components/SpendingChart";
-import BudgetLimitsPanel from "../../budgetLimits/components/BudgetLimitsPanel";
 import ExpenseForm from "../../expenses/components/ExpenseForm";
 import ExpenseFilters from "../../expenses/components/ExpenseFilters";
 import ExpenseList from "../../expenses/components/ExpenseList";
 import Card from "../../../shared/ui/Card";
+import FormField from "../../../shared/ui/FormField";
 const ENTRIES_PER_PAGE = 10;
 
 export default function TransactionsPage() {
@@ -25,14 +25,9 @@ export default function TransactionsPage() {
     deleteExpense,
   } = useExpenses();
 
-  const [limitMonthYear, setLimitMonthYear] = useState(getMonthYear(new Date()));
+  const [chartMonthYear, setChartMonthYear] = useState(getMonthYear(new Date()));
 
-  const {
-    budgetLimits,
-    loading: limitsLoading,
-    upsertLimit,
-    deleteLimit,
-  } = useBudgetLimits(limitMonthYear);
+  const { budgetLimits } = useBudgetLimits(chartMonthYear);
 
   const budgetLimitsByCategory = useMemo(() => {
     const obj = {};
@@ -86,8 +81,8 @@ export default function TransactionsPage() {
     : filteredExpenses.slice(0, ENTRIES_PER_PAGE);
 
   const totalsByCategory = useMemo(
-    () => computeMonthlyTotalsByCategory(expenses, limitMonthYear),
-    [expenses, limitMonthYear]
+    () => computeMonthlyTotalsByCategory(expenses, chartMonthYear),
+    [expenses, chartMonthYear]
   );
 
   async function handleAddExpense() {
@@ -179,16 +174,6 @@ export default function TransactionsPage() {
         setCustomCategory={setCustomCategory}
       />
   
-      <BudgetLimitsPanel
-        limitMonthYear={limitMonthYear}
-        setLimitMonthYear={setLimitMonthYear}
-        budgetLimits={budgetLimits}
-        limitsLoading={limitsLoading}
-        totalsByCategory={totalsByCategory}
-        upsertLimit={upsertLimit}
-        deleteLimit={deleteLimit}
-      />
-  
       <ExpenseFilters
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
@@ -219,6 +204,12 @@ export default function TransactionsPage() {
   
       <Card as="section" className="section chart-frame">
         <h2 className="h2">Spending vs Budget Limits</h2>
+        <FormField label="Chart month">{(id) => <input
+          id={id}
+          type="month"
+          value={chartMonthYear}
+          onChange={(e) => setChartMonthYear(e.target.value)}
+        />}</FormField>
         <SpendingChart
           totalsByCategory={totalsByCategory}
           budgetLimitsByCategory={budgetLimitsByCategory}

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -7,11 +7,12 @@ import { useBudgetLimits } from '../../budgetLimits/hooks/useBudgetLimits'
 
 vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
 vi.mock('../../budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
-vi.mock('../../budgetLimits/components/BudgetLimitsPanel', () => ({
-  default: () => <div data-testid="budget-panel" />,
-}))
 vi.mock('../../../charts/components/SpendingChart', () => ({
-  default: () => <div data-testid="spending-chart" />,
+  default: ({ totalsByCategory, budgetLimitsByCategory }) => (
+    <div data-testid="spending-chart">
+      {JSON.stringify({ totalsByCategory, budgetLimitsByCategory })}
+    </div>
+  ),
 }))
 
 const baseExpensesHook = {
@@ -133,12 +134,33 @@ describe('existing expense workflows', () => {
     expect(screen.getByRole('button', { name: 'Show More' })).toBeInTheDocument()
   })
 
-  it('keeps expense, budget-limit, and spending-chart workflows composed together', () => {
+  it('keeps expense and read-only spending-chart workflows without editable budget controls', () => {
     render(<TransactionsPage />)
 
     expect(screen.getByRole('heading', { name: 'Transactions' })).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Description')).toBeInTheDocument()
-    expect(screen.getByTestId('budget-panel')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /Budget Limits for/ })).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Chart month')).toBeInTheDocument()
     expect(screen.getByTestId('spending-chart')).toBeInTheDocument()
+  })
+
+  it('updates the read-only chart dependencies when its month changes', () => {
+    useExpenses.mockReturnValue({
+      ...baseExpensesHook,
+      expenses: [{ id: 1, category: 'food', amount: 12.34, date: '2026-07-10T00:00:00Z' }],
+    })
+    useBudgetLimits.mockReturnValue({
+      budgetLimits: [{ id: 7, category: 'food', limitAmount: 100 }],
+      loading: false,
+      upsertLimit: vi.fn(),
+      deleteLimit: vi.fn(),
+    })
+    render(<TransactionsPage />)
+
+    fireEvent.change(screen.getByLabelText('Chart month'), { target: { value: '2026-07' } })
+
+    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-07')
+    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{"food":12.34}')
+    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"limitAmount":100')
   })
 })


### PR DESCRIPTION
## Summary

- add a dedicated `/budgets` page that owns the existing editable monthly budget-limit workflow
- remove editable budget controls from Transactions while retaining the spending chart and a minimal read-only chart month selector
- add focused ownership, route, and behavior-preservation coverage

Closes #21

## Risk classification

MEDIUM — moves meaningful frontend state and ownership across feature boundaries.

## Implementation details

`BudgetsPage` now owns the selected budget month, `useBudgetLimits`, monthly spending totals, and `BudgetLimitsPanel`. Transactions remains a temporary read-only consumer of budget limits and monthly totals solely for `SpendingChart`, preserving its existing location until the later Analytics extraction.

## Verification

- `npm run verify` from `frontend/`
- 16 test files passed, 71 tests passed
- ESLint completed with the existing `useBudgetLimits` exhaustive-deps warning and no errors
- Vite production build passed
- staged diff passed `git diff --cached --check`

## Scope boundaries

- no changes to `BudgetLimitsPanel` behavior
- no Analytics extraction or redesign
- no transaction CRUD/filter/pagination semantic changes
- no backend, API, schema, migration, authentication, or deployment changes
- no dependency changes

## Impact

No migration, API contract, or dependency impact.