### PR TITLE
Add Sunflower import preview backend

### DIFF
--- a/backend.Tests/Financial/FinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/FinancialApiTestApplication.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace BudgetPlanner.Tests.Financial;
 
-internal sealed class FinancialApiTestApplication : FinancialApiTestApplicationBase
+internal class FinancialApiTestApplication : FinancialApiTestApplicationBase
 {
     private readonly string _databaseName = $"financial-api-tests-{Guid.NewGuid()}";
 
@@ -25,6 +25,8 @@ internal sealed class FinancialApiTestApplication : FinancialApiTestApplicationB
         services.AddDbContext<BudgetContext>(options =>
             options.UseInMemoryDatabase(_databaseName));
     }
+
+    protected override void ConfigureAdditionalServices(IServiceCollection services) { }
 }
 
 internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<Program>
@@ -38,6 +40,7 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
     protected abstract void ConfigureDatabase(IServiceCollection services);
 
     protected virtual void InitializeDatabase(IServiceProvider services) { }
+    protected virtual void ConfigureAdditionalServices(IServiceCollection services) { }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -50,6 +53,7 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
 
             services.RemoveAll<IEmailService>();
             services.AddSingleton<IEmailService, NoOpEmailService>();
+            ConfigureAdditionalServices(services);
         });
     }
 
@@ -154,6 +158,20 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
         using var scope = Services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
         return await context.Expenses.AsNoTracking().SingleOrDefaultAsync(expense => expense.Id == id);
+    }
+
+    public async Task<int> CountExpensesAsync()
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return await context.Expenses.CountAsync();
+    }
+
+    public async Task<int> CountImportPreviewBatchesAsync(string userId)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return await context.ImportPreviewBatches.CountAsync(value => value.OwnerId == userId);
     }
 
     public async Task<IReadOnlyList<BudgetLimit>> FindBudgetLimitsAsync(

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTestApplication.cs
@@ -5,7 +5,7 @@ using Npgsql;
 
 namespace BudgetPlanner.Tests.Financial;
 
-internal sealed class PostgreSqlFinancialApiTestApplication
+internal class PostgreSqlFinancialApiTestApplication
     : FinancialApiTestApplicationBase
 {
     public const string ConnectionEnvironmentVariable =

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -7,6 +7,9 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+using BudgetPlanner.Import;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace BudgetPlanner.Tests.Financial;
 
@@ -156,6 +159,31 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Import_preview_migration_persists_owned_batch_rows_without_creating_expenses()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-preview@example.com");
+        using var upload = new MultipartFormDataContent();
+        upload.Add(new ByteArrayContent(SunflowerFixtureCorpus.CreateRepresentativePdf()), "file", "synthetic.pdf");
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", upload);
+        var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Created,
+            $"Expected preview creation, received {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var batch = await context.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows).SingleAsync(value => value.Id == batchId);
+        Assert.Equal(owner.Id, batch.OwnerId);
+        Assert.Equal(32, batch.DocumentDigest.Length);
+        Assert.Equal(13, batch.Rows.Count);
+        Assert.False(await context.Expenses.AnyAsync());
+    }
+
+    [PostgreSqlFact]
     public async Task Budget_create_read_upsert_and_delete_use_relational_month_query()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
@@ -200,6 +228,15 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
         Assert.Empty(await app.FindBudgetLimitsAsync(owner.Id, "food"));
         Assert.Single(await app.FindBudgetLimitsAsync(other.Id, "hidden"));
+    }
+}
+
+internal sealed class PostgreSqlImportPreviewTestApplication : PostgreSqlFinancialApiTestApplication
+{
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<IPdfTextExtractor>();
+        services.AddSingleton<IPdfTextExtractor, BudgetPlanner.Tests.Import.ImmediateSyntheticExtractor>();
     }
 }
 

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using BudgetPlanner.Tests.Financial;
 using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
 using BudgetPlanner.Import;
+using BudgetPlanner.Import.Sunflower;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
@@ -191,6 +192,106 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
     }
 
