### PR TITLE
test: add PostgreSQL-backed integration verification

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,4 +29,59 @@ jobs:
         run: dotnet build backend/backend.csproj --configuration Release --no-restore
 
       - name: Run backend tests
-        run: dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-restore
+        run: >-
+          dotnet test backend.Tests/backend.Tests.csproj
+          --configuration Release
+          --no-restore
+          --filter "Category!=PostgreSQL"
+
+  postgresql-integration:
+    name: PostgreSQL financial integration
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: budget_planner_ci
+          POSTGRES_USER: budget_planner_ci
+          POSTGRES_PASSWORD: budget_planner_ci_only
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U budget_planner_ci -d budget_planner_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      BUDGETPLANNER_POSTGRESQL_TEST_CONNECTION: >-
+        Host=localhost;Port=5432;Database=budget_planner_ci;Username=budget_planner_ci;Password=budget_planner_ci_only;Pooling=false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore backend.Tests/backend.Tests.csproj
+
+      - name: Build PostgreSQL integration tests
+        run: dotnet build backend.Tests/backend.Tests.csproj --configuration Release --no-restore
+
+      - name: Verify migration chain on empty PostgreSQL
+        run: >-
+          dotnet test backend.Tests/backend.Tests.csproj
+          --configuration Release
+          --no-build
+          --filter "Category=PostgreSQL&FullyQualifiedName~Migration_chain"
+
+      - name: Run PostgreSQL financial integration tests
+        run: >-
+          dotnet test backend.Tests/backend.Tests.csproj
+          --configuration Release
+          --no-build
+          --filter "Category=PostgreSQL&FullyQualifiedName!~Migration_chain"

--- a/backend.Tests/Financial/FinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/FinancialApiTestApplication.cs
@@ -16,14 +16,28 @@ using Microsoft.Extensions.Hosting;
 
 namespace BudgetPlanner.Tests.Financial;
 
