### PR TITLE
Fix Sunflower source recognition

### DIFF
--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -208,6 +208,32 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(0, await app.CountExpensesAsync());
     }
 
+    [Fact]
+    public async Task Concatenated_sunflower_brand_flows_through_extractor_and_preview_api()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-concatenated-brand@example.com");
+        var lines = new[]
+        {
+            "SunflowerBank FIRST NATIONAL 1870",
+            "STATEMENT DATE: 02/28/26",
+            "Days in Statement Period: 28",
+            "Electronic Transactions",
+            "Posted Description Amount",
+            "02/05/26 SYNTHETIC MARKET 42.16-"
+        };
+        using var content = PdfUpload(SyntheticPdfBuilder.Build(new IReadOnlyList<string>[] { lines }));
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var row = Assert.Single(preview.GetProperty("rows").EnumerateArray());
+        Assert.Equal("SYNTHETIC MARKET", row.GetProperty("sourceDescription").GetString());
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
     [Theory]
     [InlineData("malformed", "invalid_pdf")]
     [InlineData("encrypted", "encrypted_pdf")]

--- a/backend.Tests/Import/SunflowerStatementParserTests.cs
+++ b/backend.Tests/Import/SunflowerStatementParserTests.cs
@@ -62,6 +62,18 @@ public sealed class SunflowerStatementParserTests
             "unsupported_statement_source",
             parser.Parse(Result("GENERIC HEADER\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount\nA GENERIC SUNFLOWER REFERENCE"))
                 .Failure?.Code);
+        Assert.Equal(
+            "unsupported_statement_source",
+            parser.Parse(Result("GENERIC HEADER\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount\nA LATE SunflowerBank REFERENCE"))
+                .Failure?.Code);
+
+        foreach (var nearMiss in new[] { "SunflowerBanking", "SunflowerAnything" })
+        {
+            Assert.Equal(
+                "unsupported_statement_source",
+                parser.Parse(Result($"{nearMiss}\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount"))
+                    .Failure?.Code);
+        }
 
         var preamble = parser.Parse(Result(
             "SYNTHETIC PREAMBLE\nHEADER CODE 123\nSUNFLOWER BANK ADJACENT HEADER\n" +
@@ -69,6 +81,13 @@ public sealed class SunflowerStatementParserTests
             "Posted Description Amount\n02/01/26 PURCHASE 1.00-"));
         Assert.True(preamble.IsSuccess);
         Assert.Single(preamble.Rows);
+
+        var concatenatedBrand = parser.Parse(Result(
+            "SYNTHETIC PREAMBLE\nSunflowerBank FIRST NATIONAL 1870\n" +
+            "STATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\n" +
+            "Posted Description Amount\n02/01/26 PURCHASE 1.00-"));
+        Assert.True(concatenatedBrand.IsSuccess);
+        Assert.Single(concatenatedBrand.Rows);
     }
 
     [Fact]

--- a/backend/Import/Sunflower/SunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/SunflowerStatementParser.cs
@@ -484,7 +484,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
     [GeneratedRegex(@"(?<![A-Za-z])Days in Statement Period:\s*\d+(?=\s|Page|Electronic Transactions|Deposits|$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex DaysInStatementPeriodRegex();
 
-    [GeneratedRegex(@"\bSUNFLOWER\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"\bSUNFLOWER(?:BANK)?\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex SunflowerBrandRegex();
 
     [GeneratedRegex(@"^(?:---\s*)?No Checks Paid(?: Electronically)? in this statement cycle\.(?:\s*---)?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]


### PR DESCRIPTION
## Summary

- recognize the exact concatenated `SunflowerBank` header emitted by PdfPig while preserving existing standalone/spaced recognition
- keep source identity fail-closed by retaining pre-structure ordering and rejecting longer near-miss prefixes
- add sanitized parser and contained extractor-to-authenticated-preview API regressions

Closes #70 after customer acceptance is completed.

## Risk classification

**HIGH**, governed by the approved bounded corrective plan on issue #70. This PR changes only source-recognition behavior and regression coverage.

## Verification

- `dotnet build backend/backend.csproj --configuration Release --no-restore`
- `dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-restore --filter "Category!=PostgreSQL"` — 185 passed
- focused parser recognition regression — passed
- focused concatenated-brand extractor/API regression — passed
- `git diff --check`

One earlier broad parser-class run had an existing generated boundary-PDF extraction assertion exceed/fail within the contained-worker path; the canonical full non-PostgreSQL suite subsequently passed, including that test.

## Scope boundaries

- no private statement content or identifying financial data
- no upload-limit, PDF-worker, parser-row, financial-classification, duplicate, preview-schema/lifecycle, authentication/ownership, frontend, or Expense behavior changes
- no dependency, migration, configuration, production access, deployment, confirmation, or Expense persistence impact
- merge and deployment remain separately authorized