+    [Fact]
+    public async Task Real_contained_extractor_flows_through_preview_api_and_persistence()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-real-path@example.com");
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal(13, preview.GetProperty("rows").GetArrayLength());
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Theory]
+    [InlineData("malformed", "invalid_pdf")]
+    [InlineData("encrypted", "encrypted_pdf")]
+    [InlineData("image_only", "image_only_pdf")]
+    public async Task Unsafe_pdf_failures_have_stable_safe_api_errors(string kind, string expectedCode)
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync($"preview-{kind}@example.com");
+        var pdf = kind switch
+        {
+            "encrypted" => ParserSpecificPdfFixtures.EncryptedPdf(),
+            "image_only" => ParserSpecificPdfFixtures.ImageOnlyPdf(),
+            _ => ParserSpecificPdfFixtures.InvalidPdf()
+        };
+        using var content = PdfUpload(pdf);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        Assert.Equal(expectedCode, error.GetProperty("code").GetString());
+        Assert.DoesNotContain("advisory-name", await response.Content.ReadAsStringAsync());
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Theory]
+    [InlineData("unsupported_source", "unsupported_statement_source")]
+    [InlineData("unsupported_format", "unsupported_statement_format")]
+    public async Task Unsupported_statement_failures_have_stable_safe_api_errors(string kind, string expectedCode)
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync($"preview-{kind}@example.com");
+        var header = kind == "unsupported_source" ? "PRAIRIE BANK" : "SUNFLOWER BANKFIRST NATIONAL 1870";
+        var lines = kind == "unsupported_source"
+            ? new[] { header, "STATEMENT DATE: 02/28/26", "Days in Statement Period: 28", "Electronic Transactions", "Posted Description Amount" }
+            : new[] { header, "STATEMENT DATE: 02/28/26", "Electronic Transactions", "Posted Description Amount" };
+        using var content = PdfUpload(SyntheticPdfBuilder.Build(new IReadOnlyList<string>[] { lines }));
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        Assert.Equal(expectedCode, error.GetProperty("code").GetString());
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+    }
+
+    [Fact]
+    public async Task Parser_timeout_releases_admission_and_persists_nothing()
+    {
+        await using var app = new BlockingParserFinancialApiTestApplication(TimeSpan.FromMilliseconds(50));
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-timeout@example.com");
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var admission = app.Services.GetRequiredService<IImportPreviewAdmission>();
+        using var releasedLease = admission.TryAcquire(owner.Id);
+
+        Assert.Equal(HttpStatusCode.RequestTimeout, response.StatusCode);
+        Assert.Equal("processing_timed_out", error.GetProperty("code").GetString());
+        Assert.NotNull(releasedLease);
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Parser_request_cancellation_releases_admission_and_persists_nothing()
+    {
+        await using var app = new BlockingParserFinancialApiTestApplication(TimeSpan.FromSeconds(5));
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-cancel@example.com");
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            owner.Client.PostAsync("/api/import-previews/sunflower", content, cancellation.Token));
+        var admission = app.Services.GetRequiredService<IImportPreviewAdmission>();
+        using var releasedLease = admission.TryAcquire(owner.Id);
+
+        Assert.NotNull(releasedLease);
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
     private static MultipartFormDataContent PdfUpload(byte[] bytes)
     {
         var content = new MultipartFormDataContent();
@@ -231,6 +332,33 @@ internal sealed class ImmediateSyntheticExtractor : IPdfTextExtractor
             .ToList();
         return Task.FromResult(PdfTextExtractionOutcome.Success(new PdfTextExtractionResult(
             pdf.Length, pages.Count, pages.Sum(page => page.Text.Length), pages)));
+    }
+}
+
+internal sealed class BlockingParserFinancialApiTestApplication(TimeSpan timeout) : FinancialApiTestApplication
+{
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<IPdfTextExtractor>();
+        services.AddSingleton<IPdfTextExtractor, ImmediateSyntheticExtractor>();
+        services.RemoveAll<ISunflowerStatementParser>();
+        services.AddSingleton<ISunflowerStatementParser, BlockingSunflowerParser>();
+        services.RemoveAll<ImportPreviewProcessingOptions>();
+        services.AddSingleton(new ImportPreviewProcessingOptions { Timeout = timeout });
+    }
+}
+
+internal sealed class BlockingSunflowerParser : ISunflowerStatementParser
+{
+    public SunflowerStatementParseResult Parse(
+        PdfTextExtractionResult extraction,
+        CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Thread.SpinWait(10_000);
+        }
     }
 }
 

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -1,0 +1,241 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Tests.Financial;
+using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+using BudgetPlanner.Import;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Import;
+
+[Collection("Environment variable tests")]
+public sealed class ImportPreviewApiTests
+{
+    [Fact]
+    public async Task Endpoints_require_authentication()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+
+        var create = await client.PostAsync("/api/import-previews/sunflower", content);
+        var read = await client.GetAsync("/api/import-previews/open?sourceType=sunflower_pdf");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, create.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, read.StatusCode);
+    }
+
+    [Fact]
+    public async Task Valid_synthetic_pdf_creates_owner_scoped_preview_without_expense_writes()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("preview-other@example.com");
+        await app.SeedExpenseAsync(owner.Id, "NORTH STAR MARKET", 42.16m, new DateOnly(2026, 2, 5));
+        await app.SeedExpenseAsync(other.Id, "STREAMCO SUBSCRIPTION", 7.99m, new DateOnly(2026, 2, 4));
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("sunflower_pdf", body.GetProperty("sourceType").GetString());
+        Assert.Equal(13, body.GetProperty("rows").GetArrayLength());
+        var rows = body.GetProperty("rows").EnumerateArray().ToList();
+        var duplicate = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "NORTH STAR MARKET");
+        Assert.True(duplicate.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.False(duplicate.GetProperty("selectedForImport").GetBoolean());
+        Assert.Single(duplicate.GetProperty("duplicateExpenseIds").EnumerateArray());
+        var crossUserMatch = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "STREAMCO SUBSCRIPTION");
+        Assert.False(crossUserMatch.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.True(crossUserMatch.GetProperty("selectedForImport").GetBoolean());
+        Assert.Equal(2, await app.CountExpensesAsync());
+
+        var batchId = body.GetProperty("batchId").GetGuid();
+        var forbidden = await other.Client.GetAsync($"/api/import-previews/{batchId}");
+        Assert.Equal(HttpStatusCode.NotFound, forbidden.StatusCode);
+    }
+
+    [Fact]
+    public async Task Same_pdf_reuses_open_preview_and_resume_returns_it()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-reuse@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        using var firstContent = PdfUpload(pdf);
+        using var secondContent = PdfUpload(pdf);
+
+        var first = await owner.Client.PostAsync("/api/import-previews/sunflower", firstContent);
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        var second = await owner.Client.PostAsync("/api/import-previews/sunflower", secondContent);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        var resumed = await owner.Client.GetFromJsonAsync<JsonElement>("/api/import-previews/open?sourceType=sunflower_pdf");
+
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal(firstBody.GetProperty("batchId").GetGuid(), secondBody.GetProperty("batchId").GetGuid());
+        Assert.Equal(firstBody.GetProperty("batchId").GetGuid(), resumed.GetProperty("batchId").GetGuid());
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+    }
+
+    [Fact]
+    public async Task Row_edits_are_normalized_and_ineligible_rows_cannot_be_selected()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-edit@example.com");
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var create = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var preview = await create.Content.ReadFromJsonAsync<JsonElement>();
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var eligible = rows.First(row => row.GetProperty("isEligible").GetBoolean());
+        var excluded = rows.First(row => !row.GetProperty("isEligible").GetBoolean());
+
+        var update = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{eligible.GetProperty("rowId").GetGuid()}",
+            new { editableExpenseDescription = "  Updated description  ", category = " HOME   Supplies ", selectedForImport = false });
+        var updated = await update.Content.ReadFromJsonAsync<JsonElement>();
+        var rejected = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{excluded.GetProperty("rowId").GetGuid()}",
+            new { editableExpenseDescription = "changed", category = "food", selectedForImport = true });
+
+        Assert.Equal(HttpStatusCode.OK, update.StatusCode);
+        Assert.Equal("Updated description", updated.GetProperty("editableExpenseDescription").GetString());
+        Assert.Equal("home supplies", updated.GetProperty("category").GetString());
+        Assert.False(updated.GetProperty("selectedForImport").GetBoolean());
+        Assert.Equal(HttpStatusCode.BadRequest, rejected.StatusCode);
+    }
+
+    [Fact]
+    public async Task File_content_above_ten_mib_is_rejected_before_parsing()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-size@example.com");
+        using var content = PdfUpload(new byte[(10 * 1024 * 1024) + 1]);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        Assert.Equal("upload_too_large", error.GetProperty("code").GetString());
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+    }
+
+    [Fact]
+    public async Task Exactly_ten_mib_of_valid_pdf_content_is_not_rejected_by_multipart_overhead()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-size-boundary@example.com");
+        var fixture = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var padded = new byte[10 * 1024 * 1024];
+        fixture.CopyTo(padded, 0);
+        Array.Fill(padded, (byte)' ', fixture.Length, padded.Length - fixture.Length);
+        using var content = PdfUpload(padded);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Preview_is_inaccessible_at_the_exact_24_hour_expiry_boundary()
+    {
+        var clock = new MutableTimeProvider(new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-expiry@example.com");
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var create = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var preview = await create.Content.ReadFromJsonAsync<JsonElement>();
+        var batchId = preview.GetProperty("batchId").GetGuid();
+
+        clock.Advance(TimeSpan.FromHours(24));
+        var read = await owner.Client.GetAsync($"/api/import-previews/{batchId}");
+        var resume = await owner.Client.GetAsync("/api/import-previews/open?sourceType=sunflower_pdf");
+
+        Assert.Equal(HttpStatusCode.NotFound, read.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, resume.StatusCode);
+    }
+
+    [Fact]
+    public void Per_user_admission_is_non_waiting_and_releases_its_permit()
+    {
+        var admission = new ImportPreviewAdmission();
+        using var first = admission.TryAcquire("owner");
+
+        Assert.NotNull(first);
+        Assert.Null(admission.TryAcquire("owner"));
+        using var other = admission.TryAcquire("other");
+        Assert.NotNull(other);
+
+        first.Dispose();
+        using var reacquired = admission.TryAcquire("owner");
+        Assert.NotNull(reacquired);
+    }
+
+    [Fact]
+    public async Task Active_user_admission_rejects_request_before_upload_processing()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-admission@example.com");
+        var admission = app.Services.GetRequiredService<IImportPreviewAdmission>();
+        using var lease = admission.TryAcquire(owner.Id);
+        using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.Equal("import_in_progress", error.GetProperty("code").GetString());
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+    }
+
+    private static MultipartFormDataContent PdfUpload(byte[] bytes)
+    {
+        var content = new MultipartFormDataContent();
+        var file = new ByteArrayContent(bytes);
+        file.Headers.ContentType = new("text/plain");
+        content.Add(file, "file", "advisory-name.bin");
+        return content;
+    }
+}
+
+internal sealed class ClockedFinancialApiTestApplication(MutableTimeProvider clock) : FinancialApiTestApplication
+{
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<TimeProvider>();
+        services.AddSingleton<TimeProvider>(clock);
+        services.RemoveAll<IPdfTextExtractor>();
+        services.AddSingleton<IPdfTextExtractor, ImmediateSyntheticExtractor>();
+    }
+}
+
+internal sealed class SyntheticExtractionFinancialApiTestApplication : FinancialApiTestApplication
+{
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<IPdfTextExtractor>();
+        services.AddSingleton<IPdfTextExtractor, ImmediateSyntheticExtractor>();
+    }
+}
+
+internal sealed class ImmediateSyntheticExtractor : IPdfTextExtractor
+{
+    public Task<PdfTextExtractionOutcome> ExtractAsync(ReadOnlyMemory<byte> pdf, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var pages = SunflowerFixtureCorpus.RepresentativePages
+            .Select((page, index) => new PdfExtractedPage(index + 1, string.Join('\n', page.Lines)))
+            .ToList();
+        return Task.FromResult(PdfTextExtractionOutcome.Success(new PdfTextExtractionResult(
+            pdf.Length, pages.Count, pages.Sum(page => page.Text.Length), pages)));
+    }
+}
+
+internal sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
+    public void Advance(TimeSpan duration) => utcNow = utcNow.Add(duration);
+}

