### PR TITLE
Fix page-local Sunflower source recognition

### DIFF
--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -215,14 +215,43 @@ public sealed class ImportPreviewApiTests
         using var owner = await app.CreateAuthenticatedUserAsync("preview-concatenated-brand@example.com");
         var lines = new[]
         {
-            "SunflowerBank FIRST NATIONAL 1870",
-            "STATEMENT DATE: 02/28/26",
+            "-SunflowerBank FIRST NATIONAL 1870 STATEMENT DATE: 02/28/26",
             "Days in Statement Period: 28",
             "Electronic Transactions",
-            "Posted Description Amount",
+            "-Posted Description Amount",
             "02/05/26 SYNTHETIC MARKET 42.16-"
         };
         using var content = PdfUpload(SyntheticPdfBuilder.Build(new IReadOnlyList<string>[] { lines }));
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var row = Assert.Single(preview.GetProperty("rows").EnumerateArray());
+        Assert.Equal("SYNTHETIC MARKET", row.GetProperty("sourceDescription").GetString());
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Derived_page_order_and_header_whitespace_flow_through_extractor_and_preview_api()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-derived-layout@example.com");
+        var pages = new IReadOnlyList<string>[]
+        {
+            new[] { "Deposits", "Electronic Transactions" },
+            new[]
+            {
+                "Deposits",
+                "-SunflowerBank SYNTHETIC HEADER STATEMENTDATE:02/28/26",
+                "DaysinStatementPeriod:28Deposits",
+                "Electronic Transactions",
+                "-PostedDescriptionAmount",
+                "02/05/26 SYNTHETIC MARKET 42.16-"
+            }
+        };
+        using var content = PdfUpload(SyntheticPdfBuilder.Build(pages));
 
         var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
         var preview = await response.Content.ReadFromJsonAsync<JsonElement>();

--- a/backend.Tests/Import/SunflowerStatementParserTests.cs
+++ b/backend.Tests/Import/SunflowerStatementParserTests.cs
@@ -56,7 +56,7 @@ public sealed class SunflowerStatementParserTests
                 .Failure?.Code);
         Assert.Equal(
             "unsupported_statement_format",
-            parser.Parse(Result("SUNFLOWER BANK\nSTATEMENT DATE 02/28/2026\nDays in Statement Period 28\nElectronic Transactions\nPosted Description Amount"))
+            parser.Parse(Result("SUNFLOWER BANK\nSTATEMENT DATE: 02/28/26\nDays in Statement Period 28\nElectronic Transactions\nPosted Description Amount"))
                 .Failure?.Code);
         Assert.Equal(
             "unsupported_statement_source",
@@ -88,6 +88,30 @@ public sealed class SunflowerStatementParserTests
             "Posted Description Amount\n02/01/26 PURCHASE 1.00-"));
         Assert.True(concatenatedBrand.IsSuccess);
         Assert.Single(concatenatedBrand.Rows);
+    }
+
+    [Fact]
+    public void Page_local_source_identity_accepts_only_brand_before_strong_same_page_metadata()
+    {
+        var parser = new SunflowerStatementParser();
+        var derivedLayout = parser.Parse(MultiPageResult(
+            "Deposits\nElectronic Transactions",
+            "Deposits\nSunflowerBank SYNTHETIC HEADER\nSTATEMENTDATE:02/28/26\n" +
+            "DaysinStatementPeriod:28Deposits\nElectronic Transactions\n" +
+            "PostedDescriptionAmount\n02/01/26 SYNTHETIC PURCHASE 1.00-"));
+
+        Assert.True(derivedLayout.IsSuccess, derivedLayout.Failure?.Code);
+        Assert.Single(derivedLayout.Rows);
+
+        var lateBrand = parser.Parse(Result(
+            "STATEMENTDATE:02/28/26\nSunflowerBank SYNTHETIC DISCLOSURE\n" +
+            "DaysinStatementPeriod:28\nElectronic Transactions\nPostedDescriptionAmount"));
+        Assert.Equal("unsupported_statement_source", lateBrand.Failure?.Code);
+
+        var disclosureOnly = parser.Parse(MultiPageResult(
+            "STATEMENTDATE:02/28/26\nDaysinStatementPeriod:28\nElectronic Transactions\nPostedDescriptionAmount",
+            "SunflowerBank SYNTHETIC DISCLOSURE"));
+        Assert.Equal("unsupported_statement_source", disclosureOnly.Failure?.Code);
     }
 
     [Fact]