-internal sealed class FinancialApiTestApplication : WebApplicationFactory<Program>
+internal sealed class FinancialApiTestApplication : FinancialApiTestApplicationBase
 {
-    private const string TestPassword = "Password1!";
-    private const string TestJwtKey =
+    private readonly string _databaseName = $"financial-api-tests-{Guid.NewGuid()}";
+
+    protected override void ConfigureDatabase(IServiceCollection services)
+    {
+        services.AddDbContext<BudgetContext>(options =>
+            options.UseInMemoryDatabase(_databaseName));
+    }
+}
+
+internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<Program>
+{
+    protected const string TestPassword = "Password1!";
+    protected const string TestJwtKey =
         "test-only-signing-key-that-is-at-least-thirty-two-bytes-long";
     private static readonly object HostStartupLock = new();
-    private readonly string _databaseName = $"financial-api-tests-{Guid.NewGuid()}";
     private bool _hostStarted;
+
+    protected abstract void ConfigureDatabase(IServiceCollection services);
+
+    protected virtual void InitializeDatabase(IServiceProvider services) { }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -32,8 +46,7 @@ internal sealed class FinancialApiTestApplication : WebApplicationFactory<Progra
         {
             services.RemoveAll<DbContextOptions<BudgetContext>>();
             services.RemoveAll<IDbContextOptionsConfiguration<BudgetContext>>();
-            services.AddDbContext<BudgetContext>(options =>
-                options.UseInMemoryDatabase(_databaseName));
+            ConfigureDatabase(services);
 
             services.RemoveAll<IEmailService>();
             services.AddSingleton<IEmailService, NoOpEmailService>();
@@ -179,7 +192,7 @@ internal sealed class FinancialApiTestApplication : WebApplicationFactory<Progra
             try
             {
                 Environment.SetEnvironmentVariable("Jwt__Key", TestJwtKey);
-                _ = Services;
+                InitializeDatabase(Services);
                 _hostStarted = true;
             }
             finally

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTestApplication.cs
@@ -1,6 +1,7 @@
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace BudgetPlanner.Tests.Financial;
 
@@ -17,6 +18,42 @@ internal sealed class PostgreSqlFinancialApiTestApplication
         _connectionString = Environment.GetEnvironmentVariable(ConnectionEnvironmentVariable)
             ?? throw new InvalidOperationException(
                 $"Set {ConnectionEnvironmentVariable} to an isolated PostgreSQL test database connection string.");
+
+        ValidateDestructiveDatabaseConnection(_connectionString);
+    }
+
+    internal static void ValidateDestructiveDatabaseConnection(string connectionString)
+    {
+        NpgsqlConnectionStringBuilder connection;
+
+        try
+        {
+            connection = new NpgsqlConnectionStringBuilder(connectionString);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidOperationException(
+                "PostgreSQL integration tests only operate on explicitly designated local disposable databases.",
+                exception);
+        }
+
+        var isLocalHost = string.Equals(
+                connection.Host,
+                "localhost",
+                StringComparison.OrdinalIgnoreCase)
+            || connection.Host == "127.0.0.1"
+            || connection.Host == "::1";
+        var isDisposableDatabase = connection.Database == "budget_planner_ci"
+            || connection.Database?.StartsWith(
+                "budget_planner_test_",
+                StringComparison.Ordinal) == true;
+
+        if (!isLocalHost || !isDisposableDatabase)
+        {
+            throw new InvalidOperationException(
+                "PostgreSQL integration tests only operate on explicitly designated local disposable databases. "
+                + "Use localhost, 127.0.0.1, or ::1 with database budget_planner_ci or a database whose name starts with budget_planner_test_.");
+        }
     }
 
     protected override void ConfigureDatabase(IServiceCollection services)

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTestApplication.cs
@@ -1,0 +1,50 @@
+using BudgetPlanner.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BudgetPlanner.Tests.Financial;
+
+internal sealed class PostgreSqlFinancialApiTestApplication
+    : FinancialApiTestApplicationBase
+{
+    public const string ConnectionEnvironmentVariable =
+        "BUDGETPLANNER_POSTGRESQL_TEST_CONNECTION";
+
+    private readonly string _connectionString;
+
+    public PostgreSqlFinancialApiTestApplication()
+    {
+        _connectionString = Environment.GetEnvironmentVariable(ConnectionEnvironmentVariable)
+            ?? throw new InvalidOperationException(
+                $"Set {ConnectionEnvironmentVariable} to an isolated PostgreSQL test database connection string.");
+    }
+
+    protected override void ConfigureDatabase(IServiceCollection services)
+    {
+        services.AddDbContext<BudgetContext>(options =>
+            options.UseNpgsql(_connectionString));
+    }
+
+    protected override void InitializeDatabase(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+
+        context.Database.EnsureDeleted();
+        context.Database.Migrate();
+    }
+
+    public async Task<IReadOnlyList<string>> GetAppliedMigrationsAsync()
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return (await context.Database.GetAppliedMigrationsAsync()).ToList();
+    }
+
+    public IReadOnlyList<string> GetDefinedMigrations()
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return context.Database.GetMigrations().ToList();
+    }
+}

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+[Trait("Category", "PostgreSQL")]
+public sealed class PostgreSqlFinancialApiTests
+{
+    [PostgreSqlFact]
+    public async Task Migration_chain_applies_to_empty_database_and_supports_identity()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var user = await app.CreateAuthenticatedUserAsync("migration@example.com");
+
+        var definedMigrations = app.GetDefinedMigrations();
+        var appliedMigrations = await app.GetAppliedMigrationsAsync();
+
+        Assert.NotEmpty(definedMigrations);
+        Assert.Equal(definedMigrations, appliedMigrations);
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal("Npgsql.EntityFrameworkCore.PostgreSQL", context.Database.ProviderName);
+        Assert.True(await context.Users.AnyAsync(candidate => candidate.Id == user.Id));
+        Assert.False((await context.Database.GetPendingMigrationsAsync()).Any());
+    }
+
+    [PostgreSqlFact]
+    public async Task Expense_crud_persists_current_values_and_enforces_user_isolation()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("expense-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("expense-other@example.com");
+
+        var createResponse = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "postgres expense",
+            amount = 123.456m,
+            date = "2026-08-15T12:30:00",
+            category = "Food"
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        Assert.Equal(123.456m, created.GetProperty("amount").GetDecimal());
+        var id = created.GetProperty("id").GetInt32();
+
+        var read = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
+        var readExpense = Assert.Single(read.EnumerateArray());
+        Assert.Equal(id, readExpense.GetProperty("id").GetInt32());
+        Assert.Equal(123.46m, readExpense.GetProperty("amount").GetDecimal());
+
+        var forbiddenUpdate = await other.Client.PutAsJsonAsync($"/api/expenses/{id}", new
+        {
+            id,
+            description = "not allowed",
+            amount = 1m,
+            date = "2026-08-16",
+            category = "other"
+        });
+        Assert.Equal(HttpStatusCode.NotFound, forbiddenUpdate.StatusCode);
+
+        var updateResponse = await owner.Client.PutAsJsonAsync($"/api/expenses/{id}", new
+        {
+            id,
+            description = "updated postgres expense",
+            amount = -4.50m,
+            date = "2026-09-03T09:45:00",
+            category = " FOOD "
+        });
+        Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
+
+        var persisted = await app.FindExpenseAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal(-4.50m, persisted.Amount);
+        Assert.Equal(new DateTime(2026, 9, 3, 9, 45, 0, DateTimeKind.Utc), persisted.Date);
+        Assert.Equal(" FOOD ", persisted.Category);
+
+        var deleteResponse = await owner.Client.DeleteAsync($"/api/expenses/{id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+        Assert.Null(await app.FindExpenseAsync(id));
+    }
+
+    [PostgreSqlFact]
+    public async Task Budget_create_read_upsert_and_delete_use_relational_month_query()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("budget-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("budget-other@example.com");
+
+        var createResponse = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "food",
+            limitAmount = 125.505m,
+            monthYear = "2026-08-23T14:30:00"
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+        Assert.Equal(125.505m, created.GetProperty("limitAmount").GetDecimal());
+        var id = created.GetProperty("id").GetInt32();
+
+        await app.SeedBudgetLimitAsync(other.Id, "hidden", 999m);
+        var read = await owner.Client.GetFromJsonAsync<JsonElement>(
+            "/api/budgetlimits?monthYear=2026-08");
+        var readLimit = Assert.Single(read.EnumerateArray());
+        Assert.Equal(id, readLimit.GetProperty("id").GetInt32());
+        Assert.Equal(125.51m, readLimit.GetProperty("limitAmount").GetDecimal());
+
+        var upsertResponse = await owner.Client.PostAsJsonAsync("/api/budgetlimits", new
+        {
+            category = "food",
+            limitAmount = 250m,
+            monthYear = "2026-08-31"
+        });
+        var upserted = await upsertResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, upsertResponse.StatusCode);
+        Assert.Equal(id, upserted.GetProperty("id").GetInt32());
+        var limits = await app.FindBudgetLimitsAsync(owner.Id, "food");
+        var persisted = Assert.Single(limits);
+        Assert.Equal(250m, persisted.LimitAmount);
+        Assert.Equal(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), persisted.MonthYear);
+
+        var deleteResponse = await owner.Client.DeleteAsync($"/api/budgetlimits/{id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+        Assert.Empty(await app.FindBudgetLimitsAsync(owner.Id, "food"));
+        Assert.Single(await app.FindBudgetLimitsAsync(other.Id, "hidden"));
+    }
+}
+
+internal sealed class PostgreSqlFactAttribute : FactAttribute
+{
+    public PostgreSqlFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(
+            PostgreSqlFinancialApiTestApplication.ConnectionEnvironmentVariable)))
+        {
+            Skip = $"Set {PostgreSqlFinancialApiTestApplication.ConnectionEnvironmentVariable} to run PostgreSQL integration tests.";
+        }
+    }
+}

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -146,3 +146,43 @@ internal sealed class PostgreSqlFactAttribute : FactAttribute
         }
     }
 }