--- a/backend/Contracts/ImportPreviews/ImportPreviewContracts.cs
+++ b/backend/Contracts/ImportPreviews/ImportPreviewContracts.cs
@@ -1,0 +1,34 @@
+namespace BudgetPlanner.Contracts.ImportPreviews;
+
+public sealed record ImportPreviewError(string Code, string Message);
+
+public sealed record ImportPreviewResponse(
+    Guid BatchId,
+    string SourceType,
+    string ParserRuleVersion,
+    DateTime CreatedAt,
+    DateTime ExpiresAt,
+    IReadOnlyList<ImportPreviewRowResponse> Rows);
+
+public sealed record ImportPreviewRowResponse(
+    Guid RowId,
+    int SourceRowOrdinal,
+    DateOnly? PostedDate,
+    decimal? Amount,
+    string Direction,
+    string SourceDescription,
+    string SourceSection,
+    string Classification,
+    bool IsEligible,
+    IReadOnlyList<string> Errors,
+    IReadOnlyList<string> Warnings,
+    bool IsPossibleDuplicate,
+    IReadOnlyList<int> DuplicateExpenseIds,
+    string? EditableExpenseDescription,
+    string? Category,
+    bool SelectedForImport);
+
+public sealed record UpdateImportPreviewRowRequest(
+    string? EditableExpenseDescription,
+    string? Category,
+    bool SelectedForImport);

--- a/backend/Controllers/ExpensesController.cs
+++ b/backend/Controllers/ExpensesController.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
-using System.Text.RegularExpressions;
 using BudgetPlanner.Contracts.Expenses;
 using BudgetPlanner.Data;
+using BudgetPlanner.Import;
 using BudgetPlanner.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,7 +14,6 @@ namespace BudgetPlanner.Controllers;
 [Authorize]
 public class ExpensesController : ControllerBase
 {
-    private const decimal MaxExpenseAmount = 9999999999999999.99m;
     private readonly BudgetContext _context;
 
     public ExpensesController(BudgetContext context)
@@ -156,55 +155,26 @@ public class ExpensesController : ControllerBase
         out string normalizedDescription,
         out string normalizedCategory)
     {
-        normalizedDescription = (description ?? string.Empty).Trim();
-        normalizedCategory = NormalizeCategory(category);
-
-        if (amount <= 0m)
+        normalizedDescription = ExpenseInputRules.NormalizeDescription(description);
+        normalizedCategory = ExpenseInputRules.NormalizeCategory(category);
+        foreach (var error in ExpenseInputRules.Validate(amount, DateOnly.MinValue, normalizedDescription, normalizedCategory))
         {
-            ModelState.AddModelError("amount", "Amount must be greater than zero.");
-        }
-
-        if (amount > MaxExpenseAmount)
-        {
-            ModelState.AddModelError("amount", "Amount exceeds the supported monetary range.");
-        }
-
-        if (decimal.Round(amount, 2) != amount)
-        {
-            ModelState.AddModelError("amount", "Amount must have at most two decimal places.");
-        }
-
-        if (string.IsNullOrWhiteSpace(normalizedDescription))
-        {
-            ModelState.AddModelError("description", "Description is required.");
-        }
-        else if (normalizedDescription.Length > 500)
-        {
-            ModelState.AddModelError("description", "Description must be 500 characters or fewer.");
-        }
-
-        if (string.IsNullOrWhiteSpace(normalizedCategory))
-        {
-            ModelState.AddModelError("category", "Category is required.");
-        }
-        else if (normalizedCategory.Length > 100)
-        {
-            ModelState.AddModelError("category", "Category must be 100 characters or fewer.");
-        }
-        else if (normalizedCategory == "other")
-        {
-            ModelState.AddModelError(
-                "category",
-                "Category 'other' is reserved for the UI custom-category selector.");
+            var (field, message) = error switch
+            {
+                "amount_must_be_positive" => ("amount", "Amount must be greater than zero."),
+                "amount_out_of_range" => ("amount", "Amount exceeds the supported monetary range."),
+                "amount_precision_invalid" => ("amount", "Amount must have at most two decimal places."),
+                "description_required" => ("description", "Description is required."),
+                "description_too_long" => ("description", "Description must be 500 characters or fewer."),
+                "category_required" => ("category", "Category is required."),
+                "category_too_long" => ("category", "Category must be 100 characters or fewer."),
+                "category_reserved" => ("category", "Category 'other' is reserved for the UI custom-category selector."),
+                _ => ("request", "The expense is invalid.")
+            };
+            ModelState.AddModelError(field, message);
         }
 
         return ModelState.IsValid;
-    }
-
-    private static string NormalizeCategory(string? category)
-    {
-        var trimmed = (category ?? string.Empty).Trim();
-        return Regex.Replace(trimmed, @"\s+", " ").ToLowerInvariant();
     }
 
     private static ExpenseResponse ToResponse(Expense expense)

