### PR TITLE
Implement expense date-only semantics for import persistence

### DIFF
--- a/backend.Tests/Financial/ExpensesApiTests.cs
+++ b/backend.Tests/Financial/ExpensesApiTests.cs
@@ -57,7 +57,7 @@ public sealed class ExpensesApiTests
         {
             description = "  Mixed   CASE  ",
             amount = 42.25m,
-            date = "2026-08-15T12:30:00",
+            date = "2026-08-15",
             category = "  Food   And   Dining  ",
             userId = other.Id
         });
@@ -76,8 +76,25 @@ public sealed class ExpensesApiTests
         Assert.Equal(owner.Id, persisted.UserId);
         Assert.Equal("Mixed   CASE", persisted.Description);
         Assert.Equal("food and dining", persisted.Category);
-        Assert.Equal(DateTimeKind.Utc, persisted.Date.Kind);
-        Assert.Equal(new DateTime(2026, 8, 15, 12, 30, 0, DateTimeKind.Utc), persisted.Date);
+        Assert.Equal(new DateOnly(2026, 8, 15), persisted.Date);
+        Assert.Equal("2026-08-15", body.GetProperty("date").GetString());
+    }
+
+    [Fact]
+    public async Task Create_rejects_timestamp_shaped_expense_date()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("owner@example.com");
+
+        var response = await owner.Client.PostAsJsonAsync("/api/expenses", new
+        {
+            description = "timestamp date",
+            amount = 1m,
+            date = "2026-08-15T00:00:00Z",
+            category = "food"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Theory]
@@ -272,7 +289,7 @@ public sealed class ExpensesApiTests
             id = expense.Id,
             description = "  Updated   Description  ",
             amount = 4.50m,
-            date = "2026-09-03T09:45:00",
+            date = "2026-09-03",
             category = " HOME   Supplies "
         });
 
@@ -283,8 +300,7 @@ public sealed class ExpensesApiTests
         Assert.Equal(4.50m, persisted.Amount);
         Assert.Equal("home supplies", persisted.Category);
         Assert.Equal(owner.Id, persisted.UserId);
-        Assert.Equal(DateTimeKind.Utc, persisted.Date.Kind);
-        Assert.Equal(new DateTime(2026, 9, 3, 9, 45, 0, DateTimeKind.Utc), persisted.Date);
+        Assert.Equal(new DateOnly(2026, 9, 3), persisted.Date);
     }
 
     [Fact]

--- a/backend.Tests/Financial/FinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/FinancialApiTestApplication.cs
@@ -111,7 +111,7 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
         string userId,
         string description = "seeded expense",
         decimal amount = 12.34m,
-        DateTime? date = null,
+        DateOnly? date = null,
         string category = "food")
     {
         using var scope = Services.CreateScope();
@@ -121,7 +121,7 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
             UserId = userId,
             Description = description,
             Amount = amount,
-            Date = date ?? new DateTime(2026, 8, 12, 0, 0, 0, DateTimeKind.Utc),
+            Date = date ?? new DateOnly(2026, 8, 12),
             Category = category
         };
         context.Expenses.Add(expense);

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -49,6 +49,7 @@ public sealed class PostgreSqlFinancialApiTests
     public async Task Expense_date_migration_preserves_the_utc_calendar_component()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var client = app.CreateTestClient();
         using var scope = app.Services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
         var migrator = context.GetService<IMigrator>();

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -29,6 +31,47 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Equal("Npgsql.EntityFrameworkCore.PostgreSQL", context.Database.ProviderName);
         Assert.True(await context.Users.AnyAsync(candidate => candidate.Id == user.Id));
         Assert.False((await context.Database.GetPendingMigrationsAsync()).Any());
+
+        await context.Database.OpenConnectionAsync();
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        command.CommandText =
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'Expenses'
+              AND column_name = 'Date';
+            """;
+        Assert.Equal("date", await command.ExecuteScalarAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Expense_date_migration_preserves_the_utc_calendar_component()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var migrator = context.GetService<IMigrator>();
+
+        await context.Database.EnsureDeletedAsync();
+        await migrator.MigrateAsync("20260812213613_PersistDataProtectionKeys");
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO "AspNetUsers"
+                ("Id", "EmailConfirmed", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled", "AccessFailedCount")
+            VALUES
+                ('date-migration-user', false, false, false, false, 0);
+
+            INSERT INTO "Expenses" ("Description", "Amount", "Date", "Category", "UserId")
+            VALUES ('month edge', 12.34, TIMESTAMPTZ '2026-08-31 00:00:00+00', 'food', 'date-migration-user');
+            """);
+
+        await migrator.MigrateAsync();
+
+        var migratedDate = await context.Database
+            .SqlQuery<DateOnly>($"SELECT \"Date\" AS \"Value\" FROM \"Expenses\"")
+            .SingleAsync();
+        Assert.Equal(new DateOnly(2026, 8, 31), migratedDate);
     }
 
     [PostgreSqlFact]
