### PR TITLE
Mature Investing and Settings surfaces

### DIFF
--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -170,11 +170,18 @@ describe('application routes and shell', () => {
     expect(screen.queryByRole('navigation', { name: 'Primary navigation' })).not.toBeInTheDocument()
   })
 
-  it('keeps theme selection functional in the shell header', async () => {
+  it('keeps shell and Settings theme controls unique and synchronized', async () => {
     const user = userEvent.setup()
     localStorage.setItem('token', 'jwt-value')
     renderAt('/settings')
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Theme' }), 'dark')
+
+    const shellControl = screen.getByRole('combobox', { name: 'Theme' })
+    const settingsControl = screen.getByRole('combobox', { name: 'Theme preference' })
+    expect(shellControl.id).not.toBe(settingsControl.id)
+
+    await user.selectOptions(settingsControl, 'dark')
+    expect(shellControl).toHaveValue('dark')
+    expect(settingsControl).toHaveValue('dark')
     expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
     expect(localStorage.getItem('budget-planner-theme')).toBe('dark')
   })
@@ -184,7 +191,7 @@ describe('application routes and shell', () => {
     vi.stubGlobal('fetch', fetchSpy)
     localStorage.setItem('token', 'jwt-value')
     renderAt('/investing')
-    expect(screen.getByRole('heading', { name: 'Not connected yet' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'No investment source connected' })).toBeInTheDocument()
     await waitFor(() => expect(fetchSpy).not.toHaveBeenCalled())
   })
 

--- a/frontend/src/app/pages/InvestingPage.jsx
+++ b/frontend/src/app/pages/InvestingPage.jsx
@@ -8,14 +8,51 @@ export default function InvestingPage() {
         <div>
           <p className="page-header__eyebrow">Investing</p>
           <h1>Investing</h1>
-          <p className="muted">A future home for investment connections you choose.</p>
+          <p className="muted">A future home for investment information from sources you may choose.</p>
         </div>
       </header>
-      <Card className="empty-state-card">
+
+      <Card as="section" className="investing-status">
         <span className="empty-state-card__icon"><Landmark size={24} aria-hidden="true" /></span>
-        <h2 className="h2">Not connected yet</h2>
-        <p className="muted">No portfolio, brokerage, signal, or external integration is connected. Nothing is being fetched or inferred.</p>
+        <p className="investing-status__eyebrow">Unavailable today</p>
+        <h2 className="h2">No investment source connected</h2>
+        <p className="muted">
+          No portfolio, brokerage, signal provider, market-data source, or other investment integration is connected.
+          No investment data is being fetched, imported, inferred, or evaluated.
+        </p>
       </Card>
+
+      <section className="investing-capabilities" aria-labelledby="investing-capabilities-heading">
+        <div className="section__header">
+          <div>
+            <p className="page-header__eyebrow">Future structure</p>
+            <h2 id="investing-capabilities-heading" className="h2">Planned capability areas</h2>
+          </div>
+        </div>
+
+        <div className="investing-capabilities__grid">
+          <Card as="article" className="investing-capability">
+            <span className="investing-capability__status">Not available</span>
+            <h3>Connections</h3>
+            <p>Future sources would require a source-specific adapter and a normalized application contract. No provider is supported today.</p>
+          </Card>
+          <Card as="article" className="investing-capability">
+            <span className="investing-capability__status">Not available</span>
+            <h3>Portfolio and positions</h3>
+            <p>No portfolio values, holdings, or positions are available without a real source supplying them.</p>
+          </Card>
+          <Card as="article" className="investing-capability">
+            <span className="investing-capability__status">Not available</span>
+            <h3>Signals</h3>
+            <p>No investment signals, recommendations, or trading guidance are generated.</p>
+          </Card>
+          <Card as="article" className="investing-capability">
+            <span className="investing-capability__status">Not available</span>
+            <h3>Activity and performance</h3>
+            <p>No investment activity or performance information is available to report.</p>
+          </Card>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/app/pages/InvestingPage.test.jsx
+++ b/frontend/src/app/pages/InvestingPage.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import InvestingPage from './InvestingPage'
+
+describe('Investing unavailable surface', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('describes only unconnected, unavailable, source-neutral future domains', () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    render(<InvestingPage />)
+
+    expect(screen.getByRole('heading', { name: 'No investment source connected' })).toBeInTheDocument()
+    expect(screen.getByText(/No investment data is being fetched, imported, inferred, or evaluated/)).toBeInTheDocument()
+
+    const capabilities = screen.getByRole('heading', { name: 'Planned capability areas' }).closest('section')
+    expect(within(capabilities).getByRole('heading', { name: 'Connections' })).toBeInTheDocument()
+    expect(within(capabilities).getByRole('heading', { name: 'Portfolio and positions' })).toBeInTheDocument()
+    expect(within(capabilities).getByRole('heading', { name: 'Signals' })).toBeInTheDocument()
+    expect(within(capabilities).getByRole('heading', { name: 'Activity and performance' })).toBeInTheDocument()
+    expect(within(capabilities).getAllByText('Not available')).toHaveLength(4)
+    expect(screen.getByText(/source-specific adapter and a normalized application contract/)).toBeInTheDocument()
+    expect(screen.getByText(/No provider is supported today/)).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/pages/SettingsPage.jsx
+++ b/frontend/src/app/pages/SettingsPage.jsx
@@ -1,4 +1,5 @@
 import Card from "../../shared/ui/Card";
+import ThemeControl from "../../shared/theme/ThemeControl";
 
 export default function SettingsPage({ email }) {
   return (
@@ -7,14 +8,26 @@ export default function SettingsPage({ email }) {
         <div>
           <p className="page-header__eyebrow">Settings</p>
           <h1>Settings</h1>
-          <p className="muted">Review the account currently signed in to this workspace.</p>
+          <p className="muted">Review the signed-in account and presentation preferences supported on this device.</p>
         </div>
       </header>
-      <Card>
-        <p className="field__label">Account email</p>
-        <p className="settings-value">{email}</p>
-        <p className="muted">Theme preference is available in the workspace header and remains stored only on this device.</p>
-      </Card>
+
+      <div className="settings-grid">
+        <Card as="section" className="settings-card">
+          <h2 className="h2">Account</h2>
+          <p className="field__label">Signed-in email</p>
+          <p className="settings-value">{email}</p>
+          <p className="muted">This identifies the account currently signed in to the workspace.</p>
+        </Card>
+
+        <Card as="section" className="settings-card">
+          <h2 className="h2">Appearance</h2>
+          <ThemeControl label="Theme preference" className="theme-control--settings" />
+          <p className="muted settings-card__note">
+            System follows this device’s appearance. Light or Dark is stored locally on this device.
+          </p>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/pages/SettingsPage.test.jsx
+++ b/frontend/src/app/pages/SettingsPage.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it } from 'vitest'
+import SettingsPage from './SettingsPage'
+import { ThemeProvider } from '../../shared/theme/ThemeProvider'
+import { THEME_STORAGE_KEY } from '../../shared/theme/theme'
+
+describe('Settings supported account and appearance behavior', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('shows read-only account identity without account-management controls', () => {
+    render(<ThemeProvider><SettingsPage email="person@example.com" /></ThemeProvider>)
+
+    expect(screen.getByText('person@example.com')).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('uses the existing theme preference and persistence behavior', async () => {
+    const user = userEvent.setup()
+    render(<ThemeProvider><SettingsPage email="person@example.com" /></ThemeProvider>)
+    const control = screen.getByRole('combobox', { name: 'Theme preference' })
+
+    expect(control).toHaveValue('system')
+    expect(screen.getByText(/stored locally on this device/)).toBeInTheDocument()
+
+    await user.selectOptions(control, 'dark')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+
+    await user.selectOptions(control, 'system')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull()
+    expect(document.documentElement).not.toHaveAttribute('data-theme')
+  })
+})

--- a/frontend/src/shared/theme/ThemeControl.jsx
+++ b/frontend/src/shared/theme/ThemeControl.jsx
@@ -1,11 +1,14 @@
+import { useId } from "react";
 import { useTheme } from "./useTheme";
 
-export default function ThemeControl() {
+export default function ThemeControl({ label = "Theme", className = "" }) {
   const { theme, setTheme } = useTheme();
+  const controlId = useId();
+
   return (
-    <div className="theme-control">
-      <label htmlFor="theme-preference">Theme</label>
-      <select id="theme-preference" value={theme} onChange={(event) => setTheme(event.target.value)}>
+    <div className={`theme-control ${className}`.trim()}>
+      <label htmlFor={controlId}>{label}</label>
+      <select id={controlId} value={theme} onChange={(event) => setTheme(event.target.value)}>
         <option value="system">System</option>
         <option value="light">Light</option>
         <option value="dark">Dark</option>

--- a/frontend/src/shared/theme/ThemeControl.test.jsx
+++ b/frontend/src/shared/theme/ThemeControl.test.jsx
@@ -39,4 +39,23 @@ describe("ThemeControl", () => {
 
     expect(document.documentElement).toHaveAttribute("data-theme", "dark");
   });
+
+  it("gives multiple controls unique ids and synchronizes them through one provider", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <ThemeControl label="Header theme" />
+        <ThemeControl label="Theme preference" />
+      </ThemeProvider>
+    );
+
+    const headerControl = screen.getByRole("combobox", { name: "Header theme" });
+    const settingsControl = screen.getByRole("combobox", { name: "Theme preference" });
+    expect(headerControl.id).not.toBe(settingsControl.id);
+
+    await user.selectOptions(settingsControl, "dark");
+    expect(headerControl).toHaveValue("dark");
+    expect(settingsControl).toHaveValue("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
 });

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -36,6 +36,8 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .theme-control { display: inline-flex; align-items: center; gap: var(--space-2); }
 .theme-control label { color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
 .theme-control select { width: auto; min-height: 38px; padding-block: .45rem; }
+.theme-control--settings { align-items: stretch; flex-direction: column; }
+.theme-control--settings select { width: min(100%, 280px); }
 .empty-state-card__icon { display: inline-grid; place-items: center; color: var(--color-on-primary); background: var(--color-primary); }
 .app-nav { display: flex; align-items: stretch; gap: var(--space-1); }
 .app-nav__link { position: relative; display: flex; align-items: center; justify-content: center; gap: var(--space-2); min-height: 44px; padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); color: var(--color-text-muted); text-decoration: none; font-size: var(--text-sm); font-weight: 700; transition: color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard); }
@@ -57,6 +59,18 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .empty-state-card__eyebrow { color: var(--color-success); font-size: var(--text-sm); font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
 .empty-state-card__icon { width: 48px; height: 48px; margin-bottom: var(--space-4); border-radius: var(--radius-md); }
 .settings-value { margin-bottom: var(--space-4); font-size: var(--text-lg); font-weight: 700; }
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+.settings-card { box-shadow: none; }
+.settings-card__note { margin: var(--space-3) 0 0; }
+.investing-status { max-width: 800px; }
+.investing-status__eyebrow { margin-bottom: var(--space-2); color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.investing-status > .muted { max-width: 680px; margin-bottom: 0; }
+.investing-capabilities { margin-top: var(--space-6); }
+.investing-capabilities__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+.investing-capability { box-shadow: none; }
+.investing-capability__status { display: inline-block; margin-bottom: var(--space-3); color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+.investing-capability h3 { margin-bottom: var(--space-2); font-size: var(--text-lg); }
+.investing-capability p { margin-bottom: 0; color: var(--color-text-muted); }
 .overview-hero { position: relative; grid-column: 1 / -1; min-height: 220px; overflow: hidden; padding: clamp(var(--space-5), 3vw, var(--space-6)); border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); box-shadow: var(--shadow-sm); }
 .overview-hero::after { position: absolute; top: 0; bottom: 0; left: 0; width: 4px; background: var(--color-primary); content: ""; }
 .overview-hero__content { position: relative; z-index: 1; max-width: 720px; }
@@ -85,6 +99,6 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .overview-module--analytics { grid-column: span 2; min-height: 220px; background: var(--color-bg-accent); }
 .overview-module--investing { grid-column: 1 / -1; min-height: 180px; border-style: dashed; background: var(--color-surface-subtle); }
 .mt-2 { margin-top: var(--space-4); }
-@media (max-width: 820px) { .overview-grid, .overview-metrics { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
+@media (max-width: 820px) { .overview-grid, .overview-metrics, .settings-grid, .investing-capabilities__grid { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
 @media (max-width: 520px) { .card { padding: var(--space-4); } button:not(.icon-button):not(.password-toggle) { width: 100%; } }
 @media (max-width: 380px) { .mobile-nav .app-nav__link { min-height: 56px; } }

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -47,5 +47,5 @@
   .mobile-nav { display: none; }
 }
 @media (max-width: 720px) { .page-header { align-items: start; flex-direction: column; } .filters { grid-template-columns: 1fr; } }
-@media (max-width: 620px) { .theme-control label { display: none; } .app-pagebar { padding-inline: var(--space-3); } }
-@media (max-width: 430px) { .app-content { padding-inline: var(--space-4); } .app-pagebar__actions { gap: var(--space-1); } .theme-control select { max-width: 76px; } }
+@media (max-width: 620px) { .app-pagebar .theme-control label { display: none; } .app-pagebar { padding-inline: var(--space-3); } }
+@media (max-width: 430px) { .app-content { padding-inline: var(--space-4); } .app-pagebar__actions { gap: var(--space-1); } .app-pagebar .theme-control select { max-width: 76px; } }


### PR DESCRIPTION
## Summary

- mature Investing into an explicit unconnected, source-neutral information architecture with unavailable future capability areas
- make Settings useful with read-only signed-in email and the existing System / Light / Dark preference
- preserve the AppShell theme control while giving multiple controls unique IDs and synchronized provider state
- scope compact theme CSS to the pagebar so the Settings label and control remain usable responsively
- add focused honesty, account-boundary, persistence, synchronization, ID, and route coverage

Closes #25

## Risk classification

MEDIUM — introduces a real Settings interaction through shared theme state and adapts a shared control.

## Implementation details

Investing performs no requests and contains no portfolio values, positions, returns, signals, activity, timestamps, providers, sample data, or Connect action. Every future domain is explicitly labeled unavailable.

Settings reuses the existing `ThemeProvider`, `useTheme`, `persistTheme`, `applyTheme`, options, and storage key. `ThemeControl` now uses React `useId` and optional label/class props; both shell and Settings controls remain synchronized through the single provider.

## Verification

- focused suite: 5 files, 32 tests passed
- `npm run verify` from `frontend/`
- full suite: 20 files, 83 tests passed
- ESLint completed with the existing `useBudgetLimits` exhaustive-deps warning and no errors
- Vite production build passed
- staged diff passed `git diff --cached --check`

## Scope boundaries

- no fake/demo investment data, connection flow, or external request
- no Discord, brokerage, market-data, or provider integration
- no account editing, email/password changes, auth work, or Settings-local persistence
- no changes to theme provider, persistence helpers, storage semantics, backend, API, schema, or dependencies
- no 14H cross-application polish

## Impact

No migration, API contract, backend, auth, or dependency impact.