### PR TITLE
feat: harden expense write boundary

### DIFF
--- a/backend.Tests/Financial/ExpensesApiTests.cs
+++ b/backend.Tests/Financial/ExpensesApiTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using BudgetPlanner.Models;
 using Xunit;
 
 namespace BudgetPlanner.Tests.Financial;
@@ -21,12 +20,16 @@ public sealed class ExpensesApiTests
     }
 
     [Fact]
-    public async Task Get_returns_only_authenticated_users_expenses_with_current_shape()
+    public async Task Get_returns_only_authenticated_users_expenses_without_ownership_fields_and_preserves_legacy_values()
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
         using var other = await app.CreateAuthenticatedUserAsync("other@example.com");
-        var owned = await app.SeedExpenseAsync(owner.Id, "owned", 12.34m, category: "Food");
+        var owned = await app.SeedExpenseAsync(
+            owner.Id,
+            description: "  legacy description  ",
+            amount: -12.34m,
+            category: " Legacy  Category ");
         await app.SeedExpenseAsync(other.Id, "hidden", 98.76m, category: "Bills");
 
         var response = await owner.Client.GetAsync("/api/expenses");
@@ -35,16 +38,16 @@ public sealed class ExpensesApiTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var expense = Assert.Single(body.EnumerateArray());
         Assert.Equal(owned.Id, expense.GetProperty("id").GetInt32());
-        Assert.Equal("owned", expense.GetProperty("description").GetString());
-        Assert.Equal(12.34m, expense.GetProperty("amount").GetDecimal());
-        Assert.Equal("Food", expense.GetProperty("category").GetString());
-        Assert.Equal(owner.Id, expense.GetProperty("userId").GetString());
-        Assert.Equal(JsonValueKind.Null, expense.GetProperty("user").ValueKind);
+        Assert.Equal("  legacy description  ", expense.GetProperty("description").GetString());
+        Assert.Equal(-12.34m, expense.GetProperty("amount").GetDecimal());
+        Assert.Equal(" Legacy  Category ", expense.GetProperty("category").GetString());
+        Assert.False(expense.TryGetProperty("userId", out _));
+        Assert.False(expense.TryGetProperty("user", out _));
         Assert.True(expense.TryGetProperty("date", out _));
     }
 
     [Fact]
-    public async Task Create_assigns_authenticated_owner_and_returns_current_response_shape()
+    public async Task Create_assigns_authenticated_owner_normalizes_fields_and_returns_expense_dto()
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
@@ -52,25 +55,27 @@ public sealed class ExpensesApiTests
 
         var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
         {
-            description = "new expense",
+            description = "  Mixed   CASE  ",
             amount = 42.25m,
             date = "2026-08-15T12:30:00",
-            category = "food",
+            category = "  Food   And   Dining  ",
             userId = other.Id
         });
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal("new expense", body.GetProperty("description").GetString());
+        Assert.Equal("Mixed   CASE", body.GetProperty("description").GetString());
         Assert.Equal(42.25m, body.GetProperty("amount").GetDecimal());
-        Assert.Equal("food", body.GetProperty("category").GetString());
-        Assert.Equal(owner.Id, body.GetProperty("userId").GetString());
-        Assert.Equal(JsonValueKind.Null, body.GetProperty("user").ValueKind);
+        Assert.Equal("food and dining", body.GetProperty("category").GetString());
+        Assert.False(body.TryGetProperty("userId", out _));
+        Assert.False(body.TryGetProperty("user", out _));
         Assert.NotNull(response.Headers.Location);
 
         var persisted = await app.FindExpenseAsync(body.GetProperty("id").GetInt32());
         Assert.NotNull(persisted);
         Assert.Equal(owner.Id, persisted.UserId);
+        Assert.Equal("Mixed   CASE", persisted.Description);
+        Assert.Equal("food and dining", persisted.Category);
         Assert.Equal(DateTimeKind.Utc, persisted.Date.Kind);
         Assert.Equal(new DateTime(2026, 8, 15, 12, 30, 0, DateTimeKind.Utc), persisted.Date);
     }
@@ -78,7 +83,7 @@ public sealed class ExpensesApiTests
     [Theory]
     [InlineData("0")]
     [InlineData("-12.34")]
