### PR TITLE
Add statement import preview UI

### DIFF
--- a/frontend/src/features/importPreview/api/importPreviewApi.js
+++ b/frontend/src/features/importPreview/api/importPreviewApi.js
@@ -1,0 +1,21 @@
+import client from "../../../shared/api/client";
+
+export const importPreviewApi = {
+  uploadSunflower(file, signal) {
+    const body = new FormData();
+    body.append("file", file);
+    return client.post("/api/import-previews/sunflower", body, { signal });
+  },
+  getOpen(signal) {
+    return client.get("/api/import-previews/open", {
+      params: { sourceType: "sunflower_pdf" },
+      signal,
+    });
+  },
+  getById(batchId, signal) {
+    return client.get(`/api/import-previews/${batchId}`, { signal });
+  },
+  updateRow(batchId, rowId, payload) {
+    return client.patch(`/api/import-previews/${batchId}/rows/${rowId}`, payload);
+  },
+};

--- a/frontend/src/features/importPreview/api/importPreviewApi.test.js
+++ b/frontend/src/features/importPreview/api/importPreviewApi.test.js
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import client from '../../../shared/api/client'
+import { importPreviewApi } from './importPreviewApi'
+
+vi.mock('../../../shared/api/client', () => ({ default: {
+  get: vi.fn(), post: vi.fn(), patch: vi.fn(),
+} }))
+
+describe('importPreviewApi', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('uploads the selected file as the authenticated multipart field', () => {
+    const file = new File(['pdf'], 'private-name.pdf', { type: 'application/pdf' })
+    const signal = new AbortController().signal
+
+    importPreviewApi.uploadSunflower(file, signal)
+
+    expect(client.post).toHaveBeenCalledWith('/api/import-previews/sunflower', expect.any(FormData), { signal })
+    const form = client.post.mock.calls[0][1]
+    expect(form.get('file')).toBe(file)
+  })
+
+  it('uses server-authoritative resume and row mutation routes', () => {
+    const signal = new AbortController().signal
+    importPreviewApi.getOpen(signal)
+    importPreviewApi.getById('batch-id', signal)
+    importPreviewApi.updateRow('batch-id', 'row-id', { selectedForImport: true })
+
+    expect(client.get).toHaveBeenCalledWith('/api/import-previews/open', {
+      params: { sourceType: 'sunflower_pdf' }, signal,
+    })
+    expect(client.get).toHaveBeenCalledWith('/api/import-previews/batch-id', { signal })
+    expect(client.patch).toHaveBeenCalledWith('/api/import-previews/batch-id/rows/row-id', {
+      selectedForImport: true,
+    })
+  })
+})

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
@@ -1,0 +1,94 @@
+import { useRef, useState } from "react";
+import Card from "../../../shared/ui/Card";
+import ImportPreviewRow from "./ImportPreviewRow";
+
+export default function ImportPreviewPanel({ importState }) {
+  const { preview, loading, processing, error, upload, cancel, updateRow, clearForReupload } = importState;
+  const [dragging, setDragging] = useState(false);
+  const fileInput = useRef(null);
+  const resultsHeading = useRef(null);
+
+  async function submitFile(file) {
+    if (!file) return;
+    const result = await upload(file);
+    if (result) requestAnimationFrame(() => resultsHeading.current?.focus());
+  }
+
+  function drop(event) {
+    event.preventDefault();
+    setDragging(false);
+    submitFile(event.dataTransfer.files?.[0]);
+  }
+
+  return (
+    <Card as="section" className="section import-preview" aria-labelledby="import-preview-title">
+      <div className="section__header import-preview__header">
+        <div>
+          <p className="page-header__eyebrow">Preview only</p>
+          <h2 className="h2" id="import-preview-title">Import Sunflower statement</h2>
+          <p className="muted">Upload a text-extractable Sunflower PDF, up to 10 MiB. Scanned statements are not supported.</p>
+        </div>
+        {preview && <button type="button" className="button-ghost" onClick={clearForReupload}>Choose another statement</button>}
+      </div>
+
+      <div className="status-message status-message--info">
+        Preview only — no expenses have been created. Confirmation is not available yet.
+      </div>
+
+      {error && <div className="status-message status-message--danger" role="alert">{error}</div>}
+      {(loading || processing) && (
+        <div className="import-processing" role="status" aria-live="polite">
+          <span>{loading ? "Looking for an unfinished preview…" : "Processing the statement safely…"}</span>
+          {processing && <button type="button" className="button-ghost" onClick={cancel}>Cancel</button>}
+        </div>
+      )}
+
+      {!loading && !preview && !processing && (
+        <div
+          className={`import-dropzone${dragging ? " import-dropzone--active" : ""}`}
+          onDragEnter={(event) => { event.preventDefault(); setDragging(true); }}
+          onDragOver={(event) => event.preventDefault()}
+          onDragLeave={() => setDragging(false)}
+          onDrop={drop}
+        >
+          <label className="sr-only" htmlFor="sunflower-statement-file">Sunflower statement PDF</label>
+          <input
+            className="sr-only"
+            ref={fileInput}
+            id="sunflower-statement-file"
+            type="file"
+            accept=".pdf,application/pdf"
+            onChange={(event) => submitFile(event.target.files?.[0])}
+          />
+          <p><strong>Drop a statement PDF here</strong> or choose it from your device.</p>
+          <button type="button" onClick={() => fileInput.current?.click()}>Choose PDF</button>
+        </div>
+      )}
+
+      {preview && (
+        <div className="import-results">
+          <div className="import-results__summary">
+            <h3 className="h3" ref={resultsHeading} tabIndex="-1">Statement preview</h3>
+            <p className="muted">{preview.rows.length} rows · available until {new Date(preview.expiresAt).toLocaleString()}</p>
+          </div>
+          <div className="table-wrapper import-preview-table" role="region" aria-label="Statement import preview" tabIndex="0">
+            <table className="data-table">
+              <caption>Sunflower statement rows</caption>
+              <thead><tr><th>Row</th><th>Statement details</th><th>Status</th><th>Selection</th><th>Expense fields</th></tr></thead>
+              <tbody>
+                {preview.rows.map((row) => (
+                  <ImportPreviewRow key={row.rowId} row={row} onUpdate={(payload) => updateRow(row.rowId, payload)} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="import-preview-cards">
+            {preview.rows.map((row) => (
+              <ImportPreviewRow key={row.rowId} row={row} presentation="card" onUpdate={(payload) => updateRow(row.rowId, payload)} />
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
+import { displayText, isDefaultCategory, normalizeText } from "../../../utils/text";
+
+const STATUS_LABELS = {
+  expense_candidate: "Expense candidate",
+  non_expense: "Excluded credit",
+  needs_review: "Needs review",
+  invalid: "Invalid row",
+};
+
+function RowFields({ row, onUpdate }) {
+  const defaultCategory = isDefaultCategory(row.category, DEFAULT_CATEGORIES) || row.category === "uncategorized";
+  const [description, setDescription] = useState(row.editableExpenseDescription ?? "");
+  const [categoryChoice, setCategoryChoice] = useState(defaultCategory ? row.category : "other");
+  const [customCategory, setCustomCategory] = useState(defaultCategory ? "" : row.category ?? "");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setDescription(row.editableExpenseDescription ?? "");
+    const isDefault = isDefaultCategory(row.category, DEFAULT_CATEGORIES) || row.category === "uncategorized";
+    setCategoryChoice(isDefault ? row.category : "other");
+    setCustomCategory(isDefault ? "" : row.category ?? "");
+  }, [row]);
+
+  if (!row.isEligible) return <span className="muted">Not editable</span>;
+
+  async function save() {
+    setSaving(true);
+    await onUpdate({
+      editableExpenseDescription: description.trim(),
+      category: categoryChoice === "other" ? normalizeText(customCategory) : categoryChoice,
+      selectedForImport: row.selectedForImport,
+    });
+    setSaving(false);
+  }
+
+  return (
+    <div className="import-row-fields">
+      <label>
+        <span>Expense description</span>
+        <input value={description} onChange={(event) => setDescription(event.target.value)} />
+      </label>
+      <label>
+        <span>Category</span>
+        <select value={categoryChoice} onChange={(event) => setCategoryChoice(event.target.value)}>
+          {DEFAULT_CATEGORIES.map((category) => (
+            <option key={category} value={category.toLowerCase()}>{displayText(category)}</option>
+          ))}
+          <option value="uncategorized">Uncategorized</option>
+          <option value="other">Other</option>
+        </select>
+      </label>
+      {categoryChoice === "other" && (
+        <label>
+          <span>Custom category</span>
+          <input value={customCategory} onChange={(event) => setCustomCategory(event.target.value)} />
+        </label>
+      )}
+      <button type="button" className="button-ghost" disabled={saving} onClick={save}>
+        {saving ? "Saving…" : "Save row"}
+      </button>
+    </div>
+  );
+}
+
+function RowStatus({ row }) {
+  return (
+    <div className="import-row-status">
+      <span className={`import-status import-status--${row.classification}`}>
+        {STATUS_LABELS[row.classification] ?? "Review required"}
+      </span>
+      {row.isPossibleDuplicate && (
+        <span className="import-warning">Possible duplicate — review before selecting</span>
+      )}
+      {row.errors.map((code) => <span className="import-error" key={code}>Issue: {code.replaceAll("_", " ")}</span>)}
+      {row.warnings.filter((code) => code !== "possible_duplicate").map((code) => (
+        <span className="import-warning" key={code}>Warning: {code.replaceAll("_", " ")}</span>
+      ))}
+    </div>
+  );
+}
+
+export default function ImportPreviewRow({ row, onUpdate, presentation = "table" }) {
+  async function updateSelection(selectedForImport) {
+    await onUpdate({
+      editableExpenseDescription: row.editableExpenseDescription,
+      category: row.category,
+      selectedForImport,
+    });
+  }
+
+  const selection = (
+    <label className="import-selection">
+      <input
+        type="checkbox"
+        checked={row.selectedForImport}
+        disabled={!row.isEligible}
+        onChange={(event) => updateSelection(event.target.checked)}
+      />
+      <span>{row.isEligible ? "Select for future import" : "Not selectable"}</span>
+    </label>
+  );
+
+  const details = (
+    <>
+      <div><span className="import-field-label">Date</span>{row.postedDate ?? "Unavailable"}</div>
+      <div><span className="import-field-label">Amount</span>{row.amount == null ? "Unavailable" : `$${Number(row.amount).toFixed(2)}`}</div>
+      <div><span className="import-field-label">Direction</span>{displayText(row.direction)}</div>
+      <div><span className="import-field-label">Source</span>{row.sourceDescription || "Unavailable"}</div>
+      <div><span className="import-field-label">Section</span>{displayText(row.sourceSection)}</div>
+    </>
+  );
+
+  if (presentation === "card") {
+    return (
+      <article className="import-preview-card" aria-label={`Statement row ${row.sourceRowOrdinal}`}>
+        <div className="import-preview-card__details">{details}</div>
+        <RowStatus row={row} />
+        {selection}
+        <RowFields row={row} onUpdate={onUpdate} />
+      </article>
+    );
+  }
+
+  return (
+    <tr>
+      <td>{row.sourceRowOrdinal}</td>
+      <td>{details}</td>
+      <td><RowStatus row={row} /></td>
+      <td>{selection}</td>
+      <td><RowFields row={row} onUpdate={onUpdate} /></td>
+    </tr>
+  );
+}

--- a/frontend/src/features/importPreview/hooks/useImportPreview.js
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.js
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import axios from "axios";
+import { importPreviewApi } from "../api/importPreviewApi";
+
+const SAFE_ERRORS = {
+  upload_too_large: "Choose a PDF that is 10 MiB or smaller.",
+  invalid_pdf: "This file is not a valid supported PDF.",
+  encrypted_pdf: "Encrypted or password-protected PDFs are not supported.",
+  image_only_pdf: "This PDF has no extractable text. Scanned statements are not supported yet.",
+  unsupported_statement_source: "This statement is not from the supported Sunflower format.",
+  unsupported_statement_format: "This Sunflower statement format is not supported.",
+  candidate_row_limit_exceeded: "This statement contains more than 1,000 transaction rows.",
+  processing_timed_out: "Statement processing timed out. Try the upload again.",
+  processing_cancelled: "Statement processing was cancelled.",
+  import_in_progress: "Another statement is already being processed.",
+  row_not_selectable: "That row cannot be selected for import.",
+  row_validation_failed: "Check the description and category, then try again.",
+};
+
+function safeError(error, fallback) {
+  const code = error?.response?.data?.code;
+  return SAFE_ERRORS[code] ?? fallback;
+}
+
+function batchIdFromLocation() {
+  return new URLSearchParams(window.location.search).get("importBatch");
+}
+
+function rememberBatch(batchId) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("importBatch", batchId);
+  window.history.replaceState({}, "", url);
+}
+
+export function useImportPreview() {
+  const [preview, setPreview] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [processing, setProcessing] = useState(false);
+  const [error, setError] = useState("");
+  const processingController = useRef(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function resume() {
+      try {
+        const batchId = batchIdFromLocation();
+        const response = batchId
+          ? await importPreviewApi.getById(batchId, controller.signal)
+          : await importPreviewApi.getOpen(controller.signal);
+        if (response.status !== 204 && response.data) {
+          setPreview(response.data);
+          rememberBatch(response.data.batchId);
+        }
+      } catch (requestError) {
+        if (!axios.isCancel(requestError)) {
+          setError(safeError(requestError, "The saved import preview could not be loaded."));
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }
+    resume();
+    return () => {
+      controller.abort();
+      processingController.current?.abort();
+    };
+  }, []);
+
+  const upload = useCallback(async (file) => {
+    processingController.current?.abort();
+    const controller = new AbortController();
+    processingController.current = controller;
+    setProcessing(true);
+    setError("");
+    try {
+      const response = await importPreviewApi.uploadSunflower(file, controller.signal);
+      setPreview(response.data);
+      rememberBatch(response.data.batchId);
+      return response.data;
+    } catch (requestError) {
+      if (!axios.isCancel(requestError)) {
+        setError(safeError(requestError, "The statement could not be processed safely."));
+      }
+      return null;
+    } finally {
+      if (processingController.current === controller) {
+        processingController.current = null;
+        setProcessing(false);
+      }
+    }
+  }, []);
+
+  const cancel = useCallback(() => processingController.current?.abort(), []);
+
+  const updateRow = useCallback(async (rowId, payload) => {
+    if (!preview) return null;
+    setError("");
+    try {
+      const response = await importPreviewApi.updateRow(preview.batchId, rowId, payload);
+      setPreview((current) => ({
+        ...current,
+        rows: current.rows.map((row) => row.rowId === rowId ? response.data : row),
+      }));
+      return response.data;
+    } catch (requestError) {
+      setError(safeError(requestError, "The preview row could not be updated."));
+      return null;
+    }
+  }, [preview]);
+
+  const clearForReupload = useCallback(() => {
+    setPreview(null);
+    setError("");
+  }, []);
+
+  return {
+    preview,
+    loading,
+    processing,
+    error,
+    upload,
+    cancel,
+    updateRow,
+    clearForReupload,
+  };
+}

--- a/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
@@ -1,0 +1,73 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { importPreviewApi } from '../api/importPreviewApi'
+import { useImportPreview } from './useImportPreview'
+
+vi.mock('../api/importPreviewApi', () => ({ importPreviewApi: {
+  getOpen: vi.fn(), getById: vi.fn(), uploadSunflower: vi.fn(), updateRow: vi.fn(),
+} }))
+
+const preview = {
+  batchId: '11111111-1111-1111-1111-111111111111',
+  expiresAt: '2026-08-21T12:00:00Z',
+  rows: [{ rowId: 'row-1', selectedForImport: false }],
+}
+
+describe('useImportPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.replaceState({}, '', '/transactions')
+    importPreviewApi.getOpen.mockResolvedValue({ status: 204, data: null })
+  })
+
+  it('resumes a deep-linked batch through the server and remembers the validated id', async () => {
+    window.history.replaceState({}, '', '/transactions?importBatch=11111111-1111-1111-1111-111111111111')
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
+
+    const { result } = renderHook(() => useImportPreview())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(importPreviewApi.getById).toHaveBeenCalledWith(preview.batchId, expect.any(AbortSignal))
+    expect(result.current.preview).toEqual(preview)
+    expect(window.location.search).toContain(`importBatch=${preview.batchId}`)
+  })
+
+  it('maps safe upload errors and does not expose server internals', async () => {
+    importPreviewApi.uploadSunflower.mockRejectedValue({
+      response: { data: { code: 'encrypted_pdf', message: 'internal detail' } },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(() => result.current.upload(new File(['pdf'], 'statement.pdf')))
+
+    expect(result.current.error).toBe('Encrypted or password-protected PDFs are not supported.')
+    expect(result.current.error).not.toContain('internal detail')
+  })
+
+  it('persists a row update into the current preview', async () => {
+    importPreviewApi.getOpen.mockResolvedValue({ status: 200, data: preview })
+    importPreviewApi.updateRow.mockResolvedValue({ data: { ...preview.rows[0], selectedForImport: true } })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.updateRow('row-1', { selectedForImport: true }))
+
+    expect(result.current.preview.rows[0].selectedForImport).toBe(true)
+  })
+
+  it('keeps the preview unchanged when the server rejects a row mutation', async () => {
+    importPreviewApi.getOpen.mockResolvedValue({ status: 200, data: preview })
+    importPreviewApi.updateRow.mockRejectedValue({
+      response: { data: { code: 'row_not_selectable', message: 'internal detail' } },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.updateRow('row-1', { selectedForImport: true }))
+
+    expect(result.current.preview).toEqual(preview)
+    expect(result.current.error).toBe('That row cannot be selected for import.')
+    expect(result.current.error).not.toContain('internal detail')
+  })
+})

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -8,9 +8,12 @@ import { normalizeText, isDefaultCategory } from "../../../utils/text";
 import ExpenseForm from "../../expenses/components/ExpenseForm";
 import ExpenseFilters from "../../expenses/components/ExpenseFilters";
 import ExpenseList from "../../expenses/components/ExpenseList";
+import ImportPreviewPanel from "../../importPreview/components/ImportPreviewPanel";
+import { useImportPreview } from "../../importPreview/hooks/useImportPreview";
 const ENTRIES_PER_PAGE = 10;
 
 export default function TransactionsPage() {
+  const importState = useImportPreview();
   const {
     expenses,
     loading: expensesLoading,
@@ -137,6 +140,8 @@ export default function TransactionsPage() {
           <p className="muted">Record, review, and organize your expenses.</p>
         </div>
       </header>
+
+      <ImportPreviewPanel importState={importState} />
   
       <ExpenseForm
         loading={expensesLoading}

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -3,8 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import TransactionsPage from './TransactionsPage'
 import { useExpenses } from '../../expenses/hooks/useExpenses'
+import { useImportPreview } from '../../importPreview/hooks/useImportPreview'
 
 vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
+vi.mock('../../importPreview/hooks/useImportPreview', () => ({ useImportPreview: vi.fn() }))
 
 const baseExpensesHook = {
   expenses: [],
@@ -14,9 +16,21 @@ const baseExpensesHook = {
   deleteExpense: vi.fn(),
 }
 
+const baseImportHook = {
+  preview: null,
+  loading: false,
+  processing: false,
+  error: '',
+  upload: vi.fn(),
+  cancel: vi.fn(),
+  updateRow: vi.fn(),
+  clearForReupload: vi.fn(),
+}
+
 describe('existing expense workflows', () => {
   beforeEach(() => {
     useExpenses.mockReturnValue({ ...baseExpensesHook })
+    useImportPreview.mockReturnValue({ ...baseImportHook })
     vi.spyOn(window, 'alert').mockImplementation(() => {})
   })
 
@@ -143,5 +157,85 @@ describe('existing expense workflows', () => {
     expect(screen.getByPlaceholderText('Description')).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Spending vs Budget Limits' })).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Chart month')).not.toBeInTheDocument()
+  })
+
+  it('uploads a PDF through the normal Transactions experience', async () => {
+    const user = userEvent.setup()
+    const upload = vi.fn().mockResolvedValue(null)
+    useImportPreview.mockReturnValue({ ...baseImportHook, upload })
+    render(<TransactionsPage />)
+    const file = new File(['synthetic'], 'statement.pdf', { type: 'application/pdf' })
+
+    await user.upload(screen.getByLabelText('Sunflower statement PDF'), file)
+
+    expect(upload).toHaveBeenCalledWith(file)
+    expect(screen.getByText(/Preview only — no expenses have been created/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /confirm|import expenses/i })).not.toBeInTheDocument()
+  })
+
+  it('shows processing and safe retry errors without statement details', async () => {
+    const user = userEvent.setup()
+    const cancel = vi.fn()
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      processing: true,
+      error: 'Statement processing timed out. Try the upload again.',
+      cancel,
+    })
+    render(<TransactionsPage />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Processing the statement safely')
+    expect(screen.getByRole('alert')).toHaveTextContent('Statement processing timed out')
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(cancel).toHaveBeenCalled()
+  })
+
+  it('renders resumed rows with duplicate and ineligible affordances and persists eligible edits', async () => {
+    const user = userEvent.setup()
+    const updateRow = vi.fn().mockResolvedValue(undefined)
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      updateRow,
+      preview: {
+        batchId: '11111111-1111-1111-1111-111111111111',
+        expiresAt: '2026-08-21T12:00:00Z',
+        rows: [
+          {
+            rowId: 'row-1', sourceRowOrdinal: 1, postedDate: '2026-08-12', amount: 8.5,
+            direction: 'debit', sourceDescription: 'REPEATED CAFE', sourceSection: 'electronic_transactions',
+            classification: 'expense_candidate', isEligible: true, errors: [], warnings: ['possible_duplicate'],
+            isPossibleDuplicate: true, editableExpenseDescription: 'REPEATED CAFE', category: 'uncategorized',
+            selectedForImport: false,
+          },
+          {
+            rowId: 'row-2', sourceRowOrdinal: 2, postedDate: '2026-08-13', amount: 12.34,
+            direction: 'unresolved', sourceDescription: 'SOURCE DIRECTION UNKNOWN', sourceSection: 'electronic_transactions',
+            classification: 'needs_review', isEligible: false, errors: [], warnings: [],
+            isPossibleDuplicate: false, editableExpenseDescription: null, category: null,
+            selectedForImport: false,
+          },
+        ],
+      },
+    })
+    render(<TransactionsPage />)
+
+    const table = screen.getByRole('region', { name: 'Statement import preview' })
+    expect(within(table).getByText('Possible duplicate — review before selecting')).toBeInTheDocument()
+    expect(within(table).getByText('Needs review')).toBeInTheDocument()
+    expect(within(table).getByLabelText('Not selectable')).toBeDisabled()
+    await user.click(within(table).getByLabelText('Select for future import'))
+    expect(updateRow).toHaveBeenCalledWith('row-1', expect.objectContaining({ selectedForImport: true }))
+
+    const description = within(table).getByLabelText('Expense description')
+    await user.clear(description)
+    await user.type(description, 'Morning coffee')
+    await user.selectOptions(within(table).getByLabelText('Category'), 'food')
+    await user.click(within(table).getByRole('button', { name: 'Save row' }))
+    expect(updateRow).toHaveBeenLastCalledWith('row-1', {
+      editableExpenseDescription: 'Morning coffee',
+      category: 'food',
+      selectedForImport: false,
+    })
+    expect(screen.queryByRole('button', { name: /confirm|import expenses/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -107,3 +107,40 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 @media (max-width: 820px) { .overview-grid, .overview-metrics, .settings-grid, .investing-capabilities__grid { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
 @media (max-width: 520px) { .card { padding: var(--space-4); } button:not(.icon-button):not(.password-toggle) { width: 100%; } }
 @media (max-width: 380px) { .mobile-nav .app-nav__link { min-height: 56px; } }
+
+.import-preview { display: grid; gap: var(--space-4); }
+.import-preview__header { align-items: start; margin-bottom: 0; }
+.import-preview__header .muted { max-width: 720px; margin-bottom: 0; }
+.import-processing { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-subtle); }
+.import-dropzone { display: grid; justify-items: center; gap: var(--space-3); padding: var(--space-7) var(--space-4); border: 2px dashed var(--color-border); border-radius: var(--radius-lg); text-align: center; background: var(--color-surface-subtle); transition: border-color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard); }
+.import-dropzone--active { border-color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface)); }
+.import-dropzone p { margin: 0; }
+.import-results { display: grid; gap: var(--space-4); }
+.import-results__summary h3, .import-results__summary p { margin-bottom: var(--space-1); }
+.import-preview-table .data-table { min-width: 1100px; }
+.import-preview-table .data-table td:nth-child(2) { min-width: 190px; }
+.import-preview-table .data-table td:nth-child(5) { min-width: 250px; }
+.import-field-label { display: block; margin-top: var(--space-2); color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+.import-field-label:first-child { margin-top: 0; }
+.import-row-status, .import-row-fields { display: grid; gap: var(--space-2); }
+.import-row-fields label { display: grid; gap: var(--space-1); color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 700; }
+.import-status, .import-warning, .import-error { display: block; padding: .35rem .5rem; border-radius: var(--radius-sm); font-size: var(--text-xs); font-weight: 800; }
+.import-status { color: var(--color-text); background: var(--color-surface-subtle); }
+.import-status--expense_candidate { color: var(--color-success); background: var(--color-success-soft); }
+.import-status--needs_review, .import-warning { color: var(--color-info); background: var(--color-info-soft); }
+.import-status--invalid, .import-error { color: var(--color-danger); background: var(--color-danger-soft); }
+.import-selection { display: flex; align-items: flex-start; gap: var(--space-2); font-size: var(--text-sm); }
+.import-selection input { width: auto; margin-top: .2rem; }
+.import-preview-cards { display: none; }
+.import-preview-card { display: grid; gap: var(--space-3); padding: var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface); }
+.import-preview-card__details { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2) var(--space-4); }
+
+@media (max-width: 760px) {
+  .import-preview__header, .import-processing { align-items: stretch; flex-direction: column; }
+  .import-preview-table { display: none; }
+  .import-preview-cards { display: grid; gap: var(--space-3); }
+}
+
+@media (max-width: 520px) {
+  .import-preview-card__details { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- add the authenticated Sunflower PDF upload and server-authoritative preview resume flow to Transactions
- render every preview row with responsive review, status, duplicate warning, eligibility, selection, and editable expense fields
- add safe error handling, cancellation, accessibility affordances, and frontend coverage

Closes the frontend implementation slice of #70. Issue #70 should remain open until this PR is merged and separately authorized production activation is complete.

## Risk
HIGH (inherited from issue #70). This is the approved second PR in the two-PR sequence; it consumes the merged preview API without changing authentication, financial semantics, persistence, or threat-model limits.

## Verification
- npm ci
- npx vitest run --pool=threads --maxWorkers=1 (23 files, 97 tests passed; constrained workers used because the host default parallel pool stalled)
- npm run lint (0 errors; one pre-existing react-hooks warning in useBudgetLimits.js)
- npm run build
- git diff --check

## Scope boundaries
- preview only; no confirmation action or endpoint
- no Expense create/update/delete from import preview paths
- no production migration, Neon operation, deployment, or configuration change
- no dependency or lockfile changes

## Impact
- API: consumes the merged import-preview endpoints; no contract changes
- Database/migration: none in this PR
- Dependencies: none