### PR TITLE
test: add sanitized Sunflower import fixtures

### DIFF
--- a/backend.Tests/Import/Fixtures/Sunflower/README.md
+++ b/backend.Tests/Import/Fixtures/Sunflower/README.md
@@ -1,0 +1,38 @@
+# Synthetic Sunflower import fixtures
+
+These fixtures are test-only inputs for the planned Sunflower Bank PDF import path.
+
+## Privacy and provenance
+
+The corpus is entirely synthetic. It must never contain a real customer statement, copied account details, names, addresses, balances, transaction history, merchant history, dates, amounts, or other identifying financial information.
+
+A privately inspected statement informed only generic structural observations for the initial V1 shape: text-extractable PDF pages, `Deposits`, `Electronic Transactions`, transaction continuation across a page boundary, debit/credit source formatting, and unrelated balance/disclosure pages. The private statement is not a golden file and must not be committed, attached to GitHub, stored as a CI artifact, or copied into logs/comments.
+
+Future real statements may be inspected privately to discover layout variants, but any resulting regression case must be reconstructed with invented data before it enters this directory.
+
+## Fixture layers
+
+`SunflowerFixtureCorpus` defines the human-readable representative statement shape and scenario metadata. `SyntheticPdfBuilder` turns those definitions into deterministic, text-extractable PDF bytes in memory without adding a production PDF dependency. Rebuilding the same corpus should produce identical bytes so later idempotency tests can reuse it as an exact-document duplicate.
+
+`SunflowerAdversarialFixtures` provides small malformed/unsupported inputs plus parameterized page-count, candidate-row-count, and text-volume generators. Limit tests should generate large-enough inputs at test time rather than checking oversized binary fixtures into the repository.
+
+## Expected financial semantics
+
+Fixture metadata follows the approved current single-checking-account model:
+
+- every supported valid debit is an `expense_candidate`;
+- known deposits/credits are `non_expense`;
+- `needs_review` is reserved for source-parsing uncertainty, not for deciding whether a valid debit is economically "true spending".
+
+These files do not implement or prove parser behavior. Parser extraction/classification assertions belong in the later parser implementation issue.
+
+## Intentionally deferred F1 cases
+
+The following threat-model cases remain required, but are intentionally deferred until the production parser library and its exact PDF capabilities are selected:
+
+- encrypted/password-protected PDFs;
+- standards-valid image-only/scanned PDFs;
+- PDFs containing embedded actions, links, attachments, or other active-content structures used to prove they remain inert;
+- timeout/cancellation behavior tied to the actual parser execution path.
+
+Deferral here does not weaken `docs/import-threat-model.md`; it avoids prematurely choosing or depending on a parser library solely to manufacture fixtures.