-    public async Task Create_accepts_current_zero_and_negative_amount_behavior(string amountText)
+    public async Task Create_rejects_non_positive_amounts(string amountText)
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
@@ -91,33 +96,149 @@ public sealed class ExpensesApiTests
             date = "2026-08-15",
             category = "food"
         });
-        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal(amount, body.GetProperty("amount").GetDecimal());
-        var persisted = await app.FindExpenseAsync(body.GetProperty("id").GetInt32());
-        Assert.NotNull(persisted);
-        Assert.Equal(amount, persisted.Amount);
+        await AssertValidationErrorAsync(response, "amount");
     }
 
     [Fact]
-    public async Task Create_preserves_current_empty_description_and_category_values()
+    public async Task Create_rejects_more_than_two_decimal_places()
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
 
         var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
         {
+            description = "precision edge",
+            amount = 123.456m,
+            date = "2026-08-15",
+            category = "food"
+        });
+
+        await AssertValidationErrorAsync(response, "amount");
+    }
+
+    [Fact]
+    public async Task Create_enforces_existing_numeric_18_2_range_without_smaller_product_ceiling()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var accepted = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "maximum",
+            amount = 9999999999999999.99m,
+            date = "2026-08-15",
+            category = "food"
+        });
+        var acceptedBody = await accepted.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, accepted.StatusCode);
+        Assert.Equal(9999999999999999.99m, acceptedBody.GetProperty("amount").GetDecimal());
+
+        var rejected = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "overflow",
+            amount = 10000000000000000m,
+            date = "2026-08-15",
+            category = "food"
+        });
+
+        await AssertValidationErrorAsync(rejected, "amount");
+    }
+
+    [Fact]
+    public async Task Create_validates_description_after_outer_trim()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var boundaryDescription = new string('D', 500);
+
+        var accepted = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = $"   {boundaryDescription}   ",
+            amount = 1m,
+            date = "2026-08-15",
+            category = "food"
+        });
+        var acceptedBody = await accepted.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, accepted.StatusCode);
+        Assert.Equal(boundaryDescription, acceptedBody.GetProperty("description").GetString());
+
+        var blank = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
             description = "   ",
             amount = 1m,
             date = "2026-08-15",
-            category = "  Food  "
+            category = "food"
         });
-        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        await AssertValidationErrorAsync(blank, "description");
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal("   ", body.GetProperty("description").GetString());
-        Assert.Equal("  Food  ", body.GetProperty("category").GetString());
+        var tooLong = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = new string('x', 501),
+            amount = 1m,
+            date = "2026-08-15",
+            category = "food"
+        });
+        await AssertValidationErrorAsync(tooLong, "description");
+    }
+
+    [Fact]
+    public async Task Create_validates_category_after_canonicalization()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+        var acceptedCategory = $"  {new string('A', 50)}    {new string('B', 49)}  ";
+        var expectedCategory = $"{new string('a', 50)} {new string('b', 49)}";
+
+        var accepted = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "category boundary",
+            amount = 1m,
+            date = "2026-08-15",
+            category = acceptedCategory
+        });
+        var acceptedBody = await accepted.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, accepted.StatusCode);
+        Assert.Equal(100, expectedCategory.Length);
+        Assert.Equal(expectedCategory, acceptedBody.GetProperty("category").GetString());
+
+        var blank = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "blank category",
+            amount = 1m,
+            date = "2026-08-15",
+            category = "   "
+        });
+        await AssertValidationErrorAsync(blank, "category");
+
+        var tooLong = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "long category",
+            amount = 1m,
+            date = "2026-08-15",
+            category = $"{new string('A', 50)}   {new string('B', 50)}"
+        });
+        await AssertValidationErrorAsync(tooLong, "category");
+    }
+
+    [Fact]
+    public async Task Create_rejects_other_ui_sentinel_as_persisted_category()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "sentinel",
+            amount = 1m,
+            date = "2026-08-15",
+            category = " OTHER "
+        });
+
+        await AssertValidationErrorAsync(response, "category");
     }
 
     [Fact]
@@ -140,7 +261,7 @@ public sealed class ExpensesApiTests
     }
 
     [Fact]
