### PR TITLE
fix: make Codex output schema strict-compatible

### DIFF
--- a/.github/codex/schemas/plan-output.json
+++ b/.github/codex/schemas/plan-output.json
@@ -45,10 +45,10 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["path", "reason"],
+        "required": ["path", "symbol", "reason"],
         "properties": {
           "path": { "type": "string" },
-          "symbol": { "type": "string" },
+          "symbol": { "type": ["string", "null"] },
           "reason": { "type": "string" }
         }
       }


### PR DESCRIPTION
## Summary

Fixes the first Issue #55 Codex bridge smoke failure. OpenAI rejected the read-only output schema because `context_expansion_requests[].symbol` was declared in `properties` but omitted from that object's `required` array.

This changes the schema so every declared property is required for Structured Outputs while preserving the intended optional semantic by allowing `symbol` to be `null`.

## Root cause

The first `/codex audit` smoke run successfully completed `prepare` and `prepare_context`, then failed in `codex_readonly` with `invalid_json_schema`: the Structured Outputs schema required every property key to appear in `required`, and `symbol` was missing.

## Change

- `.github/codex/schemas/plan-output.json`
  - add `symbol` to `required` for context-expansion request objects;
  - change `symbol` type from `string` to `["string", "null"]` so callers can express no specific symbol without omitting the field.

## Risk

LOW. This is a narrow bridge-schema correction only. No application/runtime/financial/API/database/deployment behavior changes.

## Verification

- Root cause matches the exact OpenAI API validation error from the live smoke run.
- JSON remains valid Draft 2020-12 syntax.
- The next required proof is to merge this correction and rerun the same Issue #55 `/codex audit` against updated `main`.

## Scope

No workflow authority, credentials, application code, migrations, production configuration, or human merge authority changes.

Refs #55