--- a/backend.Tests/Import/Fixtures/Sunflower/SunflowerAdversarialFixtures.cs
+++ b/backend.Tests/Import/Fixtures/Sunflower/SunflowerAdversarialFixtures.cs
@@ -1,0 +1,106 @@
+using System.Text;
+
+namespace BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+
+public static class SunflowerAdversarialFixtures
+{
+    private const int CandidateRowsPerPage = 50;
+
+    public static byte[] CreateInvalidSignatureInput() =>
+        Encoding.ASCII.GetBytes("THIS IS NOT A PDF\n");
+
+    public static byte[] CreateTruncatedPdf()
+    {
+        var valid = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var truncatedLength = Math.Max(8, valid.Length - 64);
+        return valid[..truncatedLength];
+    }
+
+    public static byte[] CreateUnsupportedBankPdf() =>
+        SyntheticPdfBuilder.Build(
+            new IReadOnlyList<string>[]
+            {
+                new List<string>
+                {
+                    "PRAIRIE COMMUNITY BANK",
+                    "ACCOUNT NUMBER 000000000777",
+                    "STATEMENT DATE 02/28/2026",
+                    "Electronic Transactions",
+                    "02/14 SAMPLE PURCHASE 19.25-"
+                }
+            });
+
+    public static byte[] CreatePageCountPdf(int pageCount)
+    {
+        if (pageCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageCount));
+        }
+
+        var pages = new List<IReadOnlyList<string>>(pageCount);
+
+        for (var page = 1; page <= pageCount; page++)
+        {
+            pages.Add(
+                new List<string>
+                {
+                    "SUNFLOWER BANK",
+                    $"SYNTHETIC PAGE {page:D3}"
+                });
+        }
+
+        return SyntheticPdfBuilder.Build(pages);
+    }
+
+    public static byte[] CreateCandidateRowPdf(int rowCount)
+    {
+        if (rowCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rowCount));
+        }
+
+        var pageCount = (int)Math.Ceiling(rowCount / (double)CandidateRowsPerPage);
+        var pages = new List<IReadOnlyList<string>>(pageCount);
+        var nextRow = 1;
+
+        for (var page = 0; page < pageCount; page++)
+        {
+            var lines = new List<string>
+            {
+                "SUNFLOWER BANK",
+                page == 0 ? "Electronic Transactions" : "Electronic Transactions (continued)"
+            };
+
+            for (var pageRow = 0; pageRow < CandidateRowsPerPage && nextRow <= rowCount; pageRow++)
+            {
+                var day = ((nextRow - 1) % 28) + 1;
+                var amount = 10m + ((nextRow - 1) % 90) + 0.25m;
+                lines.Add(FormattableString.Invariant($"02/{day:D2} SYNTHETIC ROW {nextRow:D4} {amount:0.00}-"));
+                nextRow++;
+            }
+
+            pages.Add(lines);
+        }
+
+        return SyntheticPdfBuilder.Build(pages);
+    }
+
+    public static byte[] CreateTextVolumePdf(int payloadCharacterCount)
+    {
+        if (payloadCharacterCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(payloadCharacterCount));
+        }
+
+        return SyntheticPdfBuilder.Build(
+            new IReadOnlyList<string>[]
+            {
+                new List<string>
+                {
+                    "SUNFLOWER BANK",
+                    "SYNTHETIC TEXT VOLUME PAYLOAD",
+                    new string('X', payloadCharacterCount)
+                }
+            });
+    }
+}