--- a/backend/Controllers/ImportPreviewsController.cs
+++ b/backend/Controllers/ImportPreviewsController.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using BudgetPlanner.Contracts.ImportPreviews;
+using BudgetPlanner.Import;
+using BudgetPlanner.Import.Sunflower;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BudgetPlanner.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/import-previews")]
+public sealed class ImportPreviewsController(
+    IImportPreviewService previews) : ControllerBase
+{
+    private const long MultipartRequestLimit = ImportPreviewService.MaximumUploadBytes + (64 * 1024);
+
+    [HttpPost("sunflower")]
+    [RequestSizeLimit(MultipartRequestLimit)]
+    [RequestFormLimits(
+        MultipartBodyLengthLimit = MultipartRequestLimit,
+        MemoryBufferThreshold = (int)MultipartRequestLimit)]
+    [ServiceFilter(typeof(ImportPreviewAdmissionFilter))]
+    public async Task<IActionResult> CreateSunflower([FromForm] IFormFile? file, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+        if (file is null) return BadRequest(new ImportPreviewError("file_required", "Choose a PDF to upload."));
+        if (file.Length > ImportPreviewService.MaximumUploadBytes)
+            return StatusCode(StatusCodes.Status413PayloadTooLarge,
+                new ImportPreviewError("upload_too_large", "The PDF exceeds the 10 MiB limit."));
+
+        await using var stream = file.OpenReadStream();
+        var result = await previews.CreateSunflowerAsync(userId, stream, file.Length, cancellationToken);
+        if (!result.IsSuccess) return ErrorResult(result.Error!);
+        return result.Reused
+            ? Ok(result.Preview)
+            : CreatedAtAction(nameof(Get), new { batchId = result.Preview!.BatchId }, result.Preview);
+    }
+
+    [HttpGet("open")]
+    public async Task<IActionResult> GetOpen([FromQuery] string sourceType, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+        var preview = await previews.GetOpenAsync(userId, sourceType, cancellationToken);
+        return preview is null ? NoContent() : Ok(preview);
+    }
+
+    [HttpGet("{batchId:guid}")]
+    public async Task<IActionResult> Get(Guid batchId, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+        var preview = await previews.GetAsync(userId, batchId, cancellationToken);
+        return preview is null ? NotFound() : Ok(preview);
+    }
+
+    [HttpPatch("{batchId:guid}/rows/{rowId:guid}")]
+    public async Task<IActionResult> UpdateRow(Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+        var result = await previews.UpdateRowAsync(userId, batchId, rowId, request, cancellationToken);
+        if (!result.IsSuccess) return ErrorResult(result.Error!);
+        var row = result.Preview!.Rows.Single(value => value.RowId == rowId);
+        return Ok(row);
+    }
+
+    private IActionResult ErrorResult(ImportPreviewError error) => error.Code switch
+    {
+        "upload_too_large" => StatusCode(StatusCodes.Status413PayloadTooLarge, error),
+        "preview_not_found" => NotFound(),
+        "processing_cancelled" => StatusCode(499, error),
+        "processing_timed_out" => StatusCode(StatusCodes.Status408RequestTimeout, error),
+        "import_in_progress" => Conflict(error),
+        "row_not_selectable" or "row_validation_failed" or "file_required" => BadRequest(error),
+        _ => UnprocessableEntity(error)
+    };
+
+}

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -12,6 +12,8 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
     public DbSet<Expense> Expenses { get; set; }
     public DbSet<BudgetLimit> BudgetLimits { get; set; }
     public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+    public DbSet<ImportPreviewBatch> ImportPreviewBatches { get; set; }
