### PR TITLE
Extract Analytics and add useful Overview data

### DIFF
--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 
 import TransactionsPage from "../features/transactions/pages/TransactionsPage";
 import BudgetsPage from "../features/budgetLimits/pages/BudgetsPage";
+import AnalyticsPage from "../features/analytics/pages/AnalyticsPage";
 import AuthPage from "../features/auth/components/AuthPage";
 import ConfirmEmailPage from "../features/auth/components/ConfirmEmailPage";
 import ForgotPasswordPage from "../features/auth/components/ForgotPasswordPage";
@@ -10,7 +11,6 @@ import ResetPasswordPage from "../features/auth/components/ResetPasswordPage";
 import AppShell from "./AppShell";
 import ProtectedRoute from "./ProtectedRoute";
 import OverviewPage from "./pages/OverviewPage";
-import CompatibilityPage from "./pages/CompatibilityPage";
 import InvestingPage from "./pages/InvestingPage";
 import SettingsPage from "./pages/SettingsPage";
 
@@ -47,13 +47,7 @@ export default function App() {
           <Route path="/overview" element={<OverviewPage />} />
           <Route path="/transactions" element={<TransactionsPage />} />
           <Route path="/budgets" element={<BudgetsPage />} />
-          <Route path="/analytics" element={(
-            <CompatibilityPage
-              title="Analytics"
-              description="The existing spending chart remains with transactions until the analytics page is extracted."
-              actionLabel="Open spending chart"
-            />
-          )} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/investing" element={<InvestingPage />} />
           <Route path="/settings" element={<SettingsPage email={localStorage.getItem("email")} />} />
         </Route>

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -13,6 +13,14 @@ vi.mock('../features/budgetLimits/pages/BudgetsPage', () => ({
   default: () => <h1>Budgets workspace</h1>,
 }))
 
+vi.mock('../features/analytics/pages/AnalyticsPage', () => ({
+  default: () => <h1>Analytics workspace</h1>,
+}))
+
+vi.mock('./pages/OverviewPage', () => ({
+  default: () => <h1>Welcome back</h1>,
+}))
+
 vi.mock('../features/auth/components/AuthPage', () => ({
   default: () => <h1>Authentication content</h1>,
 }))
@@ -76,7 +84,7 @@ describe('application routes and shell', () => {
     ['/overview', 'Welcome back'],
     ['/transactions', 'Transactions workspace'],
     ['/budgets', 'Budgets workspace'],
-    ['/analytics', 'Analytics'],
+    ['/analytics', 'Analytics workspace'],
     ['/investing', 'Investing'],
     ['/settings', 'Settings'],
   ])('supports direct authenticated navigation to %s', async (path, heading) => {
@@ -188,14 +196,11 @@ describe('application routes and shell', () => {
     expect(screen.getByTestId('location')).toHaveTextContent('/budgets')
   })
 
-  it('keeps Analytics compatibility functionality reachable through Transactions', async () => {
-    const user = userEvent.setup()
+  it('renders the dedicated Analytics surface without redirecting to Transactions', async () => {
     localStorage.setItem('token', 'jwt-value')
     renderAt('/analytics')
 
-    await user.click(screen.getByRole('link', { name: 'Open spending chart' }))
-
-    expect(await screen.findByRole('heading', { name: 'Transactions workspace' })).toBeInTheDocument()
-    expect(screen.getByTestId('location')).toHaveTextContent('/transactions')
+    expect(await screen.findByRole('heading', { name: 'Analytics workspace' })).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent('/analytics')
   })
 })

--- a/frontend/src/app/pages/OverviewPage.jsx
+++ b/frontend/src/app/pages/OverviewPage.jsx
@@ -1,8 +1,39 @@
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { ArrowRight, BarChart3, ChartNoAxesCombined, Landmark, ReceiptText } from "lucide-react";
+import { useBudgetLimits } from "../../features/budgetLimits/hooks/useBudgetLimits";
+import { computeMonthlyTotalsByCategory } from "../../features/budgetLimits/utils/totalsByCategory";
+import { useExpenses } from "../../features/expenses/hooks/useExpenses";
+import { getMonthYear } from "../../shared/utils/monthYear";
+import { usedPercentage } from "../../utils/budgets";
 import Card from "../../shared/ui/Card";
+import StatusMessage from "../../shared/ui/StatusMessage";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
 
 export default function OverviewPage() {
+  const currentMonth = getMonthYear(new Date());
+  const { expenses, loading: expensesLoading } = useExpenses();
+  const { budgetLimits, loading: limitsLoading } = useBudgetLimits(currentMonth);
+
+  const totalsByCategory = useMemo(
+    () => computeMonthlyTotalsByCategory(expenses, currentMonth),
+    [expenses, currentMonth]
+  );
+
+  const recordedSpending = Object.values(totalsByCategory)
+    .reduce((sum, amount) => sum + Number(amount || 0), 0);
+  const spendingCategoryCount = Object.keys(totalsByCategory).length;
+  const totalLimits = (budgetLimits ?? []).length;
+  const attentionCount = (budgetLimits ?? []).filter((limit) => (
+    usedPercentage(totalsByCategory[limit.category] || 0, limit.limitAmount) >= 90
+  )).length;
+  const loading = expensesLoading || limitsLoading;
+  const isEmpty = spendingCategoryCount === 0 && totalLimits === 0;
+
   return (
     <div className="shell-page">
       <section className="overview-grid" aria-label="Planning tools">
@@ -14,6 +45,52 @@ export default function OverviewPage() {
               <Link className="button-link" to="/transactions">Open transactions <ArrowRight size={18} aria-hidden="true" /></Link>
             </div>
           </div>
+          <section className="overview-summary" aria-labelledby="overview-summary-heading">
+            <div className="overview-summary__header">
+              <div>
+                <p className="overview-kicker">Current month</p>
+                <h2 id="overview-summary-heading" className="h2">Recorded spending summary</h2>
+              </div>
+            </div>
+            {loading ? (
+              <StatusMessage>Loading current-month summary...</StatusMessage>
+            ) : (
+              <>
+                {isEmpty ? (
+                  <StatusMessage>No recorded spending or budget limits for this month yet.</StatusMessage>
+                ) : null}
+                <div className="overview-metrics">
+                  <Card className="overview-metric">
+                    <p className="overview-metric__label">Recorded spending this month</p>
+                    <p className="overview-metric__value">{currencyFormatter.format(recordedSpending)}</p>
+                    <p className="overview-metric__context">Includes recorded expenses through today.</p>
+                  </Card>
+                  <Card className="overview-metric">
+                    <p className="overview-metric__label">Categories with recorded spending</p>
+                    <p className="overview-metric__value">{spendingCategoryCount}</p>
+                    <p className="overview-metric__context">Uses the existing exact category grouping.</p>
+                  </Card>
+                  <Card className="overview-metric">
+                    <p className="overview-metric__label">Budget-limit attention</p>
+                    {totalLimits > 0 ? (
+                      <>
+                        <p className="overview-metric__value">{attentionCount}</p>
+                        <p className="overview-metric__context">
+                          {attentionCount === 1 ? "limit is" : "limits are"} at or above 90% used · {totalLimits} {totalLimits === 1 ? "limit" : "limits"} set
+                        </p>
+                      </>
+                    ) : (
+                      <>
+                        <p className="overview-metric__value">0</p>
+                        <p className="overview-metric__context">No budget limits are set for this month.</p>
+                        <Link to="/budgets">Set budget limits <span aria-hidden="true">→</span></Link>
+                      </>
+                    )}
+                  </Card>
+                </div>
+              </>
+            )}
+          </section>
           <Card className="overview-module overview-module--transactions">
             <div className="overview-module__heading">
               <ReceiptText size={24} aria-hidden="true" />
@@ -23,14 +100,14 @@ export default function OverviewPage() {
             <Link to="/transactions">Open transactions <span aria-hidden="true">→</span></Link>
           </Card>
           <Card className="overview-module overview-module--budgets">
-            <div className="overview-module__heading"><BarChart3 size={22} aria-hidden="true" /><span className="overview-module__status">Shared workspace</span></div>
-            <div><h3>Budgets</h3><p>Set monthly category limits in the existing workspace.</p></div>
-            <Link to="/budgets">View budget route <span aria-hidden="true">→</span></Link>
+            <div className="overview-module__heading"><BarChart3 size={22} aria-hidden="true" /><span className="overview-module__status">Available now</span></div>
+            <div><h3>Budgets</h3><p>Set and review monthly category limits.</p></div>
+            <Link to="/budgets">Open budgets <span aria-hidden="true">→</span></Link>
           </Card>
           <Card className="overview-module overview-module--analytics">
-            <div className="overview-module__heading"><ChartNoAxesCombined size={22} aria-hidden="true" /><span className="overview-module__status">Shared workspace</span></div>
-            <div><h3>Analytics</h3><p>Access the current spending-versus-limit chart.</p></div>
-            <Link to="/analytics">View analytics route <span aria-hidden="true">→</span></Link>
+            <div className="overview-module__heading"><ChartNoAxesCombined size={22} aria-hidden="true" /><span className="overview-module__status">Available now</span></div>
+            <div><h3>Analytics</h3><p>Compare recorded spending with category limits by month.</p></div>
+            <Link to="/analytics">Open analytics <span aria-hidden="true">→</span></Link>
           </Card>
           <Card className="overview-module overview-module--investing">
             <div className="overview-module__heading"><Landmark size={22} aria-hidden="true" /><span className="overview-module__status">Coming later</span></div>

--- a/frontend/src/app/pages/OverviewPage.test.jsx
+++ b/frontend/src/app/pages/OverviewPage.test.jsx
@@ -1,0 +1,85 @@
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import OverviewPage from './OverviewPage'
+import { useExpenses } from '../../features/expenses/hooks/useExpenses'
+import { useBudgetLimits } from '../../features/budgetLimits/hooks/useBudgetLimits'
+
+vi.mock('../../features/expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
+vi.mock('../../features/budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
+
+function renderPage() {
+  return render(<MemoryRouter><OverviewPage /></MemoryRouter>)
+}
+
+describe('Overview current-month summary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
+    useExpenses.mockReturnValue({
+      expenses: [
+        { category: 'food', amount: 90, date: new Date(2026, 7, 2).toISOString() },
+        { category: 'Food', amount: 10, date: new Date(2026, 7, 3).toISOString() },
+        { category: 'food', amount: 500, date: new Date(2026, 7, 15).toISOString() },
+      ],
+      loading: false,
+    })
+    useBudgetLimits.mockReturnValue({
+      budgetLimits: [
+        { category: 'food', limitAmount: 100 },
+        { category: 'Food', limitAmount: 20 },
+      ],
+      loading: false,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('derives only the approved signals with exact categories and future-day exclusion', () => {
+    renderPage()
+
+    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-08')
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
+
+    const categoriesCard = screen.getByText('Categories with recorded spending').closest('.card')
+    expect(within(categoriesCard).getByText('2')).toBeInTheDocument()
+
+    const attentionCard = screen.getByText('Budget-limit attention').closest('.card')
+    expect(within(attentionCard).getByText('1')).toBeInTheDocument()
+    expect(attentionCard).toHaveTextContent('limit is at or above 90% used · 2 limits set')
+  })
+
+  it('shows a loading status instead of transient metrics', () => {
+    useExpenses.mockReturnValue({ expenses: [], loading: true })
+    renderPage()
+
+    expect(screen.getByText('Loading current-month summary...')).toBeInTheDocument()
+    expect(screen.queryByText('Recorded spending this month')).not.toBeInTheDocument()
+  })
+
+  it('keeps expense metrics useful and explains when no limits exist', () => {
+    useExpenses.mockReturnValue({
+      expenses: [{ category: 'food', amount: 12.34, date: new Date(2026, 7, 2).toISOString() }],
+      loading: false,
+    })
+    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
+    renderPage()
+
+    expect(screen.getByText('$12.34')).toBeInTheDocument()
+    expect(screen.getByText('No budget limits are set for this month.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Set budget limits/ })).toHaveAttribute('href', '/budgets')
+  })
+
+  it('renders honest zero values and an empty status for an empty month', () => {
+    useExpenses.mockReturnValue({ expenses: [], loading: false })
+    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
+    renderPage()
+
+    expect(screen.getByText('No recorded spending or budget limits for this month yet.')).toBeInTheDocument()
+    expect(screen.getByText('$0.00')).toBeInTheDocument()
+    expect(screen.getAllByText('0')).toHaveLength(2)
+  })
+})

--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -1,0 +1,67 @@
+import { useMemo, useState } from "react";
+import SpendingChart from "../../../charts/components/SpendingChart";
+import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
+import { computeMonthlyTotalsByCategory } from "../../budgetLimits/utils/totalsByCategory";
+import { useExpenses } from "../../expenses/hooks/useExpenses";
+import { getMonthYear } from "../../../shared/utils/monthYear";
+import Card from "../../../shared/ui/Card";
+import FormField from "../../../shared/ui/FormField";
+import StatusMessage from "../../../shared/ui/StatusMessage";
+
+export default function AnalyticsPage() {
+  const { expenses, loading: expensesLoading } = useExpenses();
+  const [chartMonthYear, setChartMonthYear] = useState(getMonthYear(new Date()));
+  const { budgetLimits, loading: limitsLoading } = useBudgetLimits(chartMonthYear);
+
+  const totalsByCategory = useMemo(
+    () => computeMonthlyTotalsByCategory(expenses, chartMonthYear),
+    [expenses, chartMonthYear]
+  );
+
+  const budgetLimitsByCategory = useMemo(() => {
+    const limitsByCategory = {};
+    for (const limit of budgetLimits ?? []) limitsByCategory[limit.category] = limit;
+    return limitsByCategory;
+  }, [budgetLimits]);
+
+  const loading = expensesLoading || limitsLoading;
+  const hasBudgetLimits = (budgetLimits ?? []).length > 0;
+
+  return (
+    <div className="container">
+      <header className="page-header">
+        <div>
+          <p className="page-header__eyebrow">Understand your spending</p>
+          <h1>Analytics</h1>
+          <p className="muted">Compare recorded spending with category limits for a selected month.</p>
+        </div>
+      </header>
+
+      <Card as="section" className="section chart-frame">
+        <div className="section__header">
+          <h2 className="h2">Spending vs Budget Limits</h2>
+          <FormField label="Chart month">{(id) => <input
+            id={id}
+            type="month"
+            value={chartMonthYear}
+            onChange={(event) => setChartMonthYear(event.target.value)}
+          />}</FormField>
+        </div>
+
+        {loading ? (
+          <StatusMessage>Loading spending analytics...</StatusMessage>
+        ) : (
+          <>
+            {!hasBudgetLimits && Object.keys(totalsByCategory).length > 0 ? (
+              <StatusMessage>No budget limits are set for this month. The chart shows recorded spending only.</StatusMessage>
+            ) : null}
+            <SpendingChart
+              totalsByCategory={totalsByCategory}
+              budgetLimitsByCategory={budgetLimitsByCategory}
+            />
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AnalyticsPage from './AnalyticsPage'
+import { useExpenses } from '../../expenses/hooks/useExpenses'
+import { useBudgetLimits } from '../../budgetLimits/hooks/useBudgetLimits'
+
+vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
+vi.mock('../../budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
+vi.mock('../../../charts/components/SpendingChart', () => ({
+  default: ({ totalsByCategory, budgetLimitsByCategory }) => (
+    <div data-testid="spending-chart">
+      {JSON.stringify({ totalsByCategory, budgetLimitsByCategory })}
+    </div>
+  ),
+}))
+
+describe('Analytics page ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
+    useExpenses.mockReturnValue({
+      expenses: [
+        { category: 'food', amount: 12.34, date: new Date(2026, 7, 2).toISOString() },
+        { category: 'bills', amount: 50, date: new Date(2026, 6, 2).toISOString() },
+      ],
+      loading: false,
+    })
+    useBudgetLimits.mockReturnValue({
+      budgetLimits: [{ id: 7, category: 'food', limitAmount: 100 }],
+      loading: false,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('owns the current chart month and exact chart data mapping', () => {
+    render(<AnalyticsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Analytics' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Chart month')).toHaveValue('2026-08')
+    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-08')
+    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{"food":12.34}')
+    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"budgetLimitsByCategory":{"food":{"id":7')
+  })
+
+  it('updates both chart dependencies when the selected month changes', () => {
+    render(<AnalyticsPage />)
+
+    fireEvent.change(screen.getByLabelText('Chart month'), { target: { value: '2026-07' } })
+
+    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-07')
+    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{"bills":50}')
+  })
+
+  it('shows loading without rendering transient chart data', () => {
+    useExpenses.mockReturnValue({ expenses: [], loading: true })
+    render(<AnalyticsPage />)
+
+    expect(screen.getByText('Loading spending analytics...')).toBeInTheDocument()
+    expect(screen.queryByTestId('spending-chart')).not.toBeInTheDocument()
+  })
+
+  it('explains spending-only chart data when no limits exist', () => {
+    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
+    render(<AnalyticsPage />)
+
+    expect(screen.getByText(/No budget limits are set for this month/)).toBeInTheDocument()
+    expect(screen.getByTestId('spending-chart')).toBeInTheDocument()
+  })
+
+  it('preserves the chart empty state when no spending or limits exist', () => {
+    useExpenses.mockReturnValue({ expenses: [], loading: false })
+    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
+    render(<AnalyticsPage />)
+
+    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{}')
+    expect(screen.queryByText(/The chart shows recorded spending only/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -1,19 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { useExpenses } from "../../expenses/hooks/useExpenses";
-import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
 
-import { getMonthYear } from "../../../shared/utils/monthYear";
 import { filterExpenses } from "../../expenses/utils/filterExpenses";
-import { computeMonthlyTotalsByCategory } from "../../budgetLimits/utils/totalsByCategory";
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import { normalizeText, isDefaultCategory } from "../../../utils/text";
 
-import SpendingChart from "../../../charts/components/SpendingChart";
 import ExpenseForm from "../../expenses/components/ExpenseForm";
 import ExpenseFilters from "../../expenses/components/ExpenseFilters";
 import ExpenseList from "../../expenses/components/ExpenseList";
-import Card from "../../../shared/ui/Card";
-import FormField from "../../../shared/ui/FormField";
 const ENTRIES_PER_PAGE = 10;
 
 export default function TransactionsPage() {
@@ -24,16 +18,6 @@ export default function TransactionsPage() {
     updateExpense,
     deleteExpense,
   } = useExpenses();
-
-  const [chartMonthYear, setChartMonthYear] = useState(getMonthYear(new Date()));
-
-  const { budgetLimits } = useBudgetLimits(chartMonthYear);
-
-  const budgetLimitsByCategory = useMemo(() => {
-    const obj = {};
-    for (const l of budgetLimits ?? []) obj[l.category] = l;
-    return obj;
-  }, [budgetLimits]);
 
   // Add expense UI state
   const [newName, setNewName] = useState("");
@@ -79,11 +63,6 @@ export default function TransactionsPage() {
   const expensesToShow = showAll
     ? filteredExpenses
     : filteredExpenses.slice(0, ENTRIES_PER_PAGE);
-
-  const totalsByCategory = useMemo(
-    () => computeMonthlyTotalsByCategory(expenses, chartMonthYear),
-    [expenses, chartMonthYear]
-  );
 
   async function handleAddExpense() {
     if (!newName || !newAmount || !newDate || !newCategory) {
@@ -155,7 +134,7 @@ export default function TransactionsPage() {
         <div>
           <p className="page-header__eyebrow">Your finances</p>
           <h1>Transactions</h1>
-          <p className="muted">Track spending and keep monthly limits in view.</p>
+          <p className="muted">Record, review, and organize your expenses.</p>
         </div>
       </header>
   
@@ -201,20 +180,6 @@ export default function TransactionsPage() {
         onCancel={cancelEditExpense}
         onDelete={deleteExpense}
       />
-  
-      <Card as="section" className="section chart-frame">
-        <h2 className="h2">Spending vs Budget Limits</h2>
-        <FormField label="Chart month">{(id) => <input
-          id={id}
-          type="month"
-          value={chartMonthYear}
-          onChange={(e) => setChartMonthYear(e.target.value)}
-        />}</FormField>
-        <SpendingChart
-          totalsByCategory={totalsByCategory}
-          budgetLimitsByCategory={budgetLimitsByCategory}
-        />
-      </Card>
     </div>
   );
 }

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -3,17 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import TransactionsPage from './TransactionsPage'
 import { useExpenses } from '../../expenses/hooks/useExpenses'
-import { useBudgetLimits } from '../../budgetLimits/hooks/useBudgetLimits'
 
 vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
-vi.mock('../../budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
-vi.mock('../../../charts/components/SpendingChart', () => ({
-  default: ({ totalsByCategory, budgetLimitsByCategory }) => (
-    <div data-testid="spending-chart">
-      {JSON.stringify({ totalsByCategory, budgetLimitsByCategory })}
-    </div>
-  ),
-}))
 
 const baseExpensesHook = {
   expenses: [],
@@ -26,12 +17,6 @@ const baseExpensesHook = {
 describe('existing expense workflows', () => {
   beforeEach(() => {
     useExpenses.mockReturnValue({ ...baseExpensesHook })
-    useBudgetLimits.mockReturnValue({
-      budgetLimits: [],
-      loading: false,
-      upsertLimit: vi.fn(),
-      deleteLimit: vi.fn(),
-    })
     vi.spyOn(window, 'alert').mockImplementation(() => {})
   })
 
@@ -134,33 +119,12 @@ describe('existing expense workflows', () => {
     expect(screen.getByRole('button', { name: 'Show More' })).toBeInTheDocument()
   })
 
-  it('keeps expense and read-only spending-chart workflows without editable budget controls', () => {
+  it('keeps the page transaction-focused without chart or budget-read controls', () => {
     render(<TransactionsPage />)
 
     expect(screen.getByRole('heading', { name: 'Transactions' })).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Description')).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: /Budget Limits for/ })).not.toBeInTheDocument()
-    expect(screen.getByLabelText('Chart month')).toBeInTheDocument()
-    expect(screen.getByTestId('spending-chart')).toBeInTheDocument()
-  })
-
-  it('updates the read-only chart dependencies when its month changes', () => {
-    useExpenses.mockReturnValue({
-      ...baseExpensesHook,
-      expenses: [{ id: 1, category: 'food', amount: 12.34, date: '2026-07-10T00:00:00Z' }],
-    })
-    useBudgetLimits.mockReturnValue({
-      budgetLimits: [{ id: 7, category: 'food', limitAmount: 100 }],
-      loading: false,
-      upsertLimit: vi.fn(),
-      deleteLimit: vi.fn(),
-    })
-    render(<TransactionsPage />)
-
-    fireEvent.change(screen.getByLabelText('Chart month'), { target: { value: '2026-07' } })
-
-    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-07')
-    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{"food":12.34}')
-    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"limitAmount":100')
+    expect(screen.queryByRole('heading', { name: 'Spending vs Budget Limits' })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Chart month')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -64,6 +64,15 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .overview-hero__content > p:not(.page-header__eyebrow) { max-width: 640px; color: var(--color-text-muted); font-size: var(--text-lg); }
 .overview-kicker { margin-bottom: var(--space-1); color: var(--color-primary); font-size: var(--text-xs); font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 .overview-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); }
+.overview-summary { grid-column: 1 / -1; }
+.overview-summary__header { margin-bottom: var(--space-3); }
+.overview-summary__header h2 { margin: 0; }
+.overview-metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); }
+.overview-metric { box-shadow: none; }
+.overview-metric__label { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
+.overview-metric__value { margin: var(--space-2) 0; font-size: clamp(1.8rem, 4vw, 2.6rem); font-weight: 900; font-variant-numeric: tabular-nums; }
+.overview-metric__context { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); }
+.overview-metric a { display: inline-block; margin-top: var(--space-3); color: var(--color-primary); font-weight: 800; text-decoration: none; }
 .overview-module { display: flex; min-height: 190px; flex-direction: column; justify-content: space-between; gap: var(--space-4); box-shadow: none; }
 .overview-module__heading { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); color: var(--color-primary); }
 .overview-module__status { color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
@@ -76,6 +85,6 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .overview-module--analytics { grid-column: span 2; min-height: 220px; background: var(--color-bg-accent); }
 .overview-module--investing { grid-column: 1 / -1; min-height: 180px; border-style: dashed; background: var(--color-surface-subtle); }
 .mt-2 { margin-top: var(--space-4); }
-@media (max-width: 820px) { .overview-grid { grid-template-columns: 1fr; } .overview-hero, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
+@media (max-width: 820px) { .overview-grid, .overview-metrics { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
 @media (max-width: 520px) { .card { padding: var(--space-4); } button:not(.icon-button):not(.password-toggle) { width: 100%; } }
 @media (max-width: 380px) { .mobile-nav .app-nav__link { min-height: 56px; } }


### PR DESCRIPTION
## Summary

- add a dedicated `/analytics` page that owns the existing read-only spending-versus-budget chart workflow
- remove all chart month, budget-read, and chart rendering responsibilities from Transactions
- add three honest current-month Overview signals: recorded spending, categories with recorded spending, and budget-limit attention with total limits as context
- add focused ownership, route, loading, empty, no-budget, exact-category, and future-date coverage

Closes #23

## Risk classification

MEDIUM — moves meaningful frontend data ownership and adds derived Overview presentation.

## Implementation details

Analytics now owns `useExpenses`, `useBudgetLimits`, the selected `YYYY-MM` chart month, characterized monthly totals, exact category indexing, loading/no-budget presentation, and the presentation-only `SpendingChart` composition.

Overview reuses the existing current-month totals and percentage utilities. Budget attention uses the established `>= 90%` threshold and exact category matching. It does not calculate a total budget or imply income, balance, savings, cash flow, financial health, or forecasting.

## Verification

- focused suite: 7 files, 42 tests passed
- `npm run verify` from `frontend/`
- full suite: 18 files, 79 tests passed
- ESLint completed with the existing `useBudgetLimits` exhaustive-deps warning and no errors
- Vite production build passed
- staged diff passed `git diff --cached --check`

## Scope boundaries

- no changes to hooks, `SpendingChart`, monthly totals, percentage, month, category, date, or rounding semantics
- no global state/provider or generalized financial-summary helper
- no new chart types or Investing/Settings work
- no backend, API, schema, migration, authentication, deployment, or dependency changes

## Impact

No migration, API contract, backend, or dependency impact.