--- a/backend/Import/Sunflower/SunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/SunflowerStatementParser.cs
@@ -24,9 +24,8 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
             return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedFormat);
         }
 
-        var statementText = string.Join('\n', extraction.Pages.Select(page => page.Text));
         cancellationToken.ThrowIfCancellationRequested();
-        if (!HasSunflowerHeaderIdentity(statementText))
+        if (!HasSunflowerHeaderIdentity(extraction.Pages))
         {
             return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedSource);
         }
@@ -46,8 +45,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 
         var hasDaysMarker = extraction.Pages.Any(page => DaysInStatementPeriodRegex().IsMatch(page.Text));
         var hasTransactionHeading = extraction.Pages.SelectMany(SplitLines).Any(line => IsTransactionHeading(line.Trim()));
-        var hasColumnHeader = extraction.Pages.Any(page =>
-            page.Text.Contains("Posted Description Amount", StringComparison.OrdinalIgnoreCase));
+        var hasColumnHeader = extraction.Pages.Any(page => PostedDescriptionAmountRegex().IsMatch(page.Text));
         if (statementDates.Count != 1 || !hasDaysMarker || !hasTransactionHeading || !hasColumnHeader)
         {
             return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedFormat);
@@ -134,7 +132,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
                     continue;
                 }
 