@@ -41,7 +84,7 @@ public sealed class PostgreSqlFinancialApiTests
         {
             description = "postgres precision",
             amount = 123.456m,
-            date = "2026-08-15T12:30:00",
+            date = "2026-08-15",
             category = "food"
         });
 
@@ -61,7 +104,7 @@ public sealed class PostgreSqlFinancialApiTests
         {
             description = " postgres expense ",
             amount = 123.45m,
-            date = "2026-08-15T12:30:00",
+            date = "2026-08-15",
             category = " Food "
         });
         var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -94,7 +137,7 @@ public sealed class PostgreSqlFinancialApiTests
             id,
             description = " updated postgres expense ",
             amount = 4.50m,
-            date = "2026-09-03T09:45:00",
+            date = "2026-09-03",
             category = " FOOD   MARKET "
         });
         Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
@@ -104,7 +147,7 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Equal(4.50m, persisted.Amount);
         Assert.Equal("updated postgres expense", persisted.Description);
         Assert.Equal("food market", persisted.Category);
-        Assert.Equal(new DateTime(2026, 9, 3, 9, 45, 0, DateTimeKind.Utc), persisted.Date);
+        Assert.Equal(new DateOnly(2026, 9, 3), persisted.Date);
 
         var deleteResponse = await owner.Client.DeleteAsync($"/api/expenses/{id}");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);

--- a/backend/Contracts/Expenses/CreateExpenseRequest.cs
+++ b/backend/Contracts/Expenses/CreateExpenseRequest.cs
@@ -3,5 +3,5 @@ namespace BudgetPlanner.Contracts.Expenses;
 public sealed record CreateExpenseRequest(
     string? Description,
     decimal Amount,
-    DateTime Date,
+    DateOnly Date,
     string? Category);

--- a/backend/Contracts/Expenses/ExpenseResponse.cs
+++ b/backend/Contracts/Expenses/ExpenseResponse.cs
@@ -4,5 +4,5 @@ public sealed record ExpenseResponse(
     int Id,
     string Description,
     decimal Amount,
-    DateTime Date,
+    DateOnly Date,
     string Category);

--- a/backend/Contracts/Expenses/UpdateExpenseRequest.cs
+++ b/backend/Contracts/Expenses/UpdateExpenseRequest.cs
@@ -4,5 +4,5 @@ public sealed record UpdateExpenseRequest(
     int Id,
     string? Description,
     decimal Amount,
-    DateTime Date,
+    DateOnly Date,
     string? Category);

--- a/backend/Controllers/ExpensesController.cs
+++ b/backend/Controllers/ExpensesController.cs
@@ -69,7 +69,7 @@ public class ExpensesController : ControllerBase
             UserId = userId,
             Description = description,
             Amount = request.Amount,
-            Date = DateTime.SpecifyKind(request.Date, DateTimeKind.Utc),
+            Date = request.Date,
             Category = category
         };
 
@@ -117,7 +117,7 @@ public class ExpensesController : ControllerBase
 
         existingExpense.Description = description;
         existingExpense.Amount = request.Amount;
-        existingExpense.Date = DateTime.SpecifyKind(request.Date, DateTimeKind.Utc);
+        existingExpense.Date = request.Date;
         existingExpense.Category = category;
 
         await _context.SaveChangesAsync();

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -21,6 +21,10 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             .Property(e => e.Amount)
             .HasColumnType("numeric(18,2)");
 
+        modelBuilder.Entity<Expense>()
+            .Property(e => e.Date)
+            .HasColumnType("date");
+
         modelBuilder.Entity<BudgetLimit>()
             .Property(b => b.LimitAmount)
             .HasColumnType("numeric(18,2)");