-    public async Task Put_updates_owned_expense_and_preserves_current_values()
+    public async Task Put_updates_owned_expense_with_authoritative_normalization()
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
@@ -149,25 +270,25 @@ public sealed class ExpensesApiTests
         var response = await owner.Client.PutAsJsonAsync($"/api/expenses/{expense.Id}", new
         {
             id = expense.Id,
-            description = "  Updated  ",
-            amount = -4.50m,
+            description = "  Updated   Description  ",
+            amount = 4.50m,
             date = "2026-09-03T09:45:00",
-            category = " FOOD "
+            category = " HOME   Supplies "
         });
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         var persisted = await app.FindExpenseAsync(expense.Id);
         Assert.NotNull(persisted);
-        Assert.Equal("  Updated  ", persisted.Description);
-        Assert.Equal(-4.50m, persisted.Amount);
-        Assert.Equal(" FOOD ", persisted.Category);
+        Assert.Equal("Updated   Description", persisted.Description);
+        Assert.Equal(4.50m, persisted.Amount);
+        Assert.Equal("home supplies", persisted.Category);
         Assert.Equal(owner.Id, persisted.UserId);
         Assert.Equal(DateTimeKind.Utc, persisted.Date.Kind);
         Assert.Equal(new DateTime(2026, 9, 3, 9, 45, 0, DateTimeKind.Utc), persisted.Date);
     }
 
     [Fact]
-    public async Task Put_of_another_users_expense_returns_not_found_and_does_not_change_it()
+    public async Task Put_of_another_users_expense_returns_not_found_before_write_validation()
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
@@ -244,5 +365,17 @@ public sealed class ExpensesApiTests
         var response = await owner.Client.DeleteAsync("/api/expenses/404");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private static async Task AssertValidationErrorAsync(
+        HttpResponseMessage response,
+        string field)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var errors = body.GetProperty("errors");
+        Assert.True(
+            errors.TryGetProperty(field, out _),
+            $"Expected validation errors for '{field}'. Response: {body}");
     }
 }

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -32,7 +32,26 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
-    public async Task Expense_crud_persists_current_values_and_enforces_user_isolation()
+    public async Task Expense_overprecision_is_rejected_before_postgresql_can_round_it()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("expense-precision@example.com");
+
+        var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "postgres precision",
+            amount = 123.456m,
+            date = "2026-08-15T12:30:00",
+            category = "food"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var read = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
+        Assert.Empty(read.EnumerateArray());
+    }
+
+    [PostgreSqlFact]
+    public async Task Expense_crud_persists_valid_values_and_enforces_user_isolation()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("expense-owner@example.com");
@@ -40,21 +59,25 @@ public sealed class PostgreSqlFinancialApiTests
 
         var createResponse = await owner.Client.PostAsJsonAsync("/api/expenses", new
         {
-            description = "postgres expense",
-            amount = 123.456m,
+            description = " postgres expense ",
+            amount = 123.45m,
             date = "2026-08-15T12:30:00",
-            category = "Food"
+            category = " Food "
         });
         var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
-        Assert.Equal(123.456m, created.GetProperty("amount").GetDecimal());
+        Assert.Equal(123.45m, created.GetProperty("amount").GetDecimal());
+        Assert.Equal("postgres expense", created.GetProperty("description").GetString());
+        Assert.Equal("food", created.GetProperty("category").GetString());
+        Assert.False(created.TryGetProperty("userId", out _));
+        Assert.False(created.TryGetProperty("user", out _));
         var id = created.GetProperty("id").GetInt32();
 
         var read = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
         var readExpense = Assert.Single(read.EnumerateArray());
         Assert.Equal(id, readExpense.GetProperty("id").GetInt32());