--- a/backend.Tests/Import/Fixtures/Sunflower/SunflowerFixtureCorpus.cs
+++ b/backend.Tests/Import/Fixtures/Sunflower/SunflowerFixtureCorpus.cs
@@ -1,0 +1,104 @@
+namespace BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+
+public enum SyntheticDirection
+{
+    Credit,
+    Debit,
+    Unknown
+}
+
+public sealed record SyntheticTransactionScenario(
+    string Id,
+    string SourceLine,
+    SyntheticDirection Direction,
+    string ExpectedClassification,
+    string Section);
+
+public sealed record SyntheticStatementPage(
+    string Name,
+    bool ContainsTransactions,
+    IReadOnlyList<string> Lines);
+
+public static class SunflowerFixtureCorpus
+{
+    public static IReadOnlyList<SyntheticTransactionScenario> Scenarios { get; } =
+        new List<SyntheticTransactionScenario>
+        {
+            new("deposit-credit", "02/03 DEMO PAYROLL CREDIT 2450.00", SyntheticDirection.Credit, "non_expense", "Deposits"),
+            new("merchant-debit", "02/05 NORTH STAR MARKET 42.16-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("subscription-debit", "02/04 STREAMCO SUBSCRIPTION 7.99-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("rent-debit", "02/06 HOME RENT PAYMENT 1125.00-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("bank-fee-debit", "02/07 ACCOUNT MAINTENANCE FEE 5.00-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("card-payment-debit", "02/08 CARDCO PAYMENT 225.00-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("p2p-debit", "02/09 P2P DEMO PAYMENT 35.00-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("transfer-debit", "02/10 TRANSFER TO SAVINGS 100.00-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("brokerage-debit", "02/11 BROKERAGE FUNDING 75.00-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("repeated-outflow", "02/12 REPEATED CAFE 8.50-", SyntheticDirection.Debit, "expense_candidate", "Electronic Transactions"),
+            new("ambiguous-source-row", "02/13 SOURCE DIRECTION UNKNOWN 12.34", SyntheticDirection.Unknown, "needs_review", "Electronic Transactions")
+        };
+
+    public static IReadOnlyList<SyntheticStatementPage> RepresentativePages { get; } =
+        new List<SyntheticStatementPage>
+        {
+            new(
+                "summary-and-first-transactions",
+                true,
+                new List<string>
+                {
+                    "SUNFLOWER BANK",
+                    "FIRST NATIONAL 1870",
+                    "ACCOUNT NUMBER 000000000001",
+                    "STATEMENT DATE 02/28/2026",
+                    "Deposits",
+                    "02/03 DEMO PAYROLL CREDIT 2450.00",
+                    "02/03 DEMO REIMBURSEMENT CREDIT 18.25",
+                    "Electronic Transactions",
+                    "02/04 STREAMCO SUBSCRIPTION 7.99-",
+                    "02/05 NORTH STAR MARKET 42.16-",
+                    "02/06 HOME RENT PAYMENT 1125.00-",
+                    "02/07 ACCOUNT MAINTENANCE FEE 5.00-",
+                    "02/08 CARDCO PAYMENT 225.00-",
+                    "02/09 P2P DEMO PAYMENT 35.00-",
+                    "02/10 TRANSFER TO SAVINGS 100.00-"
+                }),
+            new(
+                "continued-transactions",
+                true,
+                new List<string>
+                {
+                    "SUNFLOWER BANK",
+                    "Electronic Transactions (continued)",
+                    "02/11 BROKERAGE FUNDING 75.00-",
+                    "02/12 REPEATED CAFE 8.50-",
+                    "02/12 REPEATED CAFE 8.50-",
+                    "02/13 SOURCE DIRECTION UNKNOWN 12.34",
+                    "Checks Paid",
+                    "NONE"
+                }),
+            new(
+                "daily-balances",
+                false,
+                new List<string>
+                {
+                    "SUNFLOWER BANK",
+                    "Daily Balances",
+                    "02/03 3100.00",
+                    "02/10 1520.35",
+                    "02/17 1430.10",
+                    "02/28 1398.27"
+                }),
+            new(
+                "disclosures",
+                false,
+                new List<string>
+                {
+                    "SUNFLOWER BANK",
+                    "Important Account Information",
+                    "This page contains synthetic disclosure text for parser fixtures only.",
+                    "No transaction rows appear on this page."
+                })
+        };
+
+    public static byte[] CreateRepresentativePdf() =>
+        SyntheticPdfBuilder.Build(RepresentativePages.Select(page => page.Lines).ToArray());
+}

--- a/backend.Tests/Import/Fixtures/Sunflower/SyntheticPdfBuilder.cs
+++ b/backend.Tests/Import/Fixtures/Sunflower/SyntheticPdfBuilder.cs
@@ -1,0 +1,117 @@
+using System.Text;
+
+namespace BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+
+internal static class SyntheticPdfBuilder
+{
+    public static byte[] Build(IReadOnlyList<IReadOnlyList<string>> pages)
+    {
+        ArgumentNullException.ThrowIfNull(pages);
+
+        if (pages.Count == 0)
+        {
+            throw new ArgumentException("At least one page is required.", nameof(pages));
+        }
+
+        var objects = new SortedDictionary<int, string>();
+        var pageObjectNumbers = new List<int>(pages.Count);
+
+        const int catalogObject = 1;
+        const int pagesObject = 2;
+        const int fontObject = 3;
+
+        for (var index = 0; index < pages.Count; index++)
+        {
+            pageObjectNumbers.Add(4 + (index * 2));
+        }
+
+        objects[catalogObject] = "<< /Type /Catalog /Pages 2 0 R >>";
+        objects[pagesObject] =
+            $"<< /Type /Pages /Kids [{string.Join(" ", pageObjectNumbers.Select(number => $"{number} 0 R"))}] /Count {pages.Count} >>";
+        objects[fontObject] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+        for (var index = 0; index < pages.Count; index++)
+        {
+            var pageObject = pageObjectNumbers[index];
+            var contentObject = pageObject + 1;
+            var content = BuildContentStream(pages[index]);
+            var contentLength = Encoding.ASCII.GetByteCount(content);
+
+            objects[pageObject] =
+                $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents {contentObject} 0 R >>";
+            objects[contentObject] = $"<< /Length {contentLength} >>\nstream\n{content}endstream";
+        }
+
+        var maxObjectNumber = objects.Keys.Max();
+        var offsets = new int[maxObjectNumber + 1];
+        var output = new StringBuilder();
+        var byteOffset = 0;
+
+        void Append(string value)
+        {
+            output.Append(value);
+            byteOffset += Encoding.ASCII.GetByteCount(value);
+        }
+
+        Append("%PDF-1.4\n% Budget Planner synthetic test fixture\n");
+
+        foreach (var entry in objects)
+        {
+            offsets[entry.Key] = byteOffset;
+            Append($"{entry.Key} 0 obj\n{entry.Value}\nendobj\n");
+        }
+
+        var xrefOffset = byteOffset;
+        Append($"xref\n0 {maxObjectNumber + 1}\n");
+        Append("0000000000 65535 f \n");
+
+        for (var objectNumber = 1; objectNumber <= maxObjectNumber; objectNumber++)
+        {
+            Append($"{offsets[objectNumber]:D10} 00000 n \n");
+        }
+
+        Append($"trailer\n<< /Size {maxObjectNumber + 1} /Root 1 0 R >>\n");
+        Append($"startxref\n{xrefOffset}\n%%EOF\n");
+
+        return Encoding.ASCII.GetBytes(output.ToString());
+    }
+
+    private static string BuildContentStream(IReadOnlyList<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+
+        var content = new StringBuilder();
+        content.Append("BT\n/F1 10 Tf\n50 760 Td\n");
+
+        for (var index = 0; index < lines.Count; index++)
+        {
+            var line = lines[index];
+            EnsureAscii(line);
+
+            if (index > 0)
+            {
+                content.Append("0 -14 Td\n");
+            }
+
+            content.Append('(')
+                .Append(EscapePdfLiteral(line))
+                .Append(") Tj\n");
+        }
+
+        content.Append("ET\n");
+        return content.ToString();
+    }
+
+    private static string EscapePdfLiteral(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("(", "\\(", StringComparison.Ordinal)
+            .Replace(")", "\\)", StringComparison.Ordinal);
+
+    private static void EnsureAscii(string value)
+    {
+        if (value.Any(character => character > 127))
+        {
+            throw new ArgumentException("Synthetic PDF fixture text must remain ASCII for deterministic byte offsets.", nameof(value));
+        }
+    }
+}

--- a/backend.Tests/Import/SunflowerFixtureCorpusTests.cs
+++ b/backend.Tests/Import/SunflowerFixtureCorpusTests.cs
@@ -1,0 +1,129 @@
+using System.Text;
+using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Import;
+
+public sealed class SunflowerFixtureCorpusTests
+{
+    [Fact]
+    public void Representative_fixture_is_deterministic_and_pdf_shaped()
+    {
+        var first = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var second = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var text = Encoding.ASCII.GetString(first);
+
+        Assert.Equal(first, second);
+        Assert.True(text.StartsWith("%PDF-1.4", StringComparison.Ordinal));
+        Assert.True(text.EndsWith("%%EOF\n", StringComparison.Ordinal));
+        Assert.Equal(4, CountOccurrences(text, "/Type /Page "));
+    }
+
+    [Fact]
+    public void Representative_corpus_covers_required_synthetic_scenarios()
+    {
+        var scenarioIds = SunflowerFixtureCorpus.Scenarios
+            .Select(scenario => scenario.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var requiredScenarioIds = new[]
+        {
+            "deposit-credit",
+            "merchant-debit",
+            "subscription-debit",
+            "rent-debit",
+            "bank-fee-debit",
+            "card-payment-debit",
+            "p2p-debit",
+            "transfer-debit",
+            "brokerage-debit",
+            "repeated-outflow",
+            "ambiguous-source-row"
+        };
+
+        foreach (var requiredScenarioId in requiredScenarioIds)
+        {
+            Assert.Contains(requiredScenarioId, scenarioIds);
+        }
+
+        Assert.True(SunflowerFixtureCorpus.RepresentativePages[0].Lines.Contains("Deposits"));
+        Assert.True(SunflowerFixtureCorpus.RepresentativePages[0].Lines.Contains("Electronic Transactions"));
+        Assert.True(SunflowerFixtureCorpus.RepresentativePages[1].Lines.Contains("Electronic Transactions (continued)"));
+        Assert.False(SunflowerFixtureCorpus.RepresentativePages[2].ContainsTransactions);
+        Assert.False(SunflowerFixtureCorpus.RepresentativePages[3].ContainsTransactions);
+
+        var repeatedOutflows = SunflowerFixtureCorpus.RepresentativePages
+            .SelectMany(page => page.Lines)
+            .Count(line => line == "02/12 REPEATED CAFE 8.50-");
+
+        Assert.Equal(2, repeatedOutflows);
+    }
+
+    [Fact]
+    public void Scenario_metadata_matches_approved_checking_outflow_semantics()
+    {
+        var debitScenarios = SunflowerFixtureCorpus.Scenarios
+            .Where(scenario => scenario.Direction == SyntheticDirection.Debit)
+            .ToList();
+
+        Assert.NotEmpty(debitScenarios);
+        Assert.All(debitScenarios, scenario => Assert.Equal("expense_candidate", scenario.ExpectedClassification));
+        Assert.Equal(
+            "non_expense",
+            Assert.Single(SunflowerFixtureCorpus.Scenarios.Where(scenario => scenario.Direction == SyntheticDirection.Credit))
+                .ExpectedClassification);
+        Assert.Equal(
+            "needs_review",
+            Assert.Single(SunflowerFixtureCorpus.Scenarios.Where(scenario => scenario.Direction == SyntheticDirection.Unknown))
+                .ExpectedClassification);
+    }
+
+    [Fact]
+    public void Adversarial_helpers_cover_invalid_truncated_and_unsupported_shapes()
+    {
+        var invalid = Encoding.ASCII.GetString(SunflowerAdversarialFixtures.CreateInvalidSignatureInput());
+        var truncated = Encoding.ASCII.GetString(SunflowerAdversarialFixtures.CreateTruncatedPdf());
+        var unsupported = Encoding.ASCII.GetString(SunflowerAdversarialFixtures.CreateUnsupportedBankPdf());
+
+        Assert.False(invalid.StartsWith("%PDF-", StringComparison.Ordinal));
+        Assert.True(truncated.StartsWith("%PDF-", StringComparison.Ordinal));
+        Assert.False(truncated.EndsWith("%%EOF\n", StringComparison.Ordinal));
+        Assert.Contains("PRAIRIE COMMUNITY BANK", unsupported, StringComparison.Ordinal);
+        Assert.DoesNotContain("SUNFLOWER BANK", unsupported, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Limit_generators_create_requested_page_row_and_text_shapes()
+    {
+        var pageLimitText = Encoding.ASCII.GetString(SunflowerAdversarialFixtures.CreatePageCountPdf(26));
+        var rowLimitText = Encoding.ASCII.GetString(SunflowerAdversarialFixtures.CreateCandidateRowPdf(1001));
+        var textLimitText = Encoding.ASCII.GetString(SunflowerAdversarialFixtures.CreateTextVolumePdf(2_000_001));
+
+        Assert.Equal(26, CountOccurrences(pageLimitText, "/Type /Page "));
+        Assert.Equal(1001, CountOccurrences(rowLimitText, "SYNTHETIC ROW "));
+        Assert.True(textLimitText.Count(character => character == 'X') >= 2_000_001);
+    }
+
+    [Fact]
+    public void Exact_duplicate_fixture_bytes_are_stable()
+    {
+        var original = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var duplicate = SunflowerFixtureCorpus.CreateRepresentativePdf();
+
+        Assert.Equal(original, duplicate);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

- adds a fully synthetic Sunflower statement corpus under `backend.Tests/Import/Fixtures/Sunflower/`;
- adds a tiny deterministic test-only PDF writer so fixtures are generated in memory without selecting or adding the production PDF parser library;
- covers representative deposit/credit and checking-account debit scenarios, transaction continuation across a page boundary, repeated identical outflows, parser-ambiguous source rows, and non-transaction pages;
- adds generated adversarial helpers for invalid signature, truncated PDF, unsupported bank, page-count, candidate-row-count, and extracted-text-volume shapes;
- documents strict synthetic-only/privacy rules and the F1 cases intentionally deferred until parser implementation.

Closes #53

## Risk

- [ ] LOW
- [x] MEDIUM
- [ ] HIGH

The repository owner explicitly approved the inspected implementation plan in Issue #53 before editing.

## Scope

Changed paths are limited to:

- `backend.Tests/Import/Fixtures/Sunflower/**`
- `backend.Tests/Import/SunflowerFixtureCorpusTests.cs`

No files under `backend/`, `frontend/`, migrations, production configuration, or `backend.Tests/backend.Tests.csproj` changed.

## Privacy

- no real statement file is committed;
- no copied names, addresses, account details, balances, transaction history, dates, amounts, or merchant history from the private reference statement are included;
- all fixture data is invented;
- the private statement is not a golden file, CI artifact, log input, or repository asset.

## Important implementation details

- the synthetic PDF writer emits deterministic, text-extractable PDF bytes using only BCL APIs;
- exact-byte duplicate behavior can therefore be exercised later without checked-in binary fixtures;
- the page/row/text limit helpers generate large-enough inputs at test runtime instead of bloating the repository;
- encrypted/password-protected, standards-valid image-only, active-content, and real parser timeout/cancellation cases remain required by F1 but are deferred until the production parser library is selected so F3 does not prematurely choose parser technology.

## Verification

### Passed through repository inspection

- branch starts from exact `main` `9b06f7654a8270dd5f860d39bcdecd74de2ce120`;
- branch is ahead by 7 commits and behind by 0; two no-op scope-cleanup commits created and then removed an accidental empty connector-generated file, so the net diff remains unchanged;
- exactly five approved test/fixture files are added in the final diff;
- `backend.Tests.csproj` remains unchanged;
- no production/runtime files changed.

### Not run locally — capability unavailable

- .NET SDK is unavailable in the execution environment used for this connected-GitHub implementation, so focused and full backend tests could not be run locally;
- no local `git diff --check` is claimed from this connector-based write path.

### Required/proven by CI

- **Backend CI** on final head `f2eab1f2c4a2e5efd6bde85ab8b966f479bf7cf5`: success;
- **Frontend CI** on final head `f2eab1f2c4a2e5efd6bde85ab8b966f479bf7cf5`: success;
- **Vercel** on final head: success.

## Non-goals

- production PDF parser selection or dependency changes;
- upload endpoint or UI;
- database/import schema or migration;
- A5 date-only persistence work;
- recurring expenses (#51);
- income/cash-flow support;
- another bank/QFX/CSV format;
- production deployment or migration;
- automatic merge.

Human merge authority remains unchanged.