-                if (trimmed.Equals("Posted Description Amount", StringComparison.OrdinalIgnoreCase))
+                if (PostedDescriptionAmountRegex().IsMatch(trimmed))
                 {
                     section = pendingSection
                               ?? (rememberedSection == ElectronicTransactionsSection ? rememberedSection : null);
@@ -351,28 +349,14 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
         pages.Count > 0
         && pages.Select(page => page.PageNumber).SequenceEqual(Enumerable.Range(1, pages.Count));
 
-    private static bool HasSunflowerHeaderIdentity(string statementText)
-    {
-        var brand = SunflowerBrandRegex().Match(statementText);
-        if (!brand.Success)
+    private static bool HasSunflowerHeaderIdentity(IReadOnlyList<PdfExtractedPage> pages) =>
+        pages.Any(page =>
         {
-            return false;
-        }
-
-        var structuralIndexes = new[]
-            {
-                StatementDateRegex().Match(statementText),
-                DaysInStatementPeriodRegex().Match(statementText),
-                Regex.Match(statementText, Regex.Escape("Deposits"), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant),
-                Regex.Match(statementText, Regex.Escape("Electronic Transactions"), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant),
-                Regex.Match(statementText, Regex.Escape("Posted Description Amount"), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)
-            }
-            .Where(match => match.Success)
-            .Select(match => match.Index)
-            .ToList();
-
-        return structuralIndexes.Count > 0 && brand.Index < structuralIndexes.Min();
-    }
+            var statementDate = StatementDateRegex().Match(page.Text);
+            return statementDate.Success
+                   && SunflowerBrandRegex().Matches(page.Text)
+                       .Any(brand => brand.Index < statementDate.Index);
+        });
 
     private static IEnumerable<string> SplitLines(PdfExtractedPage page)
     {
@@ -380,9 +364,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
         var fixedMarkers = new[]
         {
             "Important Account Information",
-            "Posted Description Amount",
             "Electronic Transactions",
-            "Days in Statement Period",
             "Transaction Summary",
             "Account Summary",
             "Daily Balance Summary",
@@ -402,11 +384,10 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
             match => $"\n{match.Value}\n",
             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-        text = Regex.Replace(
-            text,
-            @"STATEMENT DATE:\s*\d{2}/\d{2}/\d{2}",
-            match => $"\n{match.Value}\n",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        text = StatementDateRegex().Replace(text, match => $"\n{match.Value}\n");
+        text = DaysInStatementPeriodRegex().Replace(text, match => $"\n{match.Value}\n");
+        text = PostedDescriptionAmountRegex().Replace(text, match => $"\n{match.Value}\n");
+
         text = Regex.Replace(
             text,
             @"Page\s+\d+\s+of\s+\d+",
@@ -466,7 +447,7 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
     private static bool IsStructuralLine(string line) =>
         IsTransactionHeading(line)
         || IsNonTransactionBoundary(line)
-        || line.Equals("Posted Description Amount", StringComparison.OrdinalIgnoreCase);
+        || PostedDescriptionAmountRegex().IsMatch(line);
 
     private sealed record SourceLine(int PageNumber, string Text);
 
@@ -478,11 +459,14 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
         public List<string> DescriptionContinuation { get; } = new();
     }
 
-    [GeneratedRegex(@"(?<![A-Za-z])STATEMENT DATE:\s*(?<date>\d{2}/\d{2}/\d{2})(?![\d/])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"(?<![A-Za-z])STATEMENT\s*DATE\s*:\s*(?<date>\d{2}/\d{2}/\d{2})(?![\d/])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex StatementDateRegex();
 
-    [GeneratedRegex(@"(?<![A-Za-z])Days in Statement Period:\s*\d+(?=\s|Page|Electronic Transactions|Deposits|$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"(?<![A-Za-z])Days\s*in\s*Statement\s*Period\s*:\s*\d+(?!\d)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex DaysInStatementPeriodRegex();
+
+    [GeneratedRegex(@"(?<![A-Za-z])Posted\s*Description\s*Amount(?![A-Za-z])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex PostedDescriptionAmountRegex();
 
     [GeneratedRegex(@"\bSUNFLOWER(?:BANK)?\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex SunflowerBrandRegex();


### PR DESCRIPTION
## Summary

- authenticate the exact supported Sunflower brand page-locally before a strong same-page statement-date anchor
- stop treating earlier generic transaction-section words as global source-authentication cutoffs
- tolerate only PdfPig's evidenced missing inter-word whitespace in the three fixed statement metadata/header phrases
- add sanitized fail-closed parser and contained extractor-to-authenticated-preview API regressions

Continues #70; customer acceptance remains required before closure.

## Risk classification

**HIGH**, governed by the explicitly approved second bounded corrective plan on issue #70.

The private seven-page PDF was exercised locally through the real contained worker using derived-only diagnostics. Extraction succeeded and the corrected parser returned success. No filename, raw statement text, names, account data, transactions, balances, digest, or identifying content was printed, logged, committed, or added as a fixture.

## Verification

- focused page-local parser, late/disclosure rejection, existing concatenated-brand, and contained extractor/API regressions: 4 passed
- private PDF through real contained extractor and corrected parser: extraction success; parser success; no private output
- `dotnet build backend/backend.csproj --configuration Release --no-restore` — passed, 0 warnings/errors
- `dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-restore --filter "Category!=PostgreSQL"` — 187 passed
- `git diff --check` — passed

## Scope boundaries

- runtime changes are confined to the Sunflower parser
- no broad text normalization or fuzzy brand matching
- no upload/resource, request, worker-containment, page/character, transaction-row grammar, financial-classification, duplicate, preview persistence/schema/lifecycle, authentication/ownership, frontend, or Expense behavior changes
- no dependency, migration, configuration, production access, deployment, confirmation, or Expense persistence impact
- merge and redeployment remain separately authorized

## Local checkout note

Implementation was performed from a clean temporary clone at verified live `main` because the original checkout has a pre-existing truncated Git packfile that prevented object transfer. A malformed duplicate local ref in the original checkout was moved to a recoverable `/tmp` backup; no original working-tree source files were changed.