-        Assert.Equal(123.46m, readExpense.GetProperty("amount").GetDecimal());
+        Assert.Equal(123.45m, readExpense.GetProperty("amount").GetDecimal());
 
         var forbiddenUpdate = await other.Client.PutAsJsonAsync($"/api/expenses/{id}", new
         {
@@ -69,18 +92,19 @@ public sealed class PostgreSqlFinancialApiTests
         var updateResponse = await owner.Client.PutAsJsonAsync($"/api/expenses/{id}", new
         {
             id,
-            description = "updated postgres expense",
-            amount = -4.50m,
+            description = " updated postgres expense ",
+            amount = 4.50m,
             date = "2026-09-03T09:45:00",
-            category = " FOOD "
+            category = " FOOD   MARKET "
         });
         Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
 
         var persisted = await app.FindExpenseAsync(id);
         Assert.NotNull(persisted);
-        Assert.Equal(-4.50m, persisted.Amount);
+        Assert.Equal(4.50m, persisted.Amount);
+        Assert.Equal("updated postgres expense", persisted.Description);
+        Assert.Equal("food market", persisted.Category);
         Assert.Equal(new DateTime(2026, 9, 3, 9, 45, 0, DateTimeKind.Utc), persisted.Date);
-        Assert.Equal(" FOOD ", persisted.Category);
 
         var deleteResponse = await owner.Client.DeleteAsync($"/api/expenses/{id}");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);

--- a/backend/Contracts/Expenses/CreateExpenseRequest.cs
+++ b/backend/Contracts/Expenses/CreateExpenseRequest.cs
@@ -1,0 +1,7 @@
+namespace BudgetPlanner.Contracts.Expenses;
+
+public sealed record CreateExpenseRequest(
+    string? Description,
+    decimal Amount,
+    DateTime Date,
+    string? Category);

--- a/backend/Contracts/Expenses/ExpenseResponse.cs
+++ b/backend/Contracts/Expenses/ExpenseResponse.cs
@@ -1,0 +1,8 @@
+namespace BudgetPlanner.Contracts.Expenses;
+
+public sealed record ExpenseResponse(
+    int Id,
+    string Description,
+    decimal Amount,
+    DateTime Date,
+    string Category);

--- a/backend/Contracts/Expenses/UpdateExpenseRequest.cs
+++ b/backend/Contracts/Expenses/UpdateExpenseRequest.cs
@@ -1,0 +1,8 @@
+namespace BudgetPlanner.Contracts.Expenses;
+
+public sealed record UpdateExpenseRequest(
+    int Id,
+    string? Description,
+    decimal Amount,
+    DateTime Date,
+    string? Category);

--- a/backend/Controllers/ExpensesController.cs
+++ b/backend/Controllers/ExpensesController.cs
@@ -1,9 +1,11 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using BudgetPlanner.Contracts.Expenses;
 using BudgetPlanner.Data;
 using BudgetPlanner.Models;
 using Microsoft.AspNetCore.Authorization;
-using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace BudgetPlanner.Controllers;
 
@@ -12,6 +14,7 @@ namespace BudgetPlanner.Controllers;
 [Authorize]
 public class ExpensesController : ControllerBase
 {
+    private const decimal MaxExpenseAmount = 9999999999999999.99m;
     private readonly BudgetContext _context;
 
     public ExpensesController(BudgetContext context)
@@ -25,7 +28,7 @@ public class ExpensesController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<Expense>>> GetExpenses()
+    public async Task<ActionResult<IEnumerable<ExpenseResponse>>> GetExpenses()
     {
         var userId = GetUserId();
 
@@ -34,13 +37,15 @@ public class ExpensesController : ControllerBase
             return Unauthorized();
         }
 
-        return await _context.Expenses
+        var expenses = await _context.Expenses
             .Where(e => e.UserId == userId)
             .ToListAsync();
+
+        return expenses.Select(ToResponse).ToList();
     }
 
     [HttpPost]
-    public async Task<ActionResult<Expense>> PostExpense(Expense expense)
+    public async Task<ActionResult<ExpenseResponse>> PostExpense(CreateExpenseRequest request)
     {
         var userId = GetUserId();
 
@@ -49,19 +54,36 @@ public class ExpensesController : ControllerBase
             return Unauthorized();
         }
 
-        expense.UserId = userId;
+        if (!TryValidateAndNormalize(
+                request.Description,
+                request.Amount,
+                request.Category,
+                out var description,
+                out var category))
+        {
+            return ValidationProblem(ModelState);
+        }
 
-        // 🔥 FIX: ensure UTC for PostgreSQL
-        expense.Date = DateTime.SpecifyKind(expense.Date, DateTimeKind.Utc);
+        var expense = new Expense
+        {
+            UserId = userId,
+            Description = description,
+            Amount = request.Amount,
+            Date = DateTime.SpecifyKind(request.Date, DateTimeKind.Utc),
+            Category = category
+        };
 
         _context.Expenses.Add(expense);
         await _context.SaveChangesAsync();
 
-        return CreatedAtAction(nameof(GetExpenses), new { id = expense.Id }, expense);
+        return CreatedAtAction(
+            nameof(GetExpenses),
+            new { id = expense.Id },
+            ToResponse(expense));
     }
 
     [HttpPut("{id}")]