+
+public sealed class PostgreSqlDatabaseSafetyTests
+{
+    [Fact]
+    public void Ci_connection_is_accepted()
+    {
+        PostgreSqlFinancialApiTestApplication.ValidateDestructiveDatabaseConnection(
+            "Host=localhost;Database=budget_planner_ci;Username=test;Password=test");
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    public void Local_test_designated_database_is_accepted(string host)
+    {
+        PostgreSqlFinancialApiTestApplication.ValidateDestructiveDatabaseConnection(
+            $"Host={host};Database=budget_planner_test_safety;Username=test;Password=test");
+    }
+
+    [Fact]
+    public void Remote_host_is_rejected()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PostgreSqlFinancialApiTestApplication.ValidateDestructiveDatabaseConnection(
+                "Host=example.neon.tech;Database=budget_planner_test_safety;Username=test;Password=test"));
+
+        Assert.Contains("local disposable databases", exception.Message);
+    }
+
+    [Fact]
+    public void Unsafe_database_name_is_rejected()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PostgreSqlFinancialApiTestApplication.ValidateDestructiveDatabaseConnection(
+                "Host=localhost;Database=budget_planner;Username=test;Password=test"));
+
+        Assert.Contains("local disposable databases", exception.Message);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a dedicated PostgreSQL-backed financial integration host using the existing ASP.NET Core, EF Core, Npgsql, xUnit, and WebApplicationFactory stack.
- Add three high-value PostgreSQL tests for migrations/Identity, expense CRUD and isolation, and budget persistence/upsert/scoping.
- Add a separate backend CI job backed by an ephemeral PostgreSQL 16 service container.
- Keep the fast EF Core InMemory characterization suite.

