### PR TITLE
Require durable planning publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,6 +474,26 @@ begins only after explicit human approval. A separate explicit authorization is
 still required for production migrations or other high-risk production
 operations.
 
+For every MEDIUM/HIGH planning-only run, Codex must publish the completed plan
+as a top-level comment on the governing GitHub Issue before stopping for
+approval when issue-comment publication is available. The comment must include
+the information required by the applicable risk gate and issue, such as the
+implementation and verification plans, material context expansions, risks,
+rollback considerations, and requested human decisions.
+
+The planning comment is a durable planning artifact, not implementation
+authority. Publishing it does not authorize repository edits, branch creation,
+commits, pushes, pull requests, migrations, production access or operations,
+deployment, or merge. Implementation still requires the existing explicit
+approval and short implementation handoff.
+
+If issue-comment publication is unavailable, Codex must stop and report a
+**planning-publication capability gap**, identifying the governing issue and
+the unavailable capability. It must not silently leave the workflow appearing
+ready, create an implementation artifact as a substitute, or ask the human to
+relay the full plan manually. The command center may then restore direct
+publication capability or deliberately select the smallest explicit fallback.
+
 When ChatGPT is acting as command center, it should record the approved plan and
 human approval on the governing GitHub Issue before sending the short
 implementation handoff. A materially changed plan, changed financial/security


### PR DESCRIPTION
## Summary

- require MEDIUM/HIGH planning-only Codex runs to publish their completed plan as a top-level comment on the governing GitHub Issue when publication is available
- distinguish durable planning publication from implementation authority
- define a clear planning-publication capability-gap fallback without requiring the human to relay the full plan

Closes #63.

## Risk

**MEDIUM** — repository-level agent workflow behavior changes only.

The implementation follows the plan and explicit human approval recorded on Issue #63.

## Implementation details

The change is limited to `AGENTS.md`, beside the existing local-Codex MEDIUM/HIGH risk gates. It records:

- the required durable planning output and its expected contents
- the actions that plan publication does not authorize
- the required stop/report behavior when direct issue-comment publication is unavailable

## Verification

- complete changed section and full diff inspected
- confirmed referenced canonical repository paths exist
- `git diff --check` — passed locally
- normal pull-request CI remains required before review-ready status

## Scope boundaries

No application/runtime behavior, financial semantics, API, database schema or migration, dependency, CI workflow, secret, external service, API-key bridge, publisher App, deployment, production operation, or merge authority changed.