-    public async Task<IActionResult> PutExpense(int id, Expense updatedExpense)
+    public async Task<IActionResult> PutExpense(int id, UpdateExpenseRequest request)
     {
         var userId = GetUserId();
 
@@ -70,7 +92,7 @@ public class ExpensesController : ControllerBase
             return Unauthorized();
         }
 
-        if (id != updatedExpense.Id)
+        if (id != request.Id)
         {
             return BadRequest("Expense ID mismatch");
         }
@@ -83,13 +105,20 @@ public class ExpensesController : ControllerBase
             return NotFound();
         }
 
-        existingExpense.Description = updatedExpense.Description;
-        existingExpense.Amount = updatedExpense.Amount;
+        if (!TryValidateAndNormalize(
+                request.Description,
+                request.Amount,
+                request.Category,
+                out var description,
+                out var category))
+        {
+            return ValidationProblem(ModelState);
+        }
 
-        // 🔥 FIX: ensure UTC here too
-        existingExpense.Date = DateTime.SpecifyKind(updatedExpense.Date, DateTimeKind.Utc);
-
-        existingExpense.Category = updatedExpense.Category;
+        existingExpense.Description = description;
+        existingExpense.Amount = request.Amount;
+        existingExpense.Date = DateTime.SpecifyKind(request.Date, DateTimeKind.Utc);
+        existingExpense.Category = category;
 
         await _context.SaveChangesAsync();
 
@@ -118,5 +147,73 @@ public class ExpensesController : ControllerBase
         await _context.SaveChangesAsync();
 
         return NoContent();
+    }
+
+    private bool TryValidateAndNormalize(
+        string? description,
+        decimal amount,
+        string? category,
+        out string normalizedDescription,
+        out string normalizedCategory)
+    {
+        normalizedDescription = (description ?? string.Empty).Trim();
+        normalizedCategory = NormalizeCategory(category);
+
+        if (amount <= 0m)
+        {
+            ModelState.AddModelError("amount", "Amount must be greater than zero.");
+        }
+
+        if (amount > MaxExpenseAmount)
+        {
+            ModelState.AddModelError("amount", "Amount exceeds the supported monetary range.");
+        }
+
+        if (decimal.Round(amount, 2) != amount)
+        {
+            ModelState.AddModelError("amount", "Amount must have at most two decimal places.");
+        }
+
+        if (string.IsNullOrWhiteSpace(normalizedDescription))
+        {
+            ModelState.AddModelError("description", "Description is required.");
+        }
+        else if (normalizedDescription.Length > 500)
+        {
+            ModelState.AddModelError("description", "Description must be 500 characters or fewer.");
+        }
+
+        if (string.IsNullOrWhiteSpace(normalizedCategory))
+        {
+            ModelState.AddModelError("category", "Category is required.");
+        }
+        else if (normalizedCategory.Length > 100)
+        {
+            ModelState.AddModelError("category", "Category must be 100 characters or fewer.");
+        }
+        else if (normalizedCategory == "other")
+        {
+            ModelState.AddModelError(
+                "category",
+                "Category 'other' is reserved for the UI custom-category selector.");
+        }
+
+        return ModelState.IsValid;
+    }
+
+    private static string NormalizeCategory(string? category)
+    {
+        var trimmed = (category ?? string.Empty).Trim();
+        return Regex.Replace(trimmed, @"\s+", " ").ToLowerInvariant();
+    }
+
+    private static ExpenseResponse ToResponse(Expense expense)
+    {
+        return new ExpenseResponse(
+            expense.Id,
+            expense.Description,
+            expense.Amount,
+            expense.Date,
+            expense.Category);
     }
 }