Closes #34 when reviewed and merged.

## Issue / roadmap

- Issue #34
- ROADMAP B1 — PostgreSQL-backed integration verification

## Risk

LOW. Changes are confined to test code and CI infrastructure. No production runtime, financial semantics, API, schema, migration, deployment, or data behavior changes.

## PostgreSQL architecture

- GitHub Actions starts the official `postgres:16` image as a job-local service.
- The disposable database is `budget_planner_ci` with deterministic test-only credentials.
- Tests receive the connection through `BUDGETPLANNER_POSTGRESQL_TEST_CONNECTION`.
- The test host replaces only the test `BudgetContext` registration with Npgsql.
- Each test factory deletes the disposable database and applies the complete real migration chain with `Database.Migrate()`.
- PostgreSQL tests share the existing non-parallel environment-variable collection and remain explicitly selectable with `Category=PostgreSQL`.
- Email is replaced with the existing no-op test service.

No production, Neon, Render, or hosted database credentials are used.

## Coverage

- Empty database → complete existing migration chain → no pending migrations.
- PostgreSQL Identity user creation, confirmation, JWT login, and authenticated requests.
- Expense create/read/update/delete through HTTP.
- Cross-user expense update isolation.
- Current PostgreSQL `numeric(18,2)` persistence rounding.
- Current UTC timestamp persistence.
- Budget create/read/same-category-month upsert/delete through HTTP.
- Relational year/month query translation and cross-user budget scoping.

## Migration verification

The complete existing migration chain successfully applied from an empty PostgreSQL database. The migration test compared all migrations defined by the application with all applied migrations and verified none remained pending.

## Existing behavior preserved

B1 does not implement approved future A3/A4/A5 semantics. Existing negative expense behavior, timestamp representations, category behavior, entity API shapes, and absence of budget uniqueness remain unchanged.

## Verification

- Focused PostgreSQL migration test in GitHub Actions: 1 passed.
- Focused PostgreSQL financial tests in GitHub Actions: 2 passed.
- Existing local financial tests: 27 passed.
- Complete local backend suite: 100 passed; 3 PostgreSQL tests skipped because no local PostgreSQL daemon was available.
- Release build locally and in CI: passed, 0 warnings / 0 errors.
- Backend CI run 17: passed, including PostgreSQL service startup, migration verification, integration tests, and container teardown.
- Frontend CI run 9: passed and unaffected.
- `git diff --check`: passed.

## Impact

- Runtime: none.
- API: none.
- Schema/migrations: none; existing migrations are only applied to the disposable test database.
- Dependencies: none.
- Frontend: none.
- Deployment: none.
- Production database: none.
