### PR TITLE
test: characterize financial api behavior

### DIFF
--- a/backend.Tests/Financial/BudgetLimitsApiTests.cs
+++ b/backend.Tests/Financial/BudgetLimitsApiTests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+public sealed class BudgetLimitsApiTests
+{
+    [Fact]
+    public async Task Unauthenticated_request_is_rejected()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+
+        var response = await client.GetAsync("/api/budgetlimits?monthYear=2026-08");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_requires_month_year()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.GetAsync("/api/budgetlimits");
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("One or more validation errors occurred.", body.GetProperty("title").GetString());
+        Assert.Equal(400, body.GetProperty("status").GetInt32());
+        var monthYearErrors = body.GetProperty("errors").GetProperty("monthYear");
+        Assert.Contains(
+            "The monthYear field is required.",
+            monthYearErrors.EnumerateArray().Select(error => error.GetString()));
+    }
+
+    [Fact]
+    public async Task Get_rejects_invalid_month_year()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.GetAsync("/api/budgetlimits?monthYear=not-a-month");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(
+            "Invalid monthYear format. Expected format: YYYY-MM",
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Get_scopes_limits_to_authenticated_user_and_requested_month()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+        var august = await app.SeedBudgetLimitAsync(owner.Id, "food", 100m);
+        await app.SeedBudgetLimitAsync(
+            owner.Id,
+            "bills",
+            200m,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+        await app.SeedBudgetLimitAsync(other.Id, "transport", 300m);
+
+        var response = await owner.Client.GetAsync("/api/budgetlimits?monthYear=2026-08");
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var limit = Assert.Single(body.EnumerateArray());
+        Assert.Equal(august.Id, limit.GetProperty("id").GetInt32());
+        Assert.Equal("food", limit.GetProperty("category").GetString());
+        Assert.Equal(100m, limit.GetProperty("limitAmount").GetDecimal());
+        Assert.Equal(owner.Id, limit.GetProperty("userId").GetString());
+        Assert.Equal(JsonValueKind.Null, limit.GetProperty("user").ValueKind);
+        Assert.True(limit.TryGetProperty("monthYear", out _));
+    }
+
+    [Fact]
+    public async Task Create_assigns_owner_and_normalizes_month_to_first_day_utc()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+
+        var response = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "food",
+            limitAmount = 125.50m,
+            monthYear = "2026-08-23T14:30:00",
+            userId = other.Id
+        });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(owner.Id, body.GetProperty("userId").GetString());
+        Assert.Equal("food", body.GetProperty("category").GetString());
+        Assert.Equal(125.50m, body.GetProperty("limitAmount").GetDecimal());
+        Assert.Equal(JsonValueKind.Null, body.GetProperty("user").ValueKind);
+
+        var limits = await app.FindBudgetLimitsAsync(owner.Id, "food");
+        var persisted = Assert.Single(limits);
+        Assert.Equal(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), persisted.MonthYear);
+        Assert.Equal(DateTimeKind.Utc, persisted.MonthYear.Kind);
+    }
+
+    [Fact]
+    public async Task Same_user_category_and_month_updates_existing_limit()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var existing = await app.SeedBudgetLimitAsync(owner.Id, "food", 100m);
+
+        var response = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "food",
+            limitAmount = 250m,
+            monthYear = "2026-08-31"
+        });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(existing.Id, body.GetProperty("id").GetInt32());
+        Assert.Equal(250m, body.GetProperty("limitAmount").GetDecimal());
+        var limits = await app.FindBudgetLimitsAsync(owner.Id, "food");
+        Assert.Equal(250m, Assert.Single(limits).LimitAmount);
+    }
+
+    [Fact]
+    public async Task Category_matching_is_case_and_whitespace_sensitive()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        await app.SeedBudgetLimitAsync(owner.Id, "food", 100m);
+
+        foreach (var category in new[] { "Food", " food " })
+        {
+            var response = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+            {
+                category,
+                limitAmount = 200m,
+                monthYear = "2026-08-15"
+            });
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        Assert.Single(await app.FindBudgetLimitsAsync(owner.Id, "food"));
+        Assert.Single(await app.FindBudgetLimitsAsync(owner.Id, "Food"));
+        Assert.Single(await app.FindBudgetLimitsAsync(owner.Id, " food "));
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-75.25")]
+    public async Task Create_accepts_current_zero_and_negative_limit_amounts(string amountText)
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var amount = decimal.Parse(amountText, System.Globalization.CultureInfo.InvariantCulture);
+
+        var response = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = $"edge-{amountText}",
+            limitAmount = amount,
+            monthYear = "2026-08-15"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var limits = await app.FindBudgetLimitsAsync(owner.Id, $"edge-{amountText}");
+        Assert.Equal(amount, Assert.Single(limits).LimitAmount);
+    }
+
+    [Fact]
+    public async Task Whitespace_only_category_is_rejected_but_other_category_text_is_preserved()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var rejected = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "   ",
+            limitAmount = 100m,
+            monthYear = "2026-08-15"
+        });
+        var preserved = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "  Food  ",
+            limitAmount = 100m,
+            monthYear = "2026-08-15"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, rejected.StatusCode);
+        Assert.Equal("Category is required.", await rejected.Content.ReadAsStringAsync());
+        Assert.Equal(HttpStatusCode.OK, preserved.StatusCode);
+        Assert.Single(await app.FindBudgetLimitsAsync(owner.Id, "  Food  "));
+    }
+
+    [Fact]
+    public async Task Seeded_duplicate_limits_are_both_returned_and_upsert_updates_only_one()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        await app.SeedBudgetLimitAsync(owner.Id, "food", 100m);
+        await app.SeedBudgetLimitAsync(owner.Id, "food", 150m);
+
+        var before = await owner.Client.GetFromJsonAsync<JsonElement>(
+            "/api/budgetlimits?monthYear=2026-08");
+        Assert.Equal(2, before.GetArrayLength());
+
+        var response = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "food",
+            limitAmount = 300m,
+            monthYear = "2026-08-15"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var persisted = await app.FindBudgetLimitsAsync(owner.Id, "food");
+        Assert.Equal(2, persisted.Count);
+        Assert.Single(persisted, limit => limit.LimitAmount == 300m);
+        Assert.Single(persisted, limit => limit.LimitAmount is 100m or 150m);
+    }
+
+    [Fact]
+    public async Task Delete_removes_owned_limit()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var limit = await app.SeedBudgetLimitAsync(owner.Id);
+
+        var response = await owner.Client.DeleteAsync($"/api/budgetlimits/{limit.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Empty(await app.FindBudgetLimitsAsync(owner.Id, limit.Category));
+    }
+
+    [Fact]
+    public async Task Delete_of_another_users_limit_returns_not_found_and_preserves_it()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+        var limit = await app.SeedBudgetLimitAsync(other.Id);
+
+        var response = await owner.Client.DeleteAsync($"/api/budgetlimits/{limit.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Single(await app.FindBudgetLimitsAsync(other.Id, limit.Category));
+    }
+
+    [Fact]
+    public async Task Delete_of_missing_limit_returns_not_found()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.DeleteAsync("/api/budgetlimits/404");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/backend.Tests/Financial/ExpensesApiTests.cs
+++ b/backend.Tests/Financial/ExpensesApiTests.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Models;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+public sealed class ExpensesApiTests
+{
+    [Fact]
+    public async Task Unauthenticated_request_is_rejected()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+
+        var response = await client.GetAsync("/api/expenses");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_returns_only_authenticated_users_expenses_with_current_shape()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+        var owned = await app.SeedExpenseAsync(owner.Id, "owned", 12.34m, category: "Food");
+        await app.SeedExpenseAsync(other.Id, "hidden", 98.76m, category: "Bills");
+
+        var response = await owner.Client.GetAsync("/api/expenses");
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var expense = Assert.Single(body.EnumerateArray());
+        Assert.Equal(owned.Id, expense.GetProperty("id").GetInt32());
+        Assert.Equal("owned", expense.GetProperty("description").GetString());
+        Assert.Equal(12.34m, expense.GetProperty("amount").GetDecimal());
+        Assert.Equal("Food", expense.GetProperty("category").GetString());
+        Assert.Equal(owner.Id, expense.GetProperty("userId").GetString());
+        Assert.Equal(JsonValueKind.Null, expense.GetProperty("user").ValueKind);
+        Assert.True(expense.TryGetProperty("date", out _));
+    }
+
+    [Fact]
+    public async Task Create_assigns_authenticated_owner_and_returns_current_response_shape()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+
+        var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "new expense",
+            amount = 42.25m,
+            date = "2026-08-15T12:30:00",
+            category = "food",
+            userId = other.Id
+        });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("new expense", body.GetProperty("description").GetString());
+        Assert.Equal(42.25m, body.GetProperty("amount").GetDecimal());
+        Assert.Equal("food", body.GetProperty("category").GetString());
+        Assert.Equal(owner.Id, body.GetProperty("userId").GetString());
+        Assert.Equal(JsonValueKind.Null, body.GetProperty("user").ValueKind);
+        Assert.NotNull(response.Headers.Location);
+
+        var persisted = await app.FindExpenseAsync(body.GetProperty("id").GetInt32());
+        Assert.NotNull(persisted);
+        Assert.Equal(owner.Id, persisted.UserId);
+        Assert.Equal(DateTimeKind.Utc, persisted.Date.Kind);
+        Assert.Equal(new DateTime(2026, 8, 15, 12, 30, 0, DateTimeKind.Utc), persisted.Date);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-12.34")]
+    public async Task Create_accepts_current_zero_and_negative_amount_behavior(string amountText)
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var amount = decimal.Parse(amountText, System.Globalization.CultureInfo.InvariantCulture);
+
+        var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "amount edge",
+            amount,
+            date = "2026-08-15",
+            category = "food"
+        });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal(amount, body.GetProperty("amount").GetDecimal());
+        var persisted = await app.FindExpenseAsync(body.GetProperty("id").GetInt32());
+        Assert.NotNull(persisted);
+        Assert.Equal(amount, persisted.Amount);
+    }
+
+    [Fact]
+    public async Task Create_preserves_current_empty_description_and_category_values()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "   ",
+            amount = 1m,
+            date = "2026-08-15",
+            category = "  Food  "
+        });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("   ", body.GetProperty("description").GetString());
+        Assert.Equal("  Food  ", body.GetProperty("category").GetString());
+    }
+
+    [Fact]
+    public async Task Put_rejects_route_and_body_id_mismatch_before_lookup()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.PutAsJsonAsync("/api/expenses/123", new
+        {
+            id = 456,
+            description = "mismatch",
+            amount = 1m,
+            date = "2026-08-15",
+            category = "food"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Expense ID mismatch", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Put_updates_owned_expense_and_preserves_current_values()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var expense = await app.SeedExpenseAsync(owner.Id);
+
+        var response = await owner.Client.PutAsJsonAsync($"/api/expenses/{expense.Id}", new
+        {
+            id = expense.Id,
+            description = "  Updated  ",
+            amount = -4.50m,
+            date = "2026-09-03T09:45:00",
+            category = " FOOD "
+        });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var persisted = await app.FindExpenseAsync(expense.Id);
+        Assert.NotNull(persisted);
+        Assert.Equal("  Updated  ", persisted.Description);
+        Assert.Equal(-4.50m, persisted.Amount);
+        Assert.Equal(" FOOD ", persisted.Category);
+        Assert.Equal(owner.Id, persisted.UserId);
+        Assert.Equal(DateTimeKind.Utc, persisted.Date.Kind);
+        Assert.Equal(new DateTime(2026, 9, 3, 9, 45, 0, DateTimeKind.Utc), persisted.Date);
+    }
+
+    [Fact]
+    public async Task Put_of_another_users_expense_returns_not_found_and_does_not_change_it()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+        var expense = await app.SeedExpenseAsync(other.Id, "protected");
+
+        var response = await owner.Client.PutAsJsonAsync($"/api/expenses/{expense.Id}", new
+        {
+            id = expense.Id,
+            description = "changed",
+            amount = 99m,
+            date = "2026-08-15",
+            category = "other"
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var persisted = await app.FindExpenseAsync(expense.Id);
+        Assert.NotNull(persisted);
+        Assert.Equal("protected", persisted.Description);
+        Assert.Equal(other.Id, persisted.UserId);
+    }
+
+    [Fact]
+    public async Task Put_of_missing_expense_returns_not_found()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.PutAsJsonAsync("/api/expenses/404", new
+        {
+            id = 404,
+            description = "missing",
+            amount = 1m,
+            date = "2026-08-15",
+            category = "food"
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_removes_owned_expense()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var expense = await app.SeedExpenseAsync(owner.Id);
+
+        var response = await owner.Client.DeleteAsync($"/api/expenses/{expense.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Null(await app.FindExpenseAsync(expense.Id));
+    }
+
+    [Fact]
+    public async Task Delete_of_another_users_expense_returns_not_found_and_preserves_it()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
+        var expense = await app.SeedExpenseAsync(other.Id);
+
+        var response = await owner.Client.DeleteAsync($"/api/expenses/{expense.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.NotNull(await app.FindExpenseAsync(expense.Id));
+    }
+
+    [Fact]
+    public async Task Delete_of_missing_expense_returns_not_found()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.DeleteAsync("/api/expenses/404");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/backend.Tests/Financial/FinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/FinancialApiTestApplication.cs
@@ -1,0 +1,205 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using BudgetPlanner.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace BudgetPlanner.Tests.Financial;
+
+internal sealed class FinancialApiTestApplication : WebApplicationFactory<Program>
+{
+    private const string TestPassword = "Password1!";
+    private const string TestJwtKey =
+        "test-only-signing-key-that-is-at-least-thirty-two-bytes-long";
+    private static readonly object HostStartupLock = new();
+    private readonly string _databaseName = $"financial-api-tests-{Guid.NewGuid()}";
+    private bool _hostStarted;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<BudgetContext>>();
+            services.RemoveAll<IDbContextOptionsConfiguration<BudgetContext>>();
+            services.AddDbContext<BudgetContext>(options =>
+                options.UseInMemoryDatabase(_databaseName));
+
+            services.RemoveAll<IEmailService>();
+            services.AddSingleton<IEmailService, NoOpEmailService>();
+        });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(configuration =>
+            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=unused-by-tests",
+                ["Jwt:Key"] = TestJwtKey,
+                ["EmailSettings:FromName"] = "Budget Planner Tests",
+                ["EmailSettings:FromEmail"] = "sender@example.com",
+                ["GoogleEmail:ClientId"] = "test-client-id",
+                ["GoogleEmail:ClientSecret"] = "test-client-secret",
+                ["GoogleEmail:RefreshToken"] = "test-refresh-token",
+                ["Frontend:BaseUrl"] = "https://frontend.test"
+            }));
+
+        return base.CreateHost(builder);
+    }
+
+    public async Task<TestUser> CreateAuthenticatedUserAsync(string email)
+    {
+        EnsureHostStarted();
+        using var scope = Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = new ApplicationUser { UserName = email, Email = email };
+        var createResult = await userManager.CreateAsync(user, TestPassword);
+        EnsureSucceeded(createResult, "create test user");
+
+        var confirmationToken = await userManager.GenerateEmailConfirmationTokenAsync(user);
+        var confirmationResult = await userManager.ConfirmEmailAsync(user, confirmationToken);
+        EnsureSucceeded(confirmationResult, "confirm test user");
+
+        var loginClient = CreateClient();
+        var loginResponse = await loginClient.PostAsJsonAsync(
+            "/api/auth/login",
+            new { email, password = TestPassword });
+        loginResponse.EnsureSuccessStatusCode();
+        var loginBody = await loginResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var token = loginBody.GetProperty("token").GetString()
+            ?? throw new InvalidOperationException("Login response did not contain a token.");
+
+        var authenticatedClient = CreateClient();
+        authenticatedClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+        loginClient.Dispose();
+
+        return new TestUser(user.Id, authenticatedClient);
+    }
+
+    public HttpClient CreateTestClient()
+    {
+        EnsureHostStarted();
+        return CreateClient();
+    }
+
+    public async Task<Expense> SeedExpenseAsync(
+        string userId,
+        string description = "seeded expense",
+        decimal amount = 12.34m,
+        DateTime? date = null,
+        string category = "food")
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var expense = new Expense
+        {
+            UserId = userId,
+            Description = description,
+            Amount = amount,
+            Date = date ?? new DateTime(2026, 8, 12, 0, 0, 0, DateTimeKind.Utc),
+            Category = category
+        };
+        context.Expenses.Add(expense);
+        await context.SaveChangesAsync();
+        return expense;
+    }
+
+    public async Task<BudgetLimit> SeedBudgetLimitAsync(
+        string userId,
+        string category = "food",
+        decimal limitAmount = 100m,
+        DateTime? monthYear = null)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var limit = new BudgetLimit
+        {
+            UserId = userId,
+            Category = category,
+            LimitAmount = limitAmount,
+            MonthYear = monthYear ?? new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+        context.BudgetLimits.Add(limit);
+        await context.SaveChangesAsync();
+        return limit;
+    }
+
+    public async Task<Expense?> FindExpenseAsync(int id)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return await context.Expenses.AsNoTracking().SingleOrDefaultAsync(expense => expense.Id == id);
+    }
+
+    public async Task<IReadOnlyList<BudgetLimit>> FindBudgetLimitsAsync(
+        string userId,
+        string category)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return await context.BudgetLimits
+            .AsNoTracking()
+            .Where(limit => limit.UserId == userId && limit.Category == category)
+            .OrderBy(limit => limit.Id)
+            .ToListAsync();
+    }
+
+    private static void EnsureSucceeded(IdentityResult result, string operation)
+    {
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"Unable to {operation}: {string.Join(", ", result.Errors.Select(error => error.Description))}");
+        }
+    }
+
+    private void EnsureHostStarted()
+    {
+        if (_hostStarted)
+            return;
+
+        lock (HostStartupLock)
+        {
+            if (_hostStarted)
+                return;
+
+            var originalJwtKey = Environment.GetEnvironmentVariable("Jwt__Key");
+            try
+            {
+                Environment.SetEnvironmentVariable("Jwt__Key", TestJwtKey);
+                _ = Services;
+                _hostStarted = true;
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("Jwt__Key", originalJwtKey);
+            }
+        }
+    }
+}
+
+internal sealed record TestUser(string Id, HttpClient Client) : IDisposable
+{
+    public void Dispose() => Client.Dispose();
+}
+
+internal sealed class NoOpEmailService : IEmailService
+{
+    public Task SendEmailAsync(
+        string toEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken = default) => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary

- add backend integration characterization for the existing expense and budget-limit APIs
- prove authenticated ownership and cross-user isolation with two-user scenarios
- preserve current financial edge cases, date/month handling, response shapes, and status codes before A2/A3 work
- add a narrowly scoped financial API test host using the existing WebApplicationFactory, Identity, JWT, and EF Core InMemory patterns

Closes #30

## Risk

- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

Test-only and behavior-preserving.

## Files changed

- `backend.Tests/Financial/FinancialApiTestApplication.cs`
- `backend.Tests/Financial/ExpensesApiTests.cs`
- `backend.Tests/Financial/BudgetLimitsApiTests.cs`

## Behaviors characterized

### Expenses

- unauthenticated rejection and authenticated user-scoped reads
- current response/serialization fields
- authenticated owner overriding a client-supplied `userId`
- route/body ID mismatch, successful update, missing update, and cross-user update behavior
- owned, missing, and cross-user deletes
- accepted zero and negative amounts
- preserved description/category whitespace and case
- current UTC-kind persistence on create and update

### Budget limits

- unauthenticated rejection
- missing `monthYear` validation Problem Details and invalid-value plain-text response
- authenticated user/month scoping and current response shape
- owner override and first-day UTC month normalization
- same-user/exact-category/month upsert
- case- and whitespace-sensitive category equality
- accepted zero and negative limit amounts
- current whitespace-category handling
- owned, missing, and cross-user deletes
- deterministic duplicate behavior: duplicate rows are returned and an upsert updates only one

## Notable existing behaviors / A2-A3 follow-ups

- expense and budget amounts currently accept zero and negative values
- expense description/category values preserve whitespace; budget categories preserve non-empty whitespace/case variants
- budget category equality is exact and therefore case/whitespace sensitive
- a missing `monthYear` is rejected by automatic model validation, while invalid values and several controller errors are plain text
- persistence entities expose `userId` and a null `user` field in current responses
- duplicate budget rows can coexist; reads return both and an upsert changes only one
- UTC behavior is implemented by assigning `DateTimeKind.Utc` to received date fields rather than redesigning date semantics

These findings are recorded only; this PR does not correct or redefine them.

## Verification

- focused Release financial tests: 27 passed
- Release backend build: succeeded with 0 warnings and 0 errors
- complete Release backend suite: 100 passed
- `git diff --check`: passed
- complete staged diff inspected

Frontend verification was not run because no frontend files or behavior changed.

## API impact

None. Existing contracts are characterized, not changed.

## Database / migration impact

None. Tests use isolated EF Core InMemory databases; no schema or migration files changed.

## Dependency impact

None.

## Deployment considerations

None.

## Non-goals

No production controller/model changes, DTOs, validation redesign, category/date normalization, uniqueness or concurrency fix, PostgreSQL CI lane, Problem Details redesign, authentication changes, or import implementation.