+    public DbSet<ImportPreviewRow> ImportPreviewRows { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -34,6 +36,46 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             .WithMany()
             .HasForeignKey(e => e.UserId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<ImportPreviewBatch>(batch =>
+        {
+            batch.ToTable(table =>
+            {
+                table.HasCheckConstraint("CK_ImportPreviewBatch_DigestLength", "octet_length(\"DocumentDigest\") = 32");
+                table.HasCheckConstraint("CK_ImportPreviewBatch_Expiry", "\"ExpiresAt\" > \"CreatedAt\"");
+                table.HasCheckConstraint("CK_ImportPreviewBatch_SourceType", "\"SourceType\" = 'sunflower_pdf'");
+            });
+            batch.Property(value => value.SourceType).HasMaxLength(50);
+            batch.Property(value => value.ParserRuleVersion).HasMaxLength(100);
+            batch.Property(value => value.DocumentDigest).HasColumnType("bytea").HasMaxLength(32);
+            batch.Property(value => value.Lifecycle).HasConversion<string>().HasMaxLength(20);
+            batch.HasOne(value => value.Owner).WithMany().HasForeignKey(value => value.OwnerId)
+                .OnDelete(DeleteBehavior.Cascade);
+            batch.HasIndex(value => new { value.OwnerId, value.SourceType, value.DocumentDigest })
+                .IsUnique()
+                .HasFilter("\"Lifecycle\" = 'Open'");
+            batch.HasIndex(value => value.ExpiresAt);
+        });
+
+        modelBuilder.Entity<ImportPreviewRow>(row =>
+        {
+            row.ToTable(table => table.HasCheckConstraint(
+                "CK_ImportPreviewRow_PositiveAmount", "\"Amount\" IS NULL OR \"Amount\" > 0"));
+            row.Property(value => value.Amount).HasColumnType("numeric(18,2)");
+            row.Property(value => value.PostedDate).HasColumnType("date");
+            row.Property(value => value.Direction).HasConversion<string>().HasMaxLength(20);
+            row.Property(value => value.SourceDescription).HasMaxLength(500);
+            row.Property(value => value.SourceSection).HasMaxLength(100);
+            row.Property(value => value.Classification).HasConversion<string>().HasMaxLength(30);
+            row.Property(value => value.ValidationErrorCodes).HasColumnType("jsonb");
+            row.Property(value => value.WarningCodes).HasColumnType("jsonb");
+            row.Property(value => value.DuplicateExpenseIds).HasColumnType("jsonb");
+            row.Property(value => value.EditableExpenseDescription).HasMaxLength(500);
+            row.Property(value => value.Category).HasMaxLength(100);
+            row.HasOne(value => value.Batch).WithMany(value => value.Rows).HasForeignKey(value => value.BatchId)
+                .OnDelete(DeleteBehavior.Cascade);
+            row.HasIndex(value => new { value.BatchId, value.SourceRowOrdinal }).IsUnique();
+        });
 
         modelBuilder.Entity<BudgetLimit>()
             .HasOne(b => b.User)

--- a/backend/Import/ExpenseInputRules.cs
+++ b/backend/Import/ExpenseInputRules.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+
+namespace BudgetPlanner.Import;
+
+public static partial class ExpenseInputRules
+{
+    public const decimal MaximumAmount = 9999999999999999.99m;
+
+    public static string NormalizeDescription(string? value) => (value ?? "").Trim();
+
+    public static string NormalizeDescriptionForComparison(string? value) =>
+        WhitespaceRegex().Replace(NormalizeDescription(value), " ").ToLowerInvariant();
+
+    public static string NormalizeCategory(string? value) =>
+        WhitespaceRegex().Replace((value ?? "").Trim(), " ").ToLowerInvariant();
+
+    public static IReadOnlyList<string> Validate(decimal? amount, DateOnly? date, string? description, string? category)
+    {
+        var errors = new List<string>();
+        if (date is null) errors.Add("date_required");
+        if (amount is null || amount <= 0m) errors.Add("amount_must_be_positive");
+        else
+        {
+            if (amount > MaximumAmount) errors.Add("amount_out_of_range");
+            if (decimal.Round(amount.Value, 2) != amount.Value) errors.Add("amount_precision_invalid");
+        }
+
+        var normalizedDescription = NormalizeDescription(description);
+        if (normalizedDescription.Length == 0) errors.Add("description_required");
+        else if (normalizedDescription.Length > 500) errors.Add("description_too_long");
+
+        var normalizedCategory = NormalizeCategory(category);
+        if (normalizedCategory.Length == 0) errors.Add("category_required");
+        else if (normalizedCategory.Length > 100) errors.Add("category_too_long");
+        else if (normalizedCategory == "other") errors.Add("category_reserved");
+        return errors;
+    }
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/backend/Import/ImportPreviewAdmission.cs
+++ b/backend/Import/ImportPreviewAdmission.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+
+namespace BudgetPlanner.Import;
+
+public interface IImportPreviewAdmission
+{
+    IDisposable? TryAcquire(string userId);
+}
+
+public sealed class ImportPreviewAdmission : IImportPreviewAdmission
+{
+    private readonly ConcurrentDictionary<string, byte> _activeUsers = new();
+
+    public IDisposable? TryAcquire(string userId) =>
+        _activeUsers.TryAdd(userId, 0) ? new Lease(_activeUsers, userId) : null;
+
+    private sealed class Lease(ConcurrentDictionary<string, byte> activeUsers, string userId) : IDisposable
+    {
+        private int _disposed;
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                activeUsers.TryRemove(userId, out _);
+        }
+    }
+}

--- a/backend/Import/ImportPreviewAdmissionFilter.cs
+++ b/backend/Import/ImportPreviewAdmissionFilter.cs
@@ -1,0 +1,32 @@
+using System.Security.Claims;
+using BudgetPlanner.Contracts.ImportPreviews;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace BudgetPlanner.Import;
+
+public sealed class ImportPreviewAdmissionFilter(IImportPreviewAdmission admission) : IAsyncResourceFilter
+{
+    public async Task OnResourceExecutionAsync(
+        ResourceExecutingContext context,
+        ResourceExecutionDelegate next)
+    {
+        var userId = context.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null)
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        using var lease = admission.TryAcquire(userId);
+        if (lease is null)
+        {
+            context.Result = new ConflictObjectResult(new ImportPreviewError(
+                "import_in_progress",
+                "Another statement is already being processed."));
+            return;
+        }
+
+        await next();
+    }
+}

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -1,0 +1,304 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using BudgetPlanner.Contracts.ImportPreviews;
+using BudgetPlanner.Data;
+using BudgetPlanner.Import.Sunflower;
+using BudgetPlanner.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BudgetPlanner.Import;
+
+public sealed record ImportPreviewOperation(
+    ImportPreviewResponse? Preview,
+    ImportPreviewError? Error,
+    bool Reused = false)
+{
+    public bool IsSuccess => Preview is not null;
+}
+
+public interface IImportPreviewService
+{
+    Task<ImportPreviewOperation> CreateSunflowerAsync(string userId, Stream file, long? declaredLength, CancellationToken cancellationToken);
+    Task<ImportPreviewResponse?> GetOpenAsync(string userId, string sourceType, CancellationToken cancellationToken);
+    Task<ImportPreviewResponse?> GetAsync(string userId, Guid batchId, CancellationToken cancellationToken);
+    Task<ImportPreviewOperation> UpdateRowAsync(string userId, Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class ImportPreviewService(
+    BudgetContext context,
+    IPdfTextExtractor extractor,
+    ISunflowerStatementParser parser,
+    TimeProvider clock) : IImportPreviewService
+{
+    public const int MaximumUploadBytes = 10 * 1024 * 1024;
+    private static readonly TimeSpan PreviewLifetime = TimeSpan.FromHours(24);
+
+    public async Task<ImportPreviewOperation> CreateSunflowerAsync(
+        string userId, Stream file, long? declaredLength, CancellationToken cancellationToken)
+    {
+        if (declaredLength > MaximumUploadBytes)
+            return Failed("upload_too_large", "The PDF exceeds the 10 MiB limit.");
+
+        byte[] pdf;
+        byte[] digest;
+        try
+        {
+            using var buffer = new MemoryStream(Math.Min((int)(declaredLength ?? 0), MaximumUploadBytes));
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var chunk = new byte[81920];
+            var total = 0;
+            while (true)
+            {
+                var read = await file.ReadAsync(chunk, cancellationToken);
+                if (read == 0) break;
+                total += read;
+                if (total > MaximumUploadBytes)
+                    return Failed("upload_too_large", "The PDF exceeds the 10 MiB limit.");
+                hash.AppendData(chunk, 0, read);
+                await buffer.WriteAsync(chunk.AsMemory(0, read), cancellationToken);
+            }
+            pdf = buffer.ToArray();
+            digest = hash.GetHashAndReset();
+        }
+        catch (OperationCanceledException)
+        {
+            return Failed("processing_cancelled", "Statement processing was cancelled.");
+        }
+
+        var existing = await FindOpenByDigestAsync(userId, SunflowerStatementParser.SourceType, digest, cancellationToken);
+        if (existing is not null)
+            return new(ToResponse(existing), null, true);
+
+        PdfTextExtractionOutcome extraction;
+        try
+        {
+            extraction = await extractor.ExtractAsync(pdf, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return Failed("processing_cancelled", "Statement processing was cancelled.");
+        }
+        catch
+        {
+            return Failed("processing_failed", "The PDF could not be processed safely.");
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(pdf);
+        }
+
+        if (!extraction.IsSuccess)
+            return MapExtractionFailure(extraction.Failure!);
+
+        SunflowerStatementParseResult parsed;
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            parsed = parser.Parse(extraction.Result!);
+        }
+        catch (OperationCanceledException)
+        {
+            return Failed("processing_cancelled", "Statement processing was cancelled.");
+        }
+        catch
+        {
+            return Failed("processing_failed", "The PDF could not be processed safely.");
+        }
+        if (!parsed.IsSuccess)
+            return Failed(parsed.Failure!.Code, parsed.Failure.Message);
+
+        var now = clock.GetUtcNow().UtcDateTime;
+        var batch = new ImportPreviewBatch
+        {
+            Id = Guid.NewGuid(),
+            OwnerId = userId,
+            SourceType = SunflowerStatementParser.SourceType,
+            ParserRuleVersion = SunflowerStatementParser.RuleVersion,
+            DocumentDigest = digest,
+            CreatedAt = now,
+            ExpiresAt = now.Add(PreviewLifetime),
+            Lifecycle = ImportPreviewLifecycle.Open
+        };
+
+        var eligibleRows = parsed.Rows.Where(IsPotentiallyEligible).ToList();
+        var dates = eligibleRows.Where(row => row.PostedDate.HasValue).Select(row => row.PostedDate!.Value).Distinct().ToList();
+        var expenses = await context.Expenses.AsNoTracking()
+            .Where(expense => expense.UserId == userId && dates.Contains(expense.Date))
+            .ToListAsync(cancellationToken);
+
+        foreach (var source in parsed.Rows.OrderBy(row => row.SourceRowOrdinal))
+        {
+            var description = ExpenseInputRules.NormalizeDescription(source.EditableExpenseDescription ?? source.SourceDescription);
+            var category = ExpenseInputRules.NormalizeCategory(source.Category ?? "uncategorized");
+            var errors = source.Errors.ToList();
+            if (source.SourceDescription.Length > 500)
+                errors.Add("source_description_too_long");
+            var eligible = IsPotentiallyEligible(source);
+            if (eligible)
+                errors.AddRange(ExpenseInputRules.Validate(source.Amount, source.PostedDate, description, category));
+            eligible = eligible && errors.Count == 0;
+
+            var duplicateIds = eligible
+                ? expenses.Where(expense => expense.Date == source.PostedDate
+                    && expense.Amount == source.Amount
+                    && ExpenseInputRules.NormalizeDescriptionForComparison(expense.Description)
+                        == ExpenseInputRules.NormalizeDescriptionForComparison(description))
+                    .Select(expense => expense.Id).ToList()
+                : [];
+
+            var warnings = source.Warnings.ToList();
+            if (duplicateIds.Count > 0 && !warnings.Contains("possible_duplicate"))
+                warnings.Add("possible_duplicate");
+
+            batch.Rows.Add(new ImportPreviewRow
+            {
+                Id = Guid.NewGuid(),
+                SourceRowOrdinal = source.SourceRowOrdinal,
+                PostedDate = source.PostedDate,
+                Amount = source.Amount,
+                Direction = source.Direction,
+                SourceDescription = source.SourceDescription.Length <= 500
+                    ? source.SourceDescription
+                    : source.SourceDescription[..500],
+                SourceSection = source.SourceSection,
+                SourcePageNumber = source.Provenance.SourcePageNumber,
+                Classification = source.Classification,
+                IsEligible = eligible,
+                ValidationErrorCodes = JsonSerializer.Serialize(errors.Distinct()),
+                WarningCodes = JsonSerializer.Serialize(warnings.Distinct()),
+                IsPossibleDuplicate = duplicateIds.Count > 0,
+                DuplicateExpenseIds = JsonSerializer.Serialize(duplicateIds),
+                EditableExpenseDescription = eligible ? description : null,
+                Category = eligible ? category : null,
+                SelectedForImport = eligible && duplicateIds.Count == 0
+            });
+        }
+
+        context.ImportPreviewBatches.Add(batch);
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            context.Entry(batch).State = EntityState.Detached;
+            var winner = await FindOpenByDigestAsync(userId, SunflowerStatementParser.SourceType, digest, cancellationToken);
+            if (winner is null) throw;
+            return new(ToResponse(winner), null, true);
+        }
+
+        await CleanupExpiredAsync(now, cancellationToken);
+        return new(ToResponse(batch), null);
+    }
+
+    public async Task<ImportPreviewResponse?> GetOpenAsync(string userId, string sourceType, CancellationToken cancellationToken)
+    {
+        if (sourceType != SunflowerStatementParser.SourceType) return null;
+        await ExpireOwnedAsync(userId, cancellationToken);
+        var batch = await OwnedOpenQuery(userId).Where(value => value.SourceType == sourceType)
+            .OrderByDescending(value => value.CreatedAt).FirstOrDefaultAsync(cancellationToken);
+        return batch is null ? null : ToResponse(batch);
+    }
+
+    public async Task<ImportPreviewResponse?> GetAsync(string userId, Guid batchId, CancellationToken cancellationToken)
+    {
+        await ExpireOwnedAsync(userId, cancellationToken);
+        var batch = await OwnedOpenQuery(userId).SingleOrDefaultAsync(value => value.Id == batchId, cancellationToken);
+        return batch is null ? null : ToResponse(batch);
+    }
+
+    public async Task<ImportPreviewOperation> UpdateRowAsync(string userId, Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken)
+    {
+        await ExpireOwnedAsync(userId, cancellationToken);
+        var batch = await context.ImportPreviewBatches.Include(value => value.Rows)
+            .Where(value => value.OwnerId == userId && value.Id == batchId && value.Lifecycle == ImportPreviewLifecycle.Open)
+            .SingleOrDefaultAsync(cancellationToken);
+        var row = batch?.Rows.SingleOrDefault(value => value.Id == rowId);
+        if (batch is null || row is null) return Failed("preview_not_found", "The preview is unavailable.");
+        if (!row.IsEligible && request.SelectedForImport)
+            return Failed("row_not_selectable", "This row cannot be selected for import.");
+
+        if (row.IsEligible)
+        {
+            var description = ExpenseInputRules.NormalizeDescription(request.EditableExpenseDescription);
+            var category = ExpenseInputRules.NormalizeCategory(request.Category);
+            var errors = ExpenseInputRules.Validate(row.Amount, row.PostedDate, description, category);
+            if (errors.Count > 0) return Failed("row_validation_failed", "The row changes are invalid.");
+            row.EditableExpenseDescription = description;
+            row.Category = category;
+            row.SelectedForImport = request.SelectedForImport;
+        }
+        else
+        {
+            row.SelectedForImport = false;
+        }
+        await context.SaveChangesAsync(cancellationToken);
+        return new(ToResponse(batch), null);
+    }
+
+    private IQueryable<ImportPreviewBatch> OwnedOpenQuery(string userId) => context.ImportPreviewBatches
+        .AsNoTracking().Include(value => value.Rows)
+        .Where(value => value.OwnerId == userId && value.Lifecycle == ImportPreviewLifecycle.Open);
+
+    private async Task<ImportPreviewBatch?> FindOpenByDigestAsync(string userId, string sourceType, byte[] digest, CancellationToken cancellationToken)
+    {
+        await ExpireOwnedAsync(userId, cancellationToken);
+        var candidates = await OwnedOpenQuery(userId).Where(value => value.SourceType == sourceType).ToListAsync(cancellationToken);
+        return candidates.SingleOrDefault(value => CryptographicOperations.FixedTimeEquals(value.DocumentDigest, digest));
+    }
+
+    private async Task ExpireOwnedAsync(string userId, CancellationToken cancellationToken)
+    {
+        var now = clock.GetUtcNow().UtcDateTime;
+        var expired = await context.ImportPreviewBatches
+            .Where(value => value.OwnerId == userId && value.Lifecycle == ImportPreviewLifecycle.Open && value.ExpiresAt <= now)
+            .ToListAsync(cancellationToken);
+        if (expired.Count == 0) return;
+        foreach (var value in expired) value.Lifecycle = ImportPreviewLifecycle.Expired;
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task CleanupExpiredAsync(DateTime now, CancellationToken cancellationToken)
+    {
+        var stale = await context.ImportPreviewBatches.Where(value => value.Lifecycle == ImportPreviewLifecycle.Expired && value.ExpiresAt < now.AddDays(-7))
+            .OrderBy(value => value.ExpiresAt).Take(100).ToListAsync(cancellationToken);
+        if (stale.Count == 0) return;
+        context.ImportPreviewBatches.RemoveRange(stale);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    private static bool IsPotentiallyEligible(NormalizedImportedRow row) =>
+        row.Classification == ImportedRowClassification.ExpenseCandidate
+        && row.Direction == ImportedTransactionDirection.Debit;
+
+    private static ImportPreviewOperation MapExtractionFailure(PdfExtractionFailure failure) => failure.Code switch
+    {
+        "input_too_large" => Failed("upload_too_large", "The PDF exceeds the 10 MiB limit."),
+        "no_extractable_text" => Failed("image_only_pdf", "The PDF does not contain extractable text."),
+        "cancelled" => Failed("processing_cancelled", "Statement processing was cancelled."),
+        "timed_out" => Failed("processing_timed_out", "Statement processing timed out."),
+        _ => Failed(failure.Code, failure.Message)
+    };
+
+    private static ImportPreviewOperation Failed(string code, string message) => new(null, new(code, message));
+
+    private static ImportPreviewResponse ToResponse(ImportPreviewBatch batch) => new(
+        batch.Id, batch.SourceType, batch.ParserRuleVersion, batch.CreatedAt, batch.ExpiresAt,
+        batch.Rows.OrderBy(row => row.SourceRowOrdinal).Select(row => new ImportPreviewRowResponse(
+            row.Id, row.SourceRowOrdinal, row.PostedDate, row.Amount,
+            row.Direction.ToString().ToLowerInvariant(), row.SourceDescription, row.SourceSection,
+            ToSnakeCase(row.Classification), row.IsEligible,
+            JsonSerializer.Deserialize<string[]>(row.ValidationErrorCodes) ?? [],
+            JsonSerializer.Deserialize<string[]>(row.WarningCodes) ?? [],
+            row.IsPossibleDuplicate,
+            JsonSerializer.Deserialize<int[]>(row.DuplicateExpenseIds) ?? [],
+            row.EditableExpenseDescription, row.Category, row.SelectedForImport)).ToList());
+
+    private static string ToSnakeCase(ImportedRowClassification value) => value switch
+    {
+        ImportedRowClassification.ExpenseCandidate => "expense_candidate",
+        ImportedRowClassification.NonExpense => "non_expense",
+        ImportedRowClassification.NeedsReview => "needs_review",
+        _ => "invalid"
+    };
+}

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -24,11 +24,17 @@ public interface IImportPreviewService
     Task<ImportPreviewOperation> UpdateRowAsync(string userId, Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken);
 }
 
+public sealed class ImportPreviewProcessingOptions
+{
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(10);
+}
+
 public sealed class ImportPreviewService(
     BudgetContext context,
     IPdfTextExtractor extractor,
     ISunflowerStatementParser parser,
-    TimeProvider clock) : IImportPreviewService
+    TimeProvider clock,
+    ImportPreviewProcessingOptions processingOptions) : IImportPreviewService
 {
     public const int MaximumUploadBytes = 10 * 1024 * 1024;
     private static readonly TimeSpan PreviewLifetime = TimeSpan.FromHours(24);
@@ -65,18 +71,43 @@ public sealed class ImportPreviewService(
             return Failed("processing_cancelled", "Statement processing was cancelled.");
         }
 
-        var existing = await FindOpenByDigestAsync(userId, SunflowerStatementParser.SourceType, digest, cancellationToken);
-        if (existing is not null)
-            return new(ToResponse(existing), null, true);
-
-        PdfTextExtractionOutcome extraction;
+        SunflowerStatementParseResult parsed;
         try
         {
-            extraction = await extractor.ExtractAsync(pdf, cancellationToken);
+            using var processingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            processingCts.CancelAfter(processingOptions.Timeout);
+            var processingToken = processingCts.Token;
+
+            var existing = await FindOpenByDigestAsync(
+                userId, SunflowerStatementParser.SourceType, digest, processingToken);
+            if (existing is not null)
+                return new(ToResponse(existing), null, true);
+
+            PdfTextExtractionOutcome extraction;
+            try
+            {
+                extraction = await extractor.ExtractAsync(pdf, processingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return ProcessingInterrupted(cancellationToken);
+            }
+            catch
+            {
+                return Failed("processing_failed", "The PDF could not be processed safely.");
+            }
+
+            if (!extraction.IsSuccess)
+                return extraction.Failure!.Code == "cancelled"
+                    ? ProcessingInterrupted(cancellationToken)
+                    : MapExtractionFailure(extraction.Failure);
+
+            processingToken.ThrowIfCancellationRequested();
+            parsed = parser.Parse(extraction.Result!, processingToken);
         }
         catch (OperationCanceledException)
         {
-            return Failed("processing_cancelled", "Statement processing was cancelled.");
+            return ProcessingInterrupted(cancellationToken);
         }
         catch
         {
@@ -85,24 +116,6 @@ public sealed class ImportPreviewService(
         finally
         {
             CryptographicOperations.ZeroMemory(pdf);
-        }
-
-        if (!extraction.IsSuccess)
-            return MapExtractionFailure(extraction.Failure!);
-
-        SunflowerStatementParseResult parsed;
-        try
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            parsed = parser.Parse(extraction.Result!);
-        }
-        catch (OperationCanceledException)
-        {
-            return Failed("processing_cancelled", "Statement processing was cancelled.");
-        }
-        catch
-        {
-            return Failed("processing_failed", "The PDF could not be processed safely.");
         }
         if (!parsed.IsSuccess)
             return Failed(parsed.Failure!.Code, parsed.Failure.Message);
@@ -281,6 +294,11 @@ public sealed class ImportPreviewService(
     };
 
     private static ImportPreviewOperation Failed(string code, string message) => new(null, new(code, message));
+
+    private static ImportPreviewOperation ProcessingInterrupted(CancellationToken requestToken) =>
+        requestToken.IsCancellationRequested
+            ? Failed("processing_cancelled", "Statement processing was cancelled.")
+            : Failed("processing_timed_out", "Statement processing timed out.");
 
     private static ImportPreviewResponse ToResponse(ImportPreviewBatch batch) => new(
         batch.Id, batch.SourceType, batch.ParserRuleVersion, batch.CreatedAt, batch.ExpiresAt,

--- a/backend/Import/Sunflower/ISunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/ISunflowerStatementParser.cs
@@ -2,5 +2,7 @@ namespace BudgetPlanner.Import.Sunflower;
 
 public interface ISunflowerStatementParser
 {
-    SunflowerStatementParseResult Parse(PdfTextExtractionResult extraction);
+    SunflowerStatementParseResult Parse(
+        PdfTextExtractionResult extraction,
+        CancellationToken cancellationToken = default);
 }

--- a/backend/Import/Sunflower/SunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/SunflowerStatementParser.cs
@@ -12,9 +12,12 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
     private const string DepositsSection = "deposits";
     private const string ElectronicTransactionsSection = "electronic_transactions";
 
-    public SunflowerStatementParseResult Parse(PdfTextExtractionResult extraction)
+    public SunflowerStatementParseResult Parse(
+        PdfTextExtractionResult extraction,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(extraction);
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (!HasOrderedPages(extraction.Pages))
         {
@@ -22,12 +25,18 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
         }
 
         var statementText = string.Join('\n', extraction.Pages.Select(page => page.Text));
+        cancellationToken.ThrowIfCancellationRequested();
         if (!HasSunflowerHeaderIdentity(statementText))
         {
             return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedSource);
         }
 
         var statementDates = extraction.Pages
+            .Select(page =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return page;
+            })
             .SelectMany(page => StatementDateRegex().Matches(page.Text).Select(match => match.Groups["date"].Value))
             .Select(value => TryParseStatementDate(value, out var date) ? date : (DateOnly?)null)
             .Where(date => date.HasValue)
@@ -50,6 +59,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 
         foreach (var page in extraction.Pages)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             string? section = null;
             string? pendingSection = null;
             PendingRow? pendingRow = null;
@@ -68,6 +78,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 
             foreach (var sourceLine in SplitLines(page).Select(line => new SourceLine(page.PageNumber, line)))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var trimmed = sourceLine.Text.Trim();
                 if (trimmed.Length == 0)
                 {

--- a/backend/Migrations/20260820180150_AddImportPreviews.Designer.cs
+++ b/backend/Migrations/20260820180150_AddImportPreviews.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260820180150_AddImportPreviews")]
+    partial class AddImportPreviews
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260820180150_AddImportPreviews.cs
+++ b/backend/Migrations/20260820180150_AddImportPreviews.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportPreviews : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ImportPreviewBatches",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    SourceType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ParserRuleVersion = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    DocumentDigest = table.Column<byte[]>(type: "bytea", maxLength: 32, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Lifecycle = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportPreviewBatches", x => x.Id);
+                    table.CheckConstraint("CK_ImportPreviewBatch_DigestLength", "octet_length(\"DocumentDigest\") = 32");
+                    table.CheckConstraint("CK_ImportPreviewBatch_Expiry", "\"ExpiresAt\" > \"CreatedAt\"");
+                    table.CheckConstraint("CK_ImportPreviewBatch_SourceType", "\"SourceType\" = 'sunflower_pdf'");
+                    table.ForeignKey(
+                        name: "FK_ImportPreviewBatches_AspNetUsers_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImportPreviewRows",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    BatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceRowOrdinal = table.Column<int>(type: "integer", nullable: false),
+                    PostedDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    Amount = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    Direction = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    SourceDescription = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    SourceSection = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    SourcePageNumber = table.Column<int>(type: "integer", nullable: false),
+                    Classification = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    IsEligible = table.Column<bool>(type: "boolean", nullable: false),
+                    ValidationErrorCodes = table.Column<string>(type: "jsonb", nullable: false),
+                    WarningCodes = table.Column<string>(type: "jsonb", nullable: false),
+                    IsPossibleDuplicate = table.Column<bool>(type: "boolean", nullable: false),
+                    DuplicateExpenseIds = table.Column<string>(type: "jsonb", nullable: false),
+                    EditableExpenseDescription = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    Category = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    SelectedForImport = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportPreviewRows", x => x.Id);
+                    table.CheckConstraint("CK_ImportPreviewRow_PositiveAmount", "\"Amount\" IS NULL OR \"Amount\" > 0");
+                    table.ForeignKey(
+                        name: "FK_ImportPreviewRows_ImportPreviewBatches_BatchId",
+                        column: x => x.BatchId,
+                        principalTable: "ImportPreviewBatches",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportPreviewBatches_ExpiresAt",
+                table: "ImportPreviewBatches",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportPreviewBatches_OwnerId_SourceType_DocumentDigest",
+                table: "ImportPreviewBatches",
+                columns: new[] { "OwnerId", "SourceType", "DocumentDigest" },
+                unique: true,
+                filter: "\"Lifecycle\" = 'Open'");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportPreviewRows_BatchId_SourceRowOrdinal",
+                table: "ImportPreviewRows",
+                columns: new[] { "BatchId", "SourceRowOrdinal" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ImportPreviewRows");
+
+            migrationBuilder.DropTable(
+                name: "ImportPreviewBatches");
+        }
+    }
+}

--- a/backend/Models/ImportPreviewBatch.cs
+++ b/backend/Models/ImportPreviewBatch.cs
@@ -1,0 +1,21 @@
+namespace BudgetPlanner.Models;
+
+public enum ImportPreviewLifecycle
+{
+    Open,
+    Expired
+}
+
+public class ImportPreviewBatch
+{
+    public Guid Id { get; set; }
+    public string OwnerId { get; set; } = "";
+    public ApplicationUser? Owner { get; set; }
+    public string SourceType { get; set; } = "";
+    public string ParserRuleVersion { get; set; } = "";
+    public byte[] DocumentDigest { get; set; } = [];
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public ImportPreviewLifecycle Lifecycle { get; set; }
+    public List<ImportPreviewRow> Rows { get; set; } = [];
+}

--- a/backend/Models/ImportPreviewRow.cs
+++ b/backend/Models/ImportPreviewRow.cs
@@ -1,0 +1,26 @@
+using BudgetPlanner.Import;
+
+namespace BudgetPlanner.Models;
+
+public class ImportPreviewRow
+{
+    public Guid Id { get; set; }
+    public Guid BatchId { get; set; }
+    public ImportPreviewBatch? Batch { get; set; }
+    public int SourceRowOrdinal { get; set; }
+    public DateOnly? PostedDate { get; set; }
+    public decimal? Amount { get; set; }
+    public ImportedTransactionDirection Direction { get; set; }
+    public string SourceDescription { get; set; } = "";
+    public string SourceSection { get; set; } = "";
+    public int SourcePageNumber { get; set; }
+    public ImportedRowClassification Classification { get; set; }
+    public bool IsEligible { get; set; }
+    public string ValidationErrorCodes { get; set; } = "[]";
+    public string WarningCodes { get; set; } = "[]";
+    public bool IsPossibleDuplicate { get; set; }
+    public string DuplicateExpenseIds { get; set; } = "[]";
+    public string? EditableExpenseDescription { get; set; }
+    public string? Category { get; set; }
+    public bool SelectedForImport { get; set; }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -12,6 +12,7 @@ using BudgetPlanner.Authentication;
 using BudgetPlanner.Configuration;
 using Microsoft.Extensions.Options;
 using BudgetPlanner.Import;
+using BudgetPlanner.Import.Sunflower;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,6 +32,11 @@ builder.Services.AddCors(options =>
 builder.Services.AddControllers();
 builder.Services.AddSingleton(new PdfExtractionOptions());
 builder.Services.AddSingleton<IPdfTextExtractor, ContainedPdfTextExtractor>();
+builder.Services.AddSingleton<ISunflowerStatementParser, SunflowerStatementParser>();
+builder.Services.AddSingleton<IImportPreviewAdmission, ImportPreviewAdmission>();
+builder.Services.AddScoped<ImportPreviewAdmissionFilter>();
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddScoped<IImportPreviewService, ImportPreviewService>();
 
 builder.Services
     .AddOptions<EmailSettingsOptions>()

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddSingleton<ISunflowerStatementParser, SunflowerStatementParse
 builder.Services.AddSingleton<IImportPreviewAdmission, ImportPreviewAdmission>();
 builder.Services.AddScoped<ImportPreviewAdmissionFilter>();
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton(new ImportPreviewProcessingOptions());
 builder.Services.AddScoped<IImportPreviewService, ImportPreviewService>();
 
 builder.Services


### PR DESCRIPTION
## Summary
- add authenticated Sunflower PDF upload and temporary preview APIs
- enforce per-user admission, 10 MiB file-content limits, safe failures, owner isolation, expiry, and exact re-upload reuse
- add validation, owned-expense duplicate warnings, editable preview state, and additive PostgreSQL persistence

Closes the backend/schema/API portion of #70. Issue #70 remains open for the separately sequenced frontend PR after this PR merges.

## Risk
HIGH — untrusted financial-document upload and additive persisted preview state. This implements the approved plan and binding corrections recorded on #70.

## Verification
- `dotnet build backend.Tests/backend.Tests.csproj --configuration Release --no-restore --disable-build-servers -m:1 /nr:false`
- `dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-build --filter "Category!=PostgreSQL" -m:1 /nr:false` — 176 passed
- PostgreSQL migration-chain lane — 1 passed against a disposable local PostgreSQL 17 database
- remaining PostgreSQL integration lane — 5 passed against a disposable local PostgreSQL 17 database
- generated and inspected idempotent migration SQL
- `git diff --check`

## Scope boundaries
- preview only; no confirmation endpoint or action
- no Expense creation, update, or deletion from preview paths
- no raw PDF or extracted full-page text retention
- no frontend changes, dependency changes, deployment, or production migration
- process-local per-user admission assumes the currently documented single backend instance

## Migration/API impact
- additive `ImportPreviewBatches` and `ImportPreviewRows` tables with ownership, expiry, digest, constraint, and index enforcement
- new authenticated `/api/import-previews` create/read/resume/row-update contracts
- production migration/application is not authorized by this PR and remains separately gated