### PR TITLE
Fix Render backend Docker context for PDF worker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.agents
+.codex
+frontend
+backend.Tests
+docs
+*.md
+**/.DS_Store
+**/bin
+**/obj

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -49,6 +49,60 @@ jobs:
           DOTNET_GCHeapHardLimit=8000000 "$worker" </dev/null >"$RUNNER_TEMP/worker-smoke.bin"
           test "$(wc -c <"$RUNNER_TEMP/worker-smoke.bin")" -eq 6
 
+      - name: Build production backend image
+        run: docker build --file backend/Dockerfile --tag budget-planner-backend:ci .
+
+      - name: Verify production backend image
+        shell: bash
+        run: |
+          docker image inspect budget-planner-backend:ci \
+            --format '{{json .Config.Entrypoint}}' \
+            | grep -Fx '["dotnet","backend.dll"]'
+
+          docker run --rm --entrypoint sh budget-planner-backend:ci -c '
+            test -f /app/backend.dll
+            test -x /app/PdfWorker/backend.PdfWorker
+            test -f /app/PdfWorker/backend.PdfWorker.deps.json
+            test -f /app/PdfWorker/backend.PdfWorker.runtimeconfig.json
+            find /app/PdfWorker -maxdepth 1 -name "UglyToad.PdfPig*.dll" -print -quit | grep -q .
+            DOTNET_GCHeapHardLimit=8000000 /app/PdfWorker/backend.PdfWorker </dev/null >/tmp/worker-smoke.bin
+            test "$(wc -c </tmp/worker-smoke.bin)" -eq 6
+          '
+
+          container_id=$(docker run --detach --publish 127.0.0.1::8080 \
+            --env 'ConnectionStrings__DefaultConnection=Host=127.0.0.1;Database=unused;Username=unused;Password=unused;Timeout=1' \
+            --env 'Jwt__Key=ci-only-jwt-key-with-at-least-thirty-two-bytes' \
+            --env 'EmailSettings__FromName=Budget Planner CI' \
+            --env 'EmailSettings__FromEmail=ci@example.invalid' \
+            --env 'GoogleEmail__ClientId=ci-only' \
+            --env 'GoogleEmail__ClientSecret=ci-only' \
+            --env 'GoogleEmail__RefreshToken=ci-only' \
+            --env 'Frontend__BaseUrl=https://example.invalid' \
+            --env 'Logging__LogLevel__Microsoft.EntityFrameworkCore=Critical' \
+            --env 'Logging__LogLevel__Microsoft.AspNetCore.DataProtection=Critical' \
+            budget-planner-backend:ci)
+
+          cleanup() {
+            docker logs "$container_id"
+            docker rm --force "$container_id" >/dev/null
+          }
+          trap cleanup EXIT
+
+          started=false
+          for attempt in {1..10}; do
+            test "$(docker inspect --format '{{.State.Running}}' "$container_id")" = true
+            if docker exec "$container_id" sh -c \
+              'grep -Eq ":1F90 .* 0A " /proc/net/tcp /proc/net/tcp6'; then
+              started=true
+              break
+            fi
+            sleep 1
+          done
+
+          test "$started" = true
+          docker exec "$container_id" sh -c \
+            'tr "\000" " " </proc/1/cmdline | grep -Fx "dotnet backend.dll "'
+
   postgresql-integration:
     name: PostgreSQL financial integration
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
-COPY backend.csproj .
-RUN dotnet restore
+COPY backend/backend.csproj backend/
+COPY backend.PdfWorker/backend.PdfWorker.csproj backend.PdfWorker/
+RUN dotnet restore backend/backend.csproj
 
-COPY . .
-RUN dotnet publish -c Release -o /app/publish
+COPY backend/ backend/
+COPY backend.PdfWorker/ backend.PdfWorker/
+RUN dotnet publish backend/backend.csproj --configuration Release --no-restore --output /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app


### PR DESCRIPTION
## Summary

- build the backend Dockerfile from repository-root context so the backend and contained PDF worker projects are both available
- add a root `.dockerignore` to keep unrelated/generated repository content out of the production build context
- build and smoke the production backend image in Backend CI, including its entrypoint, worker artifacts, worker protocol, process command, and port 8080 listener

Closes #71

## Risk

**HIGH** — production deployment artifact/configuration path. Implementation follows the approved plan and human approval recorded on #71. This PR does not change Render or any production system.

## Important details

- Dockerfile remains at `backend/Dockerfile`; its required build context is repository root (`.`).
- Runtime entrypoint remains `dotnet backend.dll`.
- PdfPig remains version `0.1.15` and referenced only by `backend.PdfWorker`.
- Worker process boundary, GC limit, timeout, IPC/resource limits, parser behavior, database/schema, and financial semantics are unchanged.
- After merge, Render settings and deployment still require separate explicit production authorization. The approved target settings are: blank/root repository Root Directory, `backend/Dockerfile` Dockerfile Path, `.` Docker Context, and no Docker Command override.

## Verification

- **Passed locally:** `dotnet restore backend.Tests/backend.Tests.csproj`
- **Passed locally:** `dotnet build backend/backend.csproj --configuration Release --no-restore`
- **Passed locally:** `docker build --file backend/Dockerfile --tag budget-planner-backend:issue-71 .`
- **Passed locally:** image entrypoint, executable worker, deps/runtimeconfig/PdfPig artifact, six-byte worker protocol, `dotnet backend.dll` PID 1 command, and port 8080 listener checks
- **Passed locally:** `git diff --check`
- **Passed locally:** workflow YAML parse
- **Local gap:** the non-PostgreSQL suite completed 167 tests with 165 passing and two existing PDF extraction success assertions failing; both failures reproduced on a focused rerun and no test/parser/worker source was changed by this PR. GitHub **Backend build and tests** is required to establish the Linux CI result.
- **Required by CI:** Backend build and tests, including the new production image checks
- **Required by CI:** PostgreSQL financial integration

## Scope boundaries

- no dependency changes
- no parser or security/resource-limit changes
- no database, migration, or financial behavior changes
- no Render setting change, deploy/redeploy, production access, or merge