--- a/backend/Migrations/20260819165849_ExpenseDateOnly.Designer.cs
+++ b/backend/Migrations/20260819165849_ExpenseDateOnly.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260819165849_ExpenseDateOnly")]
+    partial class ExpenseDateOnly
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260819165849_ExpenseDateOnly.cs
+++ b/backend/Migrations/20260819165849_ExpenseDateOnly.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpenseDateOnly : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE "Expenses"
+                ALTER COLUMN "Date" TYPE date
+                USING ("Date" AT TIME ZONE 'UTC')::date;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE "Expenses"
+                ALTER COLUMN "Date" TYPE timestamp with time zone
+                USING "Date"::timestamp AT TIME ZONE 'UTC';
+                """);
+        }
+    }
+}

--- a/backend/Models/Expense.cs
+++ b/backend/Models/Expense.cs
@@ -7,7 +7,7 @@ public class Expense
     public int Id { get; set; }
     public string Description { get; set; } = "";
     public decimal Amount { get; set; }
-    public DateTime Date { get; set; }
+    public DateOnly Date { get; set; }
     public string Category { get; set; } = "";
 
     public string UserId { get; set; } = "";

--- a/frontend/src/app/pages/OverviewPage.test.jsx
+++ b/frontend/src/app/pages/OverviewPage.test.jsx
@@ -18,9 +18,9 @@ describe('Overview current-month summary', () => {
     vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
     useExpenses.mockReturnValue({
       expenses: [
-        { category: 'food', amount: 90, date: new Date(2026, 7, 2).toISOString() },
-        { category: 'Food', amount: 10, date: new Date(2026, 7, 3).toISOString() },
-        { category: 'food', amount: 500, date: new Date(2026, 7, 15).toISOString() },
+        { category: 'food', amount: 90, date: '2026-08-02' },
+        { category: 'Food', amount: 10, date: '2026-08-03' },
+        { category: 'food', amount: 500, date: '2026-08-15' },
       ],
       loading: false,
     })
@@ -66,7 +66,7 @@ describe('Overview current-month summary', () => {
 
   it('keeps expense metrics useful and explains when no limits exist', () => {
     useExpenses.mockReturnValue({
-      expenses: [{ category: 'food', amount: 12.34, date: new Date(2026, 7, 2).toISOString() }],
+      expenses: [{ category: 'food', amount: 12.34, date: '2026-08-02' }],
       loading: false,
     })
     useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })

--- a/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
@@ -20,8 +20,8 @@ describe('Analytics page ownership', () => {
     vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
     useExpenses.mockReturnValue({
       expenses: [
-        { category: 'food', amount: 12.34, date: new Date(2026, 7, 2).toISOString() },
-        { category: 'bills', amount: 50, date: new Date(2026, 6, 2).toISOString() },
+        { category: 'food', amount: 12.34, date: '2026-08-02' },
+        { category: 'bills', amount: 50, date: '2026-07-02' },
       ],
       loading: false,
     })

--- a/frontend/src/features/budgetLimits/pages/BudgetsPage.test.jsx
+++ b/frontend/src/features/budgetLimits/pages/BudgetsPage.test.jsx
@@ -27,8 +27,8 @@ describe('Budgets page ownership', () => {
     vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
     useExpenses.mockReturnValue({
       expenses: [
-        { category: 'food', amount: 12.34, date: new Date(2026, 7, 2).toISOString() },
-        { category: 'bills', amount: 50, date: new Date(2026, 6, 2).toISOString() },
+        { category: 'food', amount: 12.34, date: '2026-08-02' },
+        { category: 'bills', amount: 50, date: '2026-07-02' },
       ],
     })
     useBudgetLimits.mockReturnValue({

--- a/frontend/src/features/budgetLimits/utils/totalsByCategory.js
+++ b/frontend/src/features/budgetLimits/utils/totalsByCategory.js
@@ -1,16 +1,10 @@
+import { formatLocalCalendarDate } from "../../expenses/utils/calendarDate";
+
 export function computeMonthlyTotalsByCategory(expenses, limitMonthYear) {
   const [yr, mon] = String(limitMonthYear).split("-").map(Number);
 
-  const monthStart = new Date(yr, mon - 1, 1, 0, 0, 0, 0);
-  const monthEndFull = new Date(yr, mon, 0, 23, 59, 59, 999);
-
   const now = new Date();
-  const endOfToday = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-    23, 59, 59, 999
-  );
+  const today = formatLocalCalendarDate(now);
 
   const isCurrentMonth = yr === now.getFullYear() && mon === now.getMonth() + 1;
 
@@ -19,12 +13,10 @@ export function computeMonthlyTotalsByCategory(expenses, limitMonthYear) {
 
   if (selectedMonthIsFuture) return {};
 
-  const rangeEnd = isCurrentMonth ? endOfToday : monthEndFull;
-
   const totals = {};
   for (const exp of expenses ?? []) {
-    const d = new Date(exp.date);
-    if (d < monthStart || d > rangeEnd) continue;
+    if (!exp.date.startsWith(`${limitMonthYear}-`)) continue;
+    if (isCurrentMonth && exp.date > today) continue;
 
     const cat = exp.category || "Uncategorized";
 

--- a/frontend/src/features/budgetLimits/utils/totalsByCategory.test.js
+++ b/frontend/src/features/budgetLimits/utils/totalsByCategory.test.js
@@ -11,10 +11,10 @@ describe('monthly spending totals used by budgets', () => {
 
   it('includes the current month through the end of today and excludes future days', () => {
     const result = computeMonthlyTotalsByCategory([
-      { category: 'food', amount: 10.1, date: new Date(2026, 7, 1, 10).toISOString() },
-      { category: 'food', amount: 2.22, date: new Date(2026, 7, 14, 20).toISOString() },
-      { category: 'food', amount: 99, date: new Date(2026, 7, 15, 10).toISOString() },
-      { category: 'bills', amount: 50, date: new Date(2026, 6, 31, 10).toISOString() },
+      { category: 'food', amount: 10.1, date: '2026-08-01' },
+      { category: 'food', amount: 2.22, date: '2026-08-14' },
+      { category: 'food', amount: 99, date: '2026-08-15' },
+      { category: 'bills', amount: 50, date: '2026-07-31' },
     ], '2026-08')
 
     expect(result).toEqual({ food: 12.32 })
@@ -22,16 +22,16 @@ describe('monthly spending totals used by budgets', () => {
 
   it('returns no spending for a future selected month', () => {
     expect(computeMonthlyTotalsByCategory([
-      { category: 'food', amount: 10, date: new Date(2026, 8, 1).toISOString() },
+      { category: 'food', amount: 10, date: '2026-09-01' },
     ], '2026-09')).toEqual({})
   })
 
   it('includes the full historical month and groups by exact category key', () => {
     const result = computeMonthlyTotalsByCategory([
-      { category: 'food', amount: 1.115, date: new Date(2026, 6, 1).toISOString() },
-      { category: 'food', amount: 2.225, date: new Date(2026, 6, 31, 23).toISOString() },
-      { category: 'Food', amount: 4, date: new Date(2026, 6, 20).toISOString() },
-      { category: '', amount: 3, date: new Date(2026, 6, 20).toISOString() },
+      { category: 'food', amount: 1.115, date: '2026-07-01' },
+      { category: 'food', amount: 2.225, date: '2026-07-31' },
+      { category: 'Food', amount: 4, date: '2026-07-20' },
+      { category: '', amount: 3, date: '2026-07-20' },
     ], '2026-07')
 
     expect(result).toEqual({ food: 3.35, Food: 4, Uncategorized: 3 })

--- a/frontend/src/features/expenses/components/ExpenseItem.jsx
+++ b/frontend/src/features/expenses/components/ExpenseItem.jsx
@@ -1,5 +1,6 @@
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import { displayText } from "../../../utils/text";
+import { formatExpenseDate } from "../utils/calendarDate";
 
 export default function ExpenseItem({
   expense,
@@ -57,7 +58,7 @@ export default function ExpenseItem({
           <input
             aria-label="Edit date"
             type="date"
-            value={editingData.date ? editingData.date.slice(0, 10) : ""}
+            value={editingData.date || ""}
             onChange={(e) =>
               setEditingData((prev) => ({
                 ...prev,
@@ -66,7 +67,7 @@ export default function ExpenseItem({
             }
           />
         ) : (
-          new Date(expense.date).toLocaleDateString()
+          formatExpenseDate(expense.date)
         )}
       </td>
 

--- a/frontend/src/features/expenses/utils/calendarDate.js
+++ b/frontend/src/features/expenses/utils/calendarDate.js
@@ -1,0 +1,17 @@
+export function formatLocalCalendarDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function localCalendarDateDaysAgo(days, now = new Date()) {
+  const date = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  date.setDate(date.getDate() - days);
+  return formatLocalCalendarDate(date);
+}
+
+export function formatExpenseDate(date) {
+  const [year, month, day] = String(date).split("-");
+  return year && month && day ? `${month}/${day}/${year}` : "";
+}

--- a/frontend/src/features/expenses/utils/calendarDate.test.js
+++ b/frontend/src/features/expenses/utils/calendarDate.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { formatExpenseDate, formatLocalCalendarDate, localCalendarDateDaysAgo } from './calendarDate'
+
+describe('expense calendar dates', () => {
+  it('formats persisted dates without constructing a timezone-bearing instant', () => {
+    expect(formatExpenseDate('2026-03-01')).toBe('03/01/2026')
+  })
+
+  it('formats local calendar components without UTC conversion', () => {
+    expect(formatLocalCalendarDate(new Date(2026, 0, 1, 23, 30))).toBe('2026-01-01')
+  })
+
+  it('subtracts across month and year boundaries as calendar days', () => {
+    expect(localCalendarDateDaysAgo(1, new Date(2026, 0, 1, 12))).toBe('2025-12-31')
+    expect(localCalendarDateDaysAgo(1, new Date(2026, 2, 1, 12))).toBe('2026-02-28')
+  })
+})

--- a/frontend/src/features/expenses/utils/filterExpenses.js
+++ b/frontend/src/features/expenses/utils/filterExpenses.js
@@ -1,8 +1,10 @@
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
+import { formatLocalCalendarDate, localCalendarDateDaysAgo } from "./calendarDate";
 
 export function filterExpenses(expenses, filters) {
   let filtered = [...(expenses ?? [])];
   const now = new Date();
+  const today = formatLocalCalendarDate(now);
 
   const {
     dateFilter,
@@ -13,25 +15,18 @@ export function filterExpenses(expenses, filters) {
   } = filters;
 
   if (dateFilter === "last7") {
-    const sevenDaysAgo = new Date();
-    sevenDaysAgo.setDate(now.getDate() - 7);
-    filtered = filtered.filter((exp) => new Date(exp.date) >= sevenDaysAgo);
+    const sevenDayStart = localCalendarDateDaysAgo(6, now);
+    filtered = filtered.filter((exp) => exp.date >= sevenDayStart && exp.date <= today);
   } else if (dateFilter === "last30") {
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(now.getDate() - 30);
-    filtered = filtered.filter((exp) => new Date(exp.date) >= thirtyDaysAgo);
+    const thirtyDayStart = localCalendarDateDaysAgo(29, now);
+    filtered = filtered.filter((exp) => exp.date >= thirtyDayStart && exp.date <= today);
   } else if (dateFilter === "thisMonth") {
-    filtered = filtered.filter((exp) => {
-      const d = new Date(exp.date);
-      return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
-    });
+    const currentMonth = today.slice(0, 7);
+    filtered = filtered.filter((exp) => exp.date.startsWith(`${currentMonth}-`));
   } else if (dateFilter === "custom" && customStartDate && customEndDate) {
-    const start = new Date(customStartDate);
-    const end = new Date(customEndDate);
-    filtered = filtered.filter((exp) => {
-      const d = new Date(exp.date);
-      return d >= start && d <= end;
-    });
+    filtered = filtered.filter(
+      (exp) => exp.date >= customStartDate && exp.date <= customEndDate
+    );
   }
 
   if (categoryFilter) {

--- a/frontend/src/features/expenses/utils/filterExpenses.test.js
+++ b/frontend/src/features/expenses/utils/filterExpenses.test.js
@@ -2,11 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { filterExpenses } from './filterExpenses'
 
 const expenses = [
-  { id: 1, description: 'Coffee Shop', category: 'food', date: '2026-08-14T12:00:00Z' },
-  { id: 2, description: 'Monthly Pass', category: 'transport', date: '2026-08-07T12:00:00Z' },
-  { id: 3, description: 'Electric Bill', category: 'bills', date: '2026-07-15T12:00:00Z' },
-  { id: 4, description: 'Prescription', category: 'medical', date: '2026-08-01T12:00:00Z' },
-  { id: 5, description: 'Old Concert', category: 'entertainment', date: '2026-06-01T12:00:00Z' },
+  { id: 1, description: 'Coffee Shop', category: 'food', date: '2026-08-14' },
+  { id: 2, description: 'Monthly Pass', category: 'transport', date: '2026-08-07' },
+  { id: 3, description: 'Electric Bill', category: 'bills', date: '2026-07-15' },
+  { id: 4, description: 'Prescription', category: 'medical', date: '2026-08-01' },
+  { id: 5, description: 'Old Concert', category: 'entertainment', date: '2026-06-01' },
 ]
 
 const baseFilters = {
@@ -37,7 +37,7 @@ describe('expense filtering', () => {
   it('uses case-sensitive default-category membership for the Other filter', () => {
     const result = filterExpenses([
       ...expenses,
-      { id: 6, description: 'Capitalized category', category: 'Food', date: '2026-08-10T12:00:00Z' },
+      { id: 6, description: 'Capitalized category', category: 'Food', date: '2026-08-10' },
     ], { ...baseFilters, categoryFilter: 'Other' })
 
     expect(result.map((x) => x.id)).toEqual([1, 2, 3, 4, 5])
@@ -51,7 +51,7 @@ describe('expense filtering', () => {
     expect(filterExpenses(expenses, { ...baseFilters, dateFilter }).map((x) => x.id)).toEqual(expectedIds)
   })
 
-  it('interprets custom date endpoints at midnight', () => {
+  it('includes both custom calendar-date endpoints', () => {
     const result = filterExpenses(expenses, {
       ...baseFilters,
       dateFilter: 'custom',
@@ -59,6 +59,6 @@ describe('expense filtering', () => {
       customEndDate: '2026-08-07',
     })
 
-    expect(result.map((x) => x.id)).toEqual([4])
+    expect(result.map((x) => x.id)).toEqual([2, 4])
   })
 })

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -99,7 +99,7 @@ export default function TransactionsPage() {
     setEditingExpenseData({
       description: expense.description || "",
       amount: Number(expense.amount ?? 0).toFixed(2),
-      date: expense.date ? String(expense.date).slice(0, 10) : "",
+      date: expense.date || "",
       category: categoryIsDefault ? normalizeText(currentCategory) : "other",
       customCategory: categoryIsDefault ? "" : currentCategory,
     });

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -68,7 +68,7 @@ describe('existing expense workflows', () => {
         id: 42,
         description: 'old name',
         amount: 12,
-        date: '2026-08-10T00:00:00Z',
+        date: '2026-08-10',
         category: 'medical',
       }],
     })
@@ -109,7 +109,7 @@ describe('existing expense workflows', () => {
         id: index + 1,
         description: `expense ${index + 1}`,
         amount: index + 1,
-        date: '2026-08-01T00:00:00Z',
+        date: '2026-08-01',
         category: 'food',
       })),
     })

--- a/frontend/src/utils/budgets.js
+++ b/frontend/src/utils/budgets.js
@@ -1,16 +1,8 @@
 // compute spent/percent
 
-import { monthYearToDate } from "../shared/utils/monthYear";
-
 export function amountSpentForCategoryMonth(expenses, category, monthYear) {
-  const start = monthYearToDate(monthYear);
-  const end = new Date(start.getFullYear(), start.getMonth() + 1, 1);
-
   return expenses
-    .filter(e => {
-      const d = new Date(e.date);
-      return e.category === category && d >= start && d < end;
-    })
+    .filter(e => e.category === category && e.date.startsWith(`${monthYear}-`))
     .reduce((sum, e) => sum + Number(e.amount || 0), 0);
 }
 


### PR DESCRIPTION
Closes #62

## Summary

Implements the approved Expense date-only semantics required by the Sunflower PDF import milestone:

- Expense API dates use canonical `YYYY-MM-DD` / `.NET DateOnly` semantics;
- PostgreSQL `Expenses.Date` migrates from `timestamp with time zone` to `date` using the approved UTC-calendar conversion policy;
- frontend Expense date handling treats persisted dates as calendar-date strings rather than timezone-bearing instants;
- date/month-edge and migration coverage are updated within the approved Issue #62 scope.

## Risk

HIGH — financial date semantics and database schema migration.

The conversion policy was approved after read-only production inspection showed all 35 existing Expense dates were UTC-midnight values with zero non-midnight rows.

## Verification

- Backend Release build: passed locally
- Non-PostgreSQL backend tests: 117 passed locally
- Generated migration SQL: reviewed; approved UTC conversion used
- `git diff --check`: passed
- Frontend CI: passed
- Backend CI: passed, including PostgreSQL financial integration
- Vercel check: passed
- Independent ChatGPT diff review: completed; one test-harness finding was corrected on the same branch and reverified by CI

## Production migration

Owner-authorized production migration completed successfully on Neon before merge:

- pre-migration backup branch retained: `backup-62-pre-expense-date-only-20260819`;
- production `Expenses.Date` now uses PostgreSQL `date`;
- Expense row count remains 35;
- earliest/latest dates remain 2026-06-02 / 2026-08-26;
- `__EFMigrationsHistory` contains exactly one `20260819165849_ExpenseDateOnly` entry.

## Remaining release step

This PR is ready for the repository owner's human-only merge. After merge/deploy, perform production smoke verification before considering #62 complete.