### PR DESCRIPTION
## Summary

- introduces explicit expense create/update request DTOs and an expense response DTO instead of using the EF `Expense` entity as the public API contract;
- derives ownership only from the authenticated identity and removes `userId` / `user` from expense responses;
- enforces the approved expense amount, description, and category write-boundary invariants;
- preserves the existing DateTime/UTC behavior, PUT route/body ID agreement, cross-user `404`, DELETE behavior, and read compatibility for legacy rows;
- replaces PostgreSQL rounding characterization with verification that over-precision is rejected before persistence.

Closes #38

## Risk

- [ ] LOW
- [ ] MEDIUM
- [x] HIGH

This intentionally changes financial write semantics and the expense API request/response contract. The inspection plan and implementation scope were explicitly approved on Issue #38 before implementation.

## Contract changes

### Requests

- POST/PUT accept explicit DTOs rather than EF persistence entities.
- Client-supplied `userId` is not part of the request contract and cannot select ownership.
- Unknown JSON members continue to follow the application's existing normal binding behavior rather than introducing API-wide strict unknown-member rejection.

### Responses

- GET/POST return explicit expense DTOs.
- `userId` and `user` are omitted.
- PUT remains `204 No Content`.

## Financial write-boundary behavior

- amount must be `> 0`;
- amount must have at most two decimal places;
- amount may use the existing `numeric(18,2)` range through `9999999999999999.99` with no smaller product-specific ceiling;
- description is outer-trimmed, required after trimming, max 500, with case/internal text preserved;
- category is trimmed, repeated whitespace is collapsed, lowercased invariantly, required after normalization, max 100;
- normalized literal `other` is rejected because it is the UI custom-category sentinel;
- existing stored rows are not normalized or otherwise mutated by this change.

## Compatibility preserved

- current expense DateTime / `DateTime.SpecifyKind(..., Utc)` behavior;
- PUT route/body ID mismatch response;
- user-scoped lookup and cross-user `404` behavior;
- DELETE behavior;
- valid current frontend workflows, including custom categories that resolve the `other` sentinel to the actual custom value or `uncategorized` before the API call;
- GET can still return legacy rows even if those values would fail the new POST/PUT rules.

## Files changed

- `backend/Contracts/Expenses/CreateExpenseRequest.cs`
- `backend/Contracts/Expenses/UpdateExpenseRequest.cs`
- `backend/Contracts/Expenses/ExpenseResponse.cs`
- `backend/Controllers/ExpensesController.cs`
- `backend.Tests/Financial/ExpensesApiTests.cs`
- `backend.Tests/Financial/PostgreSqlFinancialApiTests.cs`

## Verification

### Passed locally

None claimed. This implementation was published through the connected GitHub workflow rather than a local toolchain workspace.

### Not run locally — capability unavailable

- backend restore/build/tests;
- local disposable PostgreSQL integration tests;
- frontend verification;
- `git diff --check` in a local Git workspace.

The complete intended six-file change set was inspected through the GitHub commit diff before PR creation.

### Required/proven by CI

- Frontend test, lint, and build: **passed**.
- Backend build and tests: **passed**.
- PostgreSQL financial integration and migration-chain verification: **passed**.
- Vercel preview/status: **passed**.

### Remaining verification gaps

None in required CI. Independent review completed with no changes requested. Local `git diff --check` remains unavailable from the connected GitHub execution path and is not claimed as passed.

## API impact

Intentional expense API contract hardening as described above. No unrelated API changes.

## Database / migration impact

None. No schema change, EF migration, constraint, index, or production database operation.

## Dependency impact

None.

## Deployment considerations

None beyond normal CI/preview validation.

## Non-goals

No budget hardening, budget uniqueness/concurrency, DateOnly/date migration, category data cleanup, auth/JWT work, import implementation, income/refund/transfer model, ProblemDetails redesign, production data inspection, or production operation.

## Review notes

Independent review passed. The required CI evidence is green on head `b1b6192e095c8707ae74f580aadb9d70386dca15`.

After human merge is confirmed and the work is complete, clean up the merged remote feature branch according to `AGENTS.md`.