### PR TITLE
Fix positional Sunflower PDF parsing

### DIFF
--- a/backend.PdfWorker/PdfWorkerProtocol.cs
+++ b/backend.PdfWorker/PdfWorkerProtocol.cs
@@ -18,11 +18,18 @@ internal enum WorkerResultKind : byte
 
 internal static class PdfWorkerProtocol
 {
-    public const byte Version = 1;
+    public const byte Version = 2;
     public const int MaxInputBytes = 10 * 1024 * 1024;
     public const int MaxPages = 25;
     public const int MaxCharacters = 2_000_000;
     public const int MaxUtf8Bytes = 6_000_000;
+    public const int MaxLayoutWords = 100_000;
+    public const int MaxLayoutCharacters = 2_000_000;
+    public const int MaxLayoutUtf8Bytes = 6_000_000;
+    public const int CoordinateScale = 1_000_000;
+    public const int MinNormalizedCoordinate = -50_000;
+    public const int MaxNormalizedCoordinate = 1_050_000;
+    public const int MaxResponseBytes = 15 * 1024 * 1024;
     public static readonly byte[] RequestMagic = "BPDF"u8.ToArray();
     public static readonly byte[] ResponseMagic = "BPDR"u8.ToArray();
 
@@ -33,22 +40,43 @@ internal static class PdfWorkerProtocol
         await output.FlushAsync();
     }
 
-    public static async Task WriteSuccessAsync(Stream output, int inputBytes, IReadOnlyList<string> pages)
+    public static async Task WriteSuccessAsync(
+        Stream output,
+        int inputBytes,
+        IReadOnlyList<WorkerExtractedPage> pages)
     {
         var utf8 = new UTF8Encoding(false, true);
-        var encoded = pages.Select(utf8.GetBytes).ToArray();
-        var characterCount = pages.Sum(page => page.Length);
+        var encodedPages = pages.Select(page => utf8.GetBytes(page.Text)).ToArray();
+        var encodedWords = pages
+            .Select(page => page.Words.Select(word => utf8.GetBytes(word.Text)).ToArray())
+            .ToArray();
+        var characterCount = pages.Sum(page => page.Text.Length);
 
         await output.WriteAsync(ResponseMagic);
         await output.WriteAsync(new[] { Version, (byte)WorkerResultKind.Success });
         await WriteInt32Async(output, inputBytes);
         await WriteInt32Async(output, pages.Count);
         await WriteInt32Async(output, characterCount);
-        for (var index = 0; index < encoded.Length; index++)
+        for (var pageIndex = 0; pageIndex < pages.Count; pageIndex++)
         {
-            await WriteInt32Async(output, index + 1);
-            await WriteInt32Async(output, encoded[index].Length);
-            await output.WriteAsync(encoded[index]);
+            var page = pages[pageIndex];
+            await WriteInt32Async(output, page.PageNumber);
+            await WriteInt32Async(output, encodedPages[pageIndex].Length);
+            await output.WriteAsync(encodedPages[pageIndex]);
+            await WriteInt32Async(output, page.Words.Count);
+            for (var wordIndex = 0; wordIndex < page.Words.Count; wordIndex++)
+            {
+                var word = page.Words[wordIndex];
+                await WriteInt32Async(output, word.Ordinal);
+                await WriteInt32Async(output, encodedWords[pageIndex][wordIndex].Length);
+                await output.WriteAsync(encodedWords[pageIndex][wordIndex]);
+                await WriteInt32Async(output, word.Left);
+                await WriteInt32Async(output, word.Bottom);
+                await WriteInt32Async(output, word.Right);
+                await WriteInt32Async(output, word.Top);
+                await WriteInt32Async(output, word.Baseline);
+                await output.WriteAsync(new[] { word.Orientation });
+            }
         }
 
         await output.FlushAsync();
@@ -61,3 +89,18 @@ internal static class PdfWorkerProtocol
         await output.WriteAsync(buffer);
     }
 }
+
+internal sealed record WorkerExtractedPage(
+    int PageNumber,
+    string Text,
+    IReadOnlyList<WorkerExtractedWord> Words);
+
+internal sealed record WorkerExtractedWord(
+    int Ordinal,
+    string Text,
+    int Left,
+    int Bottom,
+    int Right,
+    int Top,
+    int Baseline,
+    byte Orientation);

--- a/backend.PdfWorker/Program.cs
+++ b/backend.PdfWorker/Program.cs
@@ -2,6 +2,7 @@ using System.Buffers.Binary;
 using System.Text;
 using BudgetPlanner.PdfWorker;
 using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
 using UglyToad.PdfPig.Core;
 using UglyToad.PdfPig.Exceptions;
 
@@ -94,27 +95,71 @@ static async Task<int> ExtractAsync(byte[] pdf, Stream output)
             return 0;
         }
 
-        var pages = new List<string>(document.NumberOfPages);
+        var pages = new List<WorkerExtractedPage>(document.NumberOfPages);
         var characters = 0;
         var utf8Bytes = 0;
+        var layoutWords = 0;
+        var layoutCharacters = 0;
+        var layoutUtf8Bytes = 0;
+        var responseBytes = 6 + (3 * sizeof(int));
         var hasText = false;
         var utf8 = new UTF8Encoding(false, true);
         for (var pageNumber = 1; pageNumber <= document.NumberOfPages; pageNumber++)
         {
-            var text = document.GetPage(pageNumber).Text;
+            var page = document.GetPage(pageNumber);
+            var text = page.Text;
             if (metricsEnabled) ObserveGc();
             var nextCharacters = checked(characters + text.Length);
-            var nextUtf8Bytes = checked(utf8Bytes + utf8.GetByteCount(text));
+            var pageUtf8Bytes = utf8.GetByteCount(text);
+            var nextUtf8Bytes = checked(utf8Bytes + pageUtf8Bytes);
             if (nextCharacters > PdfWorkerProtocol.MaxCharacters || nextUtf8Bytes > PdfWorkerProtocol.MaxUtf8Bytes)
             {
                 await PdfWorkerProtocol.WriteFailureAsync(output, WorkerResultKind.TextLimitExceeded);
                 return 0;
             }
 
+            var words = new List<WorkerExtractedWord>();
+            var pageLayoutCharacters = 0;
+            var pageLayoutUtf8Bytes = 0;
+            var pageLayoutResponseBytes = 0;
+            var layoutAvailable = true;
+            foreach (var word in page.GetWords())
+            {
+                var wordUtf8Bytes = utf8.GetByteCount(word.Text);
+                pageLayoutCharacters = checked(pageLayoutCharacters + word.Text.Length);
+                pageLayoutUtf8Bytes = checked(pageLayoutUtf8Bytes + wordUtf8Bytes);
+                pageLayoutResponseBytes = checked(pageLayoutResponseBytes + 29 + wordUtf8Bytes);
+                if (layoutWords + words.Count + 1 > PdfWorkerProtocol.MaxLayoutWords
+                    || layoutCharacters + pageLayoutCharacters > PdfWorkerProtocol.MaxLayoutCharacters
+                    || layoutUtf8Bytes + pageLayoutUtf8Bytes > PdfWorkerProtocol.MaxLayoutUtf8Bytes
+                    || responseBytes + 12 + pageUtf8Bytes + pageLayoutResponseBytes > PdfWorkerProtocol.MaxResponseBytes
+                    || !TryCreateWord(page, word, words.Count + 1, out var extractedWord))
+                {
+                    words.Clear();
+                    layoutAvailable = false;
+                    break;
+                }
+
+                words.Add(extractedWord!);
+            }
+
             characters = nextCharacters;
             utf8Bytes = nextUtf8Bytes;
             hasText |= !string.IsNullOrWhiteSpace(text);
-            pages.Add(text);
+            responseBytes = checked(responseBytes + 12 + pageUtf8Bytes);
+            if (layoutAvailable)
+            {
+                layoutWords = checked(layoutWords + words.Count);
+                layoutCharacters = checked(layoutCharacters + pageLayoutCharacters);
+                layoutUtf8Bytes = checked(layoutUtf8Bytes + pageLayoutUtf8Bytes);
+                responseBytes = checked(responseBytes + pageLayoutResponseBytes);
+            }
+            if (responseBytes > PdfWorkerProtocol.MaxResponseBytes)
+            {
+                await PdfWorkerProtocol.WriteFailureAsync(output, WorkerResultKind.TextLimitExceeded);
+                return 0;
+            }
+            pages.Add(new WorkerExtractedPage(pageNumber, text, words));
         }
 
         if (!hasText)
@@ -162,6 +207,90 @@ static async Task<int> ExtractAsync(byte[] pdf, Stream output)
         maxLiveBytes = Math.Max(maxLiveBytes, GC.GetTotalMemory(false));
         maxCumulativeAllocatedBytes = Math.Max(maxCumulativeAllocatedBytes, GC.GetTotalAllocatedBytes(false));
     }
+}
+
+static bool TryCreateWord(Page page, Word word, int ordinal, out WorkerExtractedWord? result)
+{
+    result = null;
+    var visibleBounds = page.CropBox.GetVisibleBounds(page.Rotation);
+    var visiblePoints = new[]
+    {
+        visibleBounds.BottomLeft,
+        visibleBounds.BottomRight,
+        visibleBounds.TopLeft,
+        visibleBounds.TopRight
+    };
+    var visibleLeft = visiblePoints.Min(point => point.X);
+    var visibleBottom = visiblePoints.Min(point => point.Y);
+    var visibleWidth = visiblePoints.Max(point => point.X) - visibleLeft;
+    var visibleHeight = visiblePoints.Max(point => point.Y) - visibleBottom;
+    if (string.IsNullOrEmpty(word.Text) || word.Letters.Count == 0
+        || visibleWidth <= 0 || visibleHeight <= 0
+        || !double.IsFinite(visibleWidth) || !double.IsFinite(visibleHeight))
+    {
+        return false;
+    }
+
+    var rectangle = word.BoundingBox;
+    var points = new[] { rectangle.BottomLeft, rectangle.BottomRight, rectangle.TopLeft, rectangle.TopRight };
+    var left = (points.Min(point => point.X) - visibleLeft) / visibleWidth;
+    var right = (points.Max(point => point.X) - visibleLeft) / visibleWidth;
+    var bottom = (points.Min(point => point.Y) - visibleBottom) / visibleHeight;
+    var top = (points.Max(point => point.Y) - visibleBottom) / visibleHeight;
+    var baseline = (word.Letters.Average(letter => letter.StartBaseLine.Y) - visibleBottom) / visibleHeight;
+    if (!TryEncodeCoordinate(left, out var encodedLeft)
+        || !TryEncodeCoordinate(bottom, out var encodedBottom)
+        || !TryEncodeCoordinate(right, out var encodedRight)
+        || !TryEncodeCoordinate(top, out var encodedTop)
+        || !TryEncodeCoordinate(baseline, out var encodedBaseline)
+        || encodedLeft > encodedRight
+        || encodedBottom > encodedTop)
+    {
+        return false;
+    }
+
+    var orientation = word.TextOrientation switch
+    {
+        TextOrientation.Horizontal => (byte)0,
+        TextOrientation.Rotate180 => (byte)1,
+        TextOrientation.Rotate90 => (byte)2,
+        TextOrientation.Rotate270 => (byte)3,
+        TextOrientation.Other => (byte)4,
+        _ => byte.MaxValue
+    };
+    if (orientation == byte.MaxValue)
+    {
+        return false;
+    }
+
+    result = new WorkerExtractedWord(
+        ordinal,
+        word.Text,
+        encodedLeft,
+        encodedBottom,
+        encodedRight,
+        encodedTop,
+        encodedBaseline,
+        orientation);
+    return true;
+}
+
+static bool TryEncodeCoordinate(double value, out int encoded)
+{
+    encoded = 0;
+    if (!double.IsFinite(value))
+    {
+        return false;
+    }
+
+    var scaled = Math.Round(value * PdfWorkerProtocol.CoordinateScale, MidpointRounding.AwayFromZero);
+    if (scaled < PdfWorkerProtocol.MinNormalizedCoordinate || scaled > PdfWorkerProtocol.MaxNormalizedCoordinate)
+    {
+        return false;
+    }
+
+    encoded = checked((int)scaled);
+    return true;
 }
 
 static void WriteTestMetric(

--- a/backend.Tests/Import/Fixtures/Sunflower/SyntheticPdfBuilder.cs
+++ b/backend.Tests/Import/Fixtures/Sunflower/SyntheticPdfBuilder.cs
@@ -4,6 +4,8 @@ namespace BudgetPlanner.Tests.Import.Fixtures.Sunflower;
 
 internal static class SyntheticPdfBuilder
 {
+    internal sealed record PositionedText(double X, double Y, string Text);
+
     public static byte[] Build(IReadOnlyList<IReadOnlyList<string>> pages, string catalogAdditions = "")
     {
         ArgumentNullException.ThrowIfNull(pages);
@@ -76,6 +78,49 @@ internal static class SyntheticPdfBuilder
         return Encoding.ASCII.GetBytes(output.ToString());
     }
 
+    public static byte[] BuildPositioned(IReadOnlyList<IReadOnlyList<PositionedText>> pages)
+    {
+        ArgumentNullException.ThrowIfNull(pages);
+        if (pages.Count == 0)
+        {
+            throw new ArgumentException("At least one page is required.", nameof(pages));
+        }
+
+        var objects = new SortedDictionary<int, string>();
+        var pageObjectNumbers = Enumerable.Range(0, pages.Count).Select(index => 4 + (index * 2)).ToList();
+        objects[1] = "<< /Type /Catalog /Pages 2 0 R >>";
+        objects[2] =
+            $"<< /Type /Pages /Kids [{string.Join(" ", pageObjectNumbers.Select(number => $"{number} 0 R"))}] /Count {pages.Count} >>";
+        objects[3] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+        for (var index = 0; index < pages.Count; index++)
+        {
+            var content = new StringBuilder("BT\n/F1 10 Tf\n");
+            foreach (var item in pages[index])
+            {
+                EnsureAscii(item.Text);
+                content.Append("1 0 0 1 ")
+                    .Append(item.X.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(' ')
+                    .Append(item.Y.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(" Tm\n(")
+                    .Append(EscapePdfLiteral(item.Text))
+                    .Append(") Tj\n");
+            }
+            content.Append("ET\n");
+
+            var pageObject = pageObjectNumbers[index];
+            var contentObject = pageObject + 1;
+            var stream = content.ToString();
+            objects[pageObject] =
+                $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents {contentObject} 0 R >>";
+            objects[contentObject] =
+                $"<< /Length {Encoding.ASCII.GetByteCount(stream)} >>\nstream\n{stream}endstream";
+        }
+
+        return BuildObjects(objects);
+    }
+
     private static string BuildContentStream(IReadOnlyList<string> lines)
     {
         ArgumentNullException.ThrowIfNull(lines);
@@ -100,6 +145,35 @@ internal static class SyntheticPdfBuilder
 
         content.Append("ET\n");
         return content.ToString();
+    }
+
+    private static byte[] BuildObjects(SortedDictionary<int, string> objects)
+    {
+        var maxObjectNumber = objects.Keys.Max();
+        var offsets = new int[maxObjectNumber + 1];
+        var output = new StringBuilder();
+        var byteOffset = 0;
+
+        void Append(string value)
+        {
+            output.Append(value);
+            byteOffset += Encoding.ASCII.GetByteCount(value);
+        }
+
+        Append("%PDF-1.4\n% Budget Planner synthetic positioned fixture\n");
+        foreach (var entry in objects)
+        {
+            offsets[entry.Key] = byteOffset;
+            Append($"{entry.Key} 0 obj\n{entry.Value}\nendobj\n");
+        }
+        var xrefOffset = byteOffset;
+        Append($"xref\n0 {maxObjectNumber + 1}\n0000000000 65535 f \n");
+        for (var objectNumber = 1; objectNumber <= maxObjectNumber; objectNumber++)
+        {
+            Append($"{offsets[objectNumber]:D10} 00000 n \n");
+        }
+        Append($"trailer\n<< /Size {maxObjectNumber + 1} /Root 1 0 R >>\nstartxref\n{xrefOffset}\n%%EOF\n");
+        return Encoding.ASCII.GetBytes(output.ToString());
     }
 
     private static string EscapePdfLiteral(string value) =>

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -263,6 +263,49 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(0, await app.CountExpensesAsync());
     }
 
+    [Fact]
+    public async Task Positioned_compact_rows_flow_through_contained_extractor_and_preview_api()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-positioned-rows@example.com");
+        var page = new[]
+        {
+            new SyntheticPdfBuilder.PositionedText(50, 760, "-SunflowerBank SYNTHETIC HEADER STATEMENTDATE:02/28/26"),
+            new SyntheticPdfBuilder.PositionedText(50, 744, "DaysinStatementPeriod:28"),
+            new SyntheticPdfBuilder.PositionedText(50, 710, "Electronic Transactions"),
+            new SyntheticPdfBuilder.PositionedText(40, 694, "-"),
+            new SyntheticPdfBuilder.PositionedText(50, 694, "Posted"),
+            new SyntheticPdfBuilder.PositionedText(160, 694, "Description"),
+            new SyntheticPdfBuilder.PositionedText(520, 694, "Amount"),
+            new SyntheticPdfBuilder.PositionedText(50, 678, "02/05/26"),
+            new SyntheticPdfBuilder.PositionedText(160, 678, "SYNTHETICREFERENCE7"),
+            new SyntheticPdfBuilder.PositionedText(520, 678, "42.16-"),
+            new SyntheticPdfBuilder.PositionedText(50, 662, "02/06/26"),
+            new SyntheticPdfBuilder.PositionedText(160, 662, "SYNTHETICUTILITY"),
+            new SyntheticPdfBuilder.PositionedText(520, 662, "75.25-"),
+            new SyntheticPdfBuilder.PositionedText(50, 40, "Page1of1")
+        };
+        var pdf = SyntheticPdfBuilder.BuildPositioned(
+            new IReadOnlyList<SyntheticPdfBuilder.PositionedText>[] { page });
+        var extraction = await new ContainedPdfTextExtractor().ExtractAsync(pdf);
+        Assert.True(extraction.IsSuccess, extraction.Failure?.Code);
+        var parsed = new SunflowerStatementParser().Parse(extraction.Result!);
+        Assert.True(parsed.IsSuccess, parsed.Failure?.Code);
+        using var content = PdfUpload(pdf);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new[] { "SYNTHETICREFERENCE7", "SYNTHETICUTILITY" },
+            rows.Select(row => row.GetProperty("sourceDescription").GetString()));
+        Assert.All(rows, row => Assert.Equal("expense_candidate", row.GetProperty("classification").GetString()));
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
     [Theory]
     [InlineData("malformed", "invalid_pdf")]
     [InlineData("encrypted", "encrypted_pdf")]

--- a/backend.Tests/Import/PdfTextExtractorTests.cs
+++ b/backend.Tests/Import/PdfTextExtractorTests.cs
@@ -1,5 +1,6 @@
 using BudgetPlanner.Import;
 using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -292,6 +293,166 @@ public sealed class PdfTextExtractorTests
             Environment.SetEnvironmentVariable("COMPlus_GCHeapHardLimitLOH", priorComPlus);
             Environment.SetEnvironmentVariable("BUDGETPLANNER_TEST_SECRET", priorSecret);
         }
+    }
+
+    [Fact]
+    public void Protocol_v2_round_trip_preserves_bounded_word_layout()
+    {
+        var response = BuildProtocolResponse();
+
+        var outcome = ContainedPdfTextExtractor.ParseResponse(response, 123);
+
+        Assert.True(outcome.IsSuccess);
+        var word = Assert.Single(Assert.Single(outcome.Result!.Pages).Words);
+        Assert.Equal("SAFE", word.Text);
+        Assert.Equal(.1, word.Left, 6);
+        Assert.Equal(.9, word.Right, 6);
+        Assert.Equal(PdfWordOrientation.Horizontal, word.Orientation);
+        Assert.Equal(15 * 1024 * 1024, PdfWorkerProtocol.MaxResponseBytes);
+    }
+
+    [Fact]
+    public void Protocol_v2_accepts_exact_layout_word_limit()
+    {
+        var response = BuildProtocolResponse(wordCount: PdfWorkerProtocol.MaxLayoutWords);
+
+        var outcome = ContainedPdfTextExtractor.ParseResponse(response, 123);
+
+        Assert.True(outcome.IsSuccess);
+        Assert.Equal(PdfWorkerProtocol.MaxLayoutWords, outcome.Result!.Pages.Single().Words.Count);
+    }
+
+    [Fact]
+    public void Protocol_v2_accepts_exact_layout_character_and_utf8_limits()
+    {
+        var exactWord = Encoding.UTF8.GetBytes(new string('\u754c', 20));
+        var response = BuildProtocolResponse(
+            wordCount: PdfWorkerProtocol.MaxLayoutWords,
+            wordBytes: exactWord);
+
+        var outcome = ContainedPdfTextExtractor.ParseResponse(response, 123);
+
+        Assert.True(outcome.IsSuccess);
+        Assert.Equal(PdfWorkerProtocol.MaxLayoutCharacters,
+            outcome.Result!.Pages.Single().Words.Sum(word => word.Text.Length));
+        Assert.Equal(PdfWorkerProtocol.MaxLayoutUtf8Bytes,
+            outcome.Result.Pages.Single().Words.Sum(word => Encoding.UTF8.GetByteCount(word.Text)));
+    }
+
+    [Fact]
+    public async Task Protocol_v2_response_buffer_ceiling_is_calculated_and_enforced()
+    {
+        const int calculatedMaximum = 18
+            + (PdfWorkerProtocol.MaxPages * 12)
+            + PdfWorkerProtocol.MaxUtf8Bytes
+            + PdfWorkerProtocol.MaxLayoutUtf8Bytes
+            + (PdfWorkerProtocol.MaxLayoutWords * 29);
+        Assert.True(calculatedMaximum < PdfWorkerProtocol.MaxResponseBytes);
+
+        var exact = await ContainedPdfTextExtractor.ReadBoundedAsync(
+            new MemoryStream(new byte[32]),
+            32,
+            CancellationToken.None);
+        Assert.Equal(32, exact.Length);
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            ContainedPdfTextExtractor.ReadBoundedAsync(
+                new MemoryStream(new byte[33]),
+                32,
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public void Protocol_v2_rejects_excess_layout_character_and_utf8_limits()
+    {
+        var excessWord = Encoding.UTF8.GetBytes(new string('\u754c', 21));
+        var response = BuildProtocolResponse(
+            wordCount: PdfWorkerProtocol.MaxLayoutWords,
+            wordBytes: excessWord);
+
+        var outcome = ContainedPdfTextExtractor.ParseResponse(response, 123);
+
+        Assert.Equal("processing_failed", outcome.Failure?.Code);
+    }
+
+    [Theory]
+    [InlineData("version")]
+    [InlineData("truncated")]
+    [InlineData("excess")]
+    [InlineData("ordinal")]
+    [InlineData("inverted")]
+    [InlineData("coordinate")]
+    [InlineData("orientation")]
+    [InlineData("utf8")]
+    [InlineData("word_count")]
+    [InlineData("negative_word_count")]
+    [InlineData("length_overflow")]
+    public void Protocol_v2_rejects_malformed_or_excess_layout_frames(string kind)
+    {
+        var response = kind switch
+        {
+            "ordinal" => BuildProtocolResponse(ordinal: 2),
+            "inverted" => BuildProtocolResponse(left: 900_000, right: 100_000),
+            "coordinate" => BuildProtocolResponse(left: PdfWorkerProtocol.MaxNormalizedCoordinate + 1),
+            "orientation" => BuildProtocolResponse(orientation: byte.MaxValue),
+            "utf8" => BuildProtocolResponse(wordBytes: new byte[] { 0xff }),
+            "word_count" => BuildProtocolResponse(wordCount: PdfWorkerProtocol.MaxLayoutWords + 1, writeWords: false),
+            "negative_word_count" => BuildProtocolResponse(wordCount: -1, writeWords: false),
+            "length_overflow" => BuildProtocolResponse(wordLengthOverride: int.MaxValue),
+            _ => BuildProtocolResponse()
+        };
+        response = kind switch
+        {
+            "version" => response.Select((value, index) => index == 4 ? (byte)1 : value).ToArray(),
+            "truncated" => response[..^1],
+            "excess" => response.Append((byte)0).ToArray(),
+            _ => response
+        };
+
+        var outcome = ContainedPdfTextExtractor.ParseResponse(response, 123);
+
+        Assert.Equal("processing_failed", outcome.Failure?.Code);
+    }
+
+    private static byte[] BuildProtocolResponse(
+        int wordCount = 1,
+        bool writeWords = true,
+        int ordinal = 1,
+        int left = 100_000,
+        int right = 900_000,
+        byte orientation = 0,
+        byte[]? wordBytes = null,
+        int? wordLengthOverride = null)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+        writer.Write("BPDR"u8);
+        writer.Write(PdfWorkerProtocol.Version);
+        writer.Write((byte)0);
+        writer.Write(123);
+        writer.Write(1);
+        writer.Write(4);
+        writer.Write(1);
+        writer.Write(4);
+        writer.Write("TEXT"u8);
+        writer.Write(wordCount);
+        if (writeWords)
+        {
+            var encodedWord = wordBytes ?? "SAFE"u8.ToArray();
+            for (var index = 0; index < wordCount; index++)
+            {
+                writer.Write(ordinal + index);
+                writer.Write(wordLengthOverride ?? encodedWord.Length);
+                writer.Write(encodedWord);
+                writer.Write(left);
+                writer.Write(200_000);
+                writer.Write(right);
+                writer.Write(300_000);
+                writer.Write(220_000);
+                writer.Write(orientation);
+            }
+        }
+        writer.Flush();
+        return stream.ToArray();
     }
 
 }

--- a/backend.Tests/Import/SunflowerStatementParserTests.cs
+++ b/backend.Tests/Import/SunflowerStatementParserTests.cs
@@ -185,6 +185,81 @@ public sealed class SunflowerStatementParserTests
     }
 
     [Fact]
+    public void Positional_words_separate_digit_ending_description_from_compact_amount()
+    {
+        var result = new SunflowerStatementParser().Parse(PositionalResult(
+            "02/01/26SYNTHETICREFERENCE710.00-02/02/26SECONDPURCHASE20.25-",
+            PositionalWord(1, "Posted", .08, .16, .80),
+            PositionalWord(2, "Description", .25, .40, .80),
+            PositionalWord(3, "Amount", .85, .93, .80),
+            PositionalWord(4, "02/01/26", .08, .16, .70),
+            PositionalWord(5, "SYNTHETIC", .25, .36, .70),
+            PositionalWord(6, "REFERENCE7", .37, .49, .70),
+            PositionalWord(7, "10.00-", .86, .93, .70),
+            PositionalWord(8, "02/02/26", .08, .16, .65),
+            PositionalWord(9, "SECOND", .25, .34, .65),
+            PositionalWord(10, "PURCHASE", .35, .46, .65),
+            PositionalWord(11, "20.25", .86, .92, .65),
+            PositionalWord(12, "-", .92, .93, .65)));
+
+        Assert.True(result.IsSuccess);
+        Assert.Collection(
+            result.Rows,
+            row =>
+            {
+                Assert.Equal("SYNTHETIC REFERENCE7", row.SourceDescription);
+                Assert.Equal(10.00m, row.Amount);
+                Assert.Equal(ImportedTransactionDirection.Debit, row.Direction);
+                Assert.Equal(ImportedRowClassification.ExpenseCandidate, row.Classification);
+            },
+            row =>
+            {
+                Assert.Equal("SECOND PURCHASE", row.SourceDescription);
+                Assert.Equal(20.25m, row.Amount);
+            });
+    }
+
+    [Theory]
+    [InlineData("duplicate_amount")]
+    [InlineData("column_drift")]
+    [InlineData("overlap")]
+    [InlineData("rotated")]
+    [InlineData("missing_layout")]
+    public void Ambiguous_or_invalid_positional_rows_fail_closed(string kind)
+    {
+        var words = new List<PdfExtractedWord>
+        {
+            PositionalWord(1, "Posted", .08, .16, .80),
+            PositionalWord(2, "Description", .25, .40, .80),
+            PositionalWord(3, "Amount", .85, .93, .80),
+            PositionalWord(4, "02/01/26", .08, .16, .70),
+            PositionalWord(5, "SYNTHETIC7", .25, kind == "overlap" ? .88 : .45, .70),
+            PositionalWord(6, "10.00-", kind == "column_drift" ? .70 : .86, kind == "column_drift" ? .77 : .93, .70,
+                kind == "rotated" ? PdfWordOrientation.Rotate90 : PdfWordOrientation.Horizontal),
+            PositionalWord(7, "02/02/26", .08, .16, .65),
+            PositionalWord(8, "SECOND", .25, .35, .65),
+            PositionalWord(9, "20.00-", .86, .93, .65)
+        };
+        if (kind == "duplicate_amount")
+        {
+            words.Add(PositionalWord(10, "11.00-", .78, .84, .70));
+        }
+        if (kind == "missing_layout")
+        {
+            words.Clear();
+        }
+
+        var result = new SunflowerStatementParser().Parse(PositionalResult(
+            "02/01/26SYNTHETIC710.00-02/02/26SECOND20.00-",
+            words.ToArray()));
+
+        Assert.True(result.IsSuccess);
+        var invalid = Assert.Single(result.Rows);
+        Assert.Equal(ImportedRowClassification.Invalid, invalid.Classification);
+        Assert.Contains("unsupported_transaction_row", invalid.Errors);
+    }
+
+    [Fact]
     public void Summary_headers_page_markers_balances_disclosures_and_no_checks_create_no_rows()
     {
         var result = new SunflowerStatementParser().Parse(Result(
@@ -316,6 +391,28 @@ public sealed class SunflowerStatementParserTests
             '\n',
             new[] { "SUNFLOWER BANK", statementDate, "Days in Statement Period: 28", "Electronic Transactions", "Posted Description Amount" }
                 .Concat(rows))));
+
+    private static PdfTextExtractionResult PositionalResult(
+        string compactRows,
+        params PdfExtractedWord[] words)
+    {
+        var text = "SUNFLOWER BANK\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\n" +
+                   "Electronic Transactions\nPosted Description Amount\n" + compactRows;
+        return new PdfTextExtractionResult(
+            0,
+            1,
+            text.Length,
+            new[] { new PdfExtractedPage(1, text, words) });
+    }
+
+    private static PdfExtractedWord PositionalWord(
+        int ordinal,
+        string text,
+        double left,
+        double right,
+        double baseline,
+        PdfWordOrientation orientation = PdfWordOrientation.Horizontal) =>
+        new(ordinal, text, left, baseline - .01, right, baseline + .01, baseline, orientation);
 
     private static SunflowerStatementParseResult ParseGeneratedRows(int count)
     {

--- a/backend/Import/ContainedPdfTextExtractor.cs
+++ b/backend/Import/ContainedPdfTextExtractor.cs
@@ -274,7 +274,7 @@ public sealed class ContainedPdfTextExtractor : IPdfTextExtractor
         stream.Close();
     }
 
-    private static async Task<byte[]> ReadBoundedAsync(Stream stream, int limit, CancellationToken token)
+    internal static async Task<byte[]> ReadBoundedAsync(Stream stream, int limit, CancellationToken token)
     {
         using var output = new MemoryStream(Math.Min(limit, 8192));
         var buffer = new byte[8192];
@@ -287,7 +287,7 @@ public sealed class ContainedPdfTextExtractor : IPdfTextExtractor
         }
     }
 
-    private static PdfTextExtractionOutcome ParseResponse(byte[] response, int expectedInputBytes)
+    internal static PdfTextExtractionOutcome ParseResponse(byte[] response, int expectedInputBytes)
     {
         if (response.Length < 6 || !response.AsSpan(0, 4).SequenceEqual(PdfWorkerProtocol.ResponseMagic) ||
             response[4] != PdfWorkerProtocol.Version)
@@ -325,17 +325,61 @@ public sealed class ContainedPdfTextExtractor : IPdfTextExtractor
             var pages = new List<PdfExtractedPage>(pageCount);
             var actualCharacters = 0;
             var actualUtf8Bytes = 0;
+            var actualLayoutWords = 0;
+            var actualLayoutCharacters = 0;
+            var actualLayoutUtf8Bytes = 0;
             for (var index = 0; index < pageCount; index++)
             {
                 var pageNumber = ReadInt32(response, ref offset);
                 var textLength = ReadInt32(response, ref offset);
-                if (pageNumber != index + 1 || textLength < 0 || offset + textLength > response.Length)
+                if (pageNumber != index + 1 || textLength < 0 || textLength > response.Length - offset)
                     throw new InvalidDataException();
                 var text = decoder.GetString(response, offset, textLength);
                 offset += textLength;
                 actualCharacters = checked(actualCharacters + text.Length);
                 actualUtf8Bytes = checked(actualUtf8Bytes + textLength);
-                pages.Add(new PdfExtractedPage(pageNumber, text));
+                var wordCount = ReadInt32(response, ref offset);
+                actualLayoutWords = checked(actualLayoutWords + wordCount);
+                if (wordCount < 0 || actualLayoutWords > PdfWorkerProtocol.MaxLayoutWords)
+                    throw new InvalidDataException();
+
+                var words = new List<PdfExtractedWord>(wordCount);
+                for (var wordIndex = 0; wordIndex < wordCount; wordIndex++)
+                {
+                    var ordinal = ReadInt32(response, ref offset);
+                    var wordLength = ReadInt32(response, ref offset);
+                    if (ordinal != wordIndex + 1 || wordLength <= 0 || wordLength > response.Length - offset)
+                        throw new InvalidDataException();
+                    var wordText = decoder.GetString(response, offset, wordLength);
+                    offset += wordLength;
+                    actualLayoutCharacters = checked(actualLayoutCharacters + wordText.Length);
+                    actualLayoutUtf8Bytes = checked(actualLayoutUtf8Bytes + wordLength);
+                    if (actualLayoutCharacters > PdfWorkerProtocol.MaxLayoutCharacters
+                        || actualLayoutUtf8Bytes > PdfWorkerProtocol.MaxLayoutUtf8Bytes)
+                        throw new InvalidDataException();
+
+                    var left = ReadCoordinate(response, ref offset);
+                    var bottom = ReadCoordinate(response, ref offset);
+                    var right = ReadCoordinate(response, ref offset);
+                    var top = ReadCoordinate(response, ref offset);
+                    var baseline = ReadCoordinate(response, ref offset);
+                    var orientationValue = ReadByte(response, ref offset);
+                    if (left > right || bottom > top
+                        || !Enum.IsDefined(typeof(PdfWordOrientation), orientationValue))
+                        throw new InvalidDataException();
+
+                    words.Add(new PdfExtractedWord(
+                        ordinal,
+                        wordText,
+                        left,
+                        bottom,
+                        right,
+                        top,
+                        baseline,
+                        (PdfWordOrientation)orientationValue));
+                }
+
+                pages.Add(new PdfExtractedPage(pageNumber, text, words));
             }
 
             if (offset != response.Length || actualCharacters != characterCount || actualUtf8Bytes > PdfWorkerProtocol.MaxUtf8Bytes)
@@ -354,6 +398,21 @@ public sealed class ContainedPdfTextExtractor : IPdfTextExtractor
         var value = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(offset, 4));
         offset += 4;
         return value;
+    }
+
+    private static double ReadCoordinate(byte[] bytes, ref int offset)
+    {
+        var value = ReadInt32(bytes, ref offset);
+        if (value < PdfWorkerProtocol.MinNormalizedCoordinate
+            || value > PdfWorkerProtocol.MaxNormalizedCoordinate)
+            throw new InvalidDataException();
+        return (double)value / PdfWorkerProtocol.CoordinateScale;
+    }
+
+    private static byte ReadByte(byte[] bytes, ref int offset)
+    {
+        if (offset >= bytes.Length) throw new InvalidDataException();
+        return bytes[offset++];
     }
 
     internal static async Task<bool> TerminateAndReapAsync(Process process)

--- a/backend/Import/PdfTextExtractionResult.cs
+++ b/backend/Import/PdfTextExtractionResult.cs
@@ -1,6 +1,32 @@
 namespace BudgetPlanner.Import;
 
-public sealed record PdfExtractedPage(int PageNumber, string Text);
+public enum PdfWordOrientation : byte
+{
+    Horizontal = 0,
+    Rotate180 = 1,
+    Rotate90 = 2,
+    Rotate270 = 3,
+    Other = 4
+}
+
+public sealed record PdfExtractedWord(
+    int Ordinal,
+    string Text,
+    double Left,
+    double Bottom,
+    double Right,
+    double Top,
+    double Baseline,
+    PdfWordOrientation Orientation);
+
+public sealed record PdfExtractedPage(
+    int PageNumber,
+    string Text,
+    IReadOnlyList<PdfExtractedWord> Words)
+{
+    public PdfExtractedPage(int pageNumber, string text)
+        : this(pageNumber, text, Array.Empty<PdfExtractedWord>()) { }
+}
 
 public sealed record PdfTextExtractionResult(
     int ByteCount,

--- a/backend/Import/PdfWorkerProtocol.cs
+++ b/backend/Import/PdfWorkerProtocol.cs
@@ -9,12 +9,18 @@ internal enum WorkerResultKind : byte
 
 internal static class PdfWorkerProtocol
 {
-    public const byte Version = 1;
+    public const byte Version = 2;
     public const int MaxInputBytes = 10 * 1024 * 1024;
     public const int MaxPages = 25;
     public const int MaxCharacters = 2_000_000;
     public const int MaxUtf8Bytes = 6_000_000;
-    public const int MaxResponseBytes = 6_001_024;
+    public const int MaxLayoutWords = 100_000;
+    public const int MaxLayoutCharacters = 2_000_000;
+    public const int MaxLayoutUtf8Bytes = 6_000_000;
+    public const int CoordinateScale = 1_000_000;
+    public const int MinNormalizedCoordinate = -50_000;
+    public const int MaxNormalizedCoordinate = 1_050_000;
+    public const int MaxResponseBytes = 15 * 1024 * 1024;
     public const int MaxErrorBytes = 4_096;
     public static ReadOnlySpan<byte> RequestMagic => "BPDF"u8;
     public static ReadOnlySpan<byte> ResponseMagic => "BPDR"u8;

--- a/backend/Import/Sunflower/SunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/SunflowerStatementParser.cs
@@ -62,6 +62,8 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
             string? pendingSection = null;
             PendingRow? pendingRow = null;
             var inUnsupportedCheckSection = false;
+            var positionalRows = TryGetPositionalElectronicRows(page, statementDate);
+            var positionalRowsConsumed = false;
 
             void FlushPending()
             {
@@ -157,6 +159,29 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 
                 if (LooksLikeTransactionStart(trimmed))
                 {
+                    if (!positionalRowsConsumed
+                        && section == ElectronicTransactionsSection
+                        && !sourceLine.Text.Any(char.IsWhiteSpace)
+                        && !TransactionRowRegex().IsMatch(trimmed)
+                        && positionalRows.Count > 0)
+                    {
+                        if (rows.Count + positionalRows.Count > MaximumCandidateRows)
+                        {
+                            return SunflowerStatementParseResult.Failed(
+                                SunflowerStatementParseFailure.CandidateRowLimitExceeded);
+                        }
+
+                        foreach (var positionalRow in positionalRows)
+                        {
+                            rows.Add(ParseRow(
+                                new PendingRow(page.PageNumber, section, positionalRow),
+                                statementDate,
+                                rows.Count + 1));
+                        }
+                        positionalRowsConsumed = true;
+                        continue;
+                    }
+
                     if (rows.Count >= MaximumCandidateRows)
                     {
                         return SunflowerStatementParseResult.Failed(
@@ -186,6 +211,243 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
             FlushPending();
         }
         return SunflowerStatementParseResult.Success(rows);
+    }
+
+    private static IReadOnlyList<string> TryGetPositionalElectronicRows(
+        PdfExtractedPage page,
+        DateOnly statementDate)
+    {
+        if (page.Words.Count == 0
+            || page.Words.Any(word => word.Orientation != PdfWordOrientation.Horizontal
+                || word.Ordinal <= 0
+                || string.IsNullOrEmpty(word.Text)
+                || !HasValidBox(word)))
+        {
+            return Array.Empty<string>();
+        }
+
+        var orderedWords = page.Words.OrderBy(word => word.Ordinal).ToList();
+        if (!orderedWords.Select(word => word.Ordinal).SequenceEqual(Enumerable.Range(1, orderedWords.Count)))
+        {
+            return Array.Empty<string>();
+        }
+
+        var medianHeight = Median(orderedWords.Select(word => word.Top - word.Bottom));
+        var characterWidths = orderedWords
+            .Where(word => word.Text.Length > 0)
+            .Select(word => (word.Right - word.Left) / word.Text.Length)
+            .Where(width => width > 0)
+            .ToList();
+        var medianCharacterWidth = Median(characterWidths);
+        if (medianHeight <= 0 || medianCharacterWidth <= 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var baselineTolerance = medianHeight * 0.45;
+        var lines = new List<PositionalLine>();
+        foreach (var word in orderedWords.OrderByDescending(word => word.Baseline).ThenBy(word => word.Left))
+        {
+            var line = lines
+                .Where(candidate => Math.Abs(candidate.Baseline - word.Baseline) <= baselineTolerance)
+                .OrderBy(candidate => Math.Abs(candidate.Baseline - word.Baseline))
+                .FirstOrDefault();
+            if (line is null)
+            {
+                lines.Add(new PositionalLine(word.Baseline, new List<PdfExtractedWord> { word }));
+            }
+            else
+            {
+                line.Words.Add(word);
+            }
+        }
+
+        lines = lines.OrderByDescending(line => line.Baseline).ToList();
+        foreach (var line in lines)
+        {
+            line.Words.Sort((left, right) => left.Left.CompareTo(right.Left));
+        }
+
+        var electronicHeadingIndex = lines.FindIndex(line =>
+            JoinedToken(line).Equals("ElectronicTransactions", StringComparison.OrdinalIgnoreCase));
+        var headerIndex = lines.FindIndex(
+            Math.Max(0, electronicHeadingIndex + 1),
+            line => JoinedToken(line).TrimStart('-')
+                .Equals("PostedDescriptionAmount", StringComparison.OrdinalIgnoreCase));
+        if (headerIndex < 0 || (electronicHeadingIndex >= 0 && headerIndex <= electronicHeadingIndex))
+        {
+            return Array.Empty<string>();
+        }
+
+        var headerLine = lines[headerIndex];
+        var postedHeaders = headerLine.Words
+            .Where(word => word.Text.Equals("Posted", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var descriptionHeaders = headerLine.Words
+            .Where(word => word.Text.Equals("Description", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var amountHeaders = headerLine.Words
+            .Where(word => word.Text.Equals("Amount", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (postedHeaders.Count != 1 || descriptionHeaders.Count != 1 || amountHeaders.Count != 1
+            || postedHeaders[0].Right > descriptionHeaders[0].Left
+            || descriptionHeaders[0].Right > amountHeaders[0].Left)
+        {
+            return Array.Empty<string>();
+        }
+
+        var candidates = new List<PositionalCandidate>();
+        var sawCandidate = false;
+        for (var lineIndex = headerIndex + 1; lineIndex < lines.Count; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var joined = JoinedToken(line);
+            if (IsLayoutTerminal(joined))
+            {
+                break;
+            }
+
+            var dateWords = line.Words.Where(word => TransactionDateRegex().IsMatch(word.Text)).ToList();
+            var amountCandidates = new List<PositionalAmount>();
+            for (var wordIndex = 0; wordIndex < line.Words.Count; wordIndex++)
+            {
+                var word = line.Words[wordIndex];
+                if (word.Text.EndsWith("-", StringComparison.Ordinal)
+                    && TryParseAmount(word.Text[..^1], out _))
+                {
+                    amountCandidates.Add(new PositionalAmount(word, null, word.Text));
+                    continue;
+                }
+
+                if (TryParseAmount(word.Text, out _)
+                    && wordIndex + 1 < line.Words.Count
+                    && line.Words[wordIndex + 1].Text == "-"
+                    && line.Words[wordIndex + 1].Left >= word.Right
+                    && line.Words[wordIndex + 1].Left - word.Right <= medianCharacterWidth * 2)
+                {
+                    amountCandidates.Add(new PositionalAmount(
+                        word,
+                        line.Words[wordIndex + 1],
+                        $"{word.Text}-"));
+                }
+            }
+
+            if (dateWords.Count == 0 && amountCandidates.Count == 0)
+            {
+                if (sawCandidate && !IsKnownLayoutContent(joined))
+                {
+                    return Array.Empty<string>();
+                }
+                continue;
+            }
+
+            sawCandidate = true;
+            if (dateWords.Count != 1 || amountCandidates.Count != 1)
+            {
+                return Array.Empty<string>();
+            }
+
+            var dateWord = dateWords[0];
+            var amount = amountCandidates[0];
+            var amountWord = amount.Word;
+            if (!TryResolveDate(dateWord.Text, statementDate, out _)
+                || dateWord.Right >= amountWord.Left)
+            {
+                return Array.Empty<string>();
+            }
+
+            var descriptionWords = line.Words
+                .Where(word => word.Left >= dateWord.Right && word.Right <= amountWord.Left)
+                .ToList();
+            if (descriptionWords.Count == 0
+                || line.Words.Any(word => word != dateWord
+                    && word != amountWord
+                    && word != amount.Marker
+                    && !descriptionWords.Contains(word)))
+            {
+                return Array.Empty<string>();
+            }
+
+            var lastDescription = descriptionWords[^1];
+            if (lastDescription.Right >= amountWord.Left
+                || line.Words.Max(word => word.Baseline) - line.Words.Min(word => word.Baseline) > baselineTolerance)
+            {
+                return Array.Empty<string>();
+            }
+
+            candidates.Add(new PositionalCandidate(
+                dateWord,
+                descriptionWords,
+                amount,
+                amountWord.Left - lastDescription.Right));
+        }
+
+        if (candidates.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var dateColumn = Median(candidates.Select(candidate => candidate.Date.Left));
+        var amountColumn = Median(candidates.Select(candidate => candidate.Amount.Right));
+        var columnTolerance = medianCharacterWidth * 2;
+        var headerTolerance = medianCharacterWidth * 4;
+        if (candidates.Any(candidate =>
+                Math.Abs(candidate.Date.Left - dateColumn) > columnTolerance
+                || Math.Abs(candidate.Amount.Right - amountColumn) > columnTolerance
+                || candidate.DescriptionAmountGap < medianCharacterWidth)
+            || Math.Abs(postedHeaders[0].Left - dateColumn) > headerTolerance
+            || Math.Abs(amountHeaders[0].Right - amountColumn) > headerTolerance)
+        {
+            return Array.Empty<string>();
+        }
+
+        return candidates.Select(candidate =>
+            $"{candidate.Date.Text} {string.Join(' ', candidate.Description.Select(word => word.Text))} {candidate.Amount.CanonicalText}")
+            .ToList();
+    }
+
+    private static bool HasValidBox(PdfExtractedWord word) =>
+        double.IsFinite(word.Left)
+        && double.IsFinite(word.Bottom)
+        && double.IsFinite(word.Right)
+        && double.IsFinite(word.Top)
+        && double.IsFinite(word.Baseline)
+        && word.Left >= -0.05
+        && word.Right <= 1.05
+        && word.Bottom >= -0.05
+        && word.Top <= 1.05
+        && word.Baseline >= -0.05
+        && word.Baseline <= 1.05
+        && word.Left <= word.Right
+        && word.Bottom <= word.Top;
+
+    private static string JoinedToken(PositionalLine line) =>
+        string.Concat(line.Words.Select(word => word.Text));
+
+    private static bool IsLayoutTerminal(string joined) =>
+        joined.StartsWith("Page", StringComparison.OrdinalIgnoreCase)
+        || joined.Equals("DailyBalanceSummary", StringComparison.OrdinalIgnoreCase)
+        || joined.Equals("ImportantAccountInformation", StringComparison.OrdinalIgnoreCase)
+        || joined.Equals("AccountSummary", StringComparison.OrdinalIgnoreCase)
+        || joined.Equals("TransactionSummary", StringComparison.OrdinalIgnoreCase)
+        || joined.StartsWith("ChecksPaid", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsKnownLayoutContent(string joined) =>
+        joined.StartsWith("Total", StringComparison.OrdinalIgnoreCase)
+        || StatementDateRegex().IsMatch(joined)
+        || DaysInStatementPeriodRegex().IsMatch(joined);
+
+    private static double Median(IEnumerable<double> values)
+    {
+        var ordered = values.Where(double.IsFinite).OrderBy(value => value).ToList();
+        if (ordered.Count == 0)
+        {
+            return 0;
+        }
+        var middle = ordered.Count / 2;
+        return ordered.Count % 2 == 0
+            ? (ordered[middle - 1] + ordered[middle]) / 2
+            : ordered[middle];
     }
 
     private static NormalizedImportedRow ParseRow(PendingRow pending, DateOnly statementDate, int ordinal)
@@ -457,6 +719,22 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
         public string Section { get; } = section;
         public string SourceLine { get; } = sourceLine;
         public List<string> DescriptionContinuation { get; } = new();
+    }
+
+    private sealed record PositionalLine(double Baseline, List<PdfExtractedWord> Words);
+
+    private sealed record PositionalCandidate(
+        PdfExtractedWord Date,
+        IReadOnlyList<PdfExtractedWord> Description,
+        PositionalAmount Amount,
+        double DescriptionAmountGap);
+
+    private sealed record PositionalAmount(
+        PdfExtractedWord Word,
+        PdfExtractedWord? Marker,
+        string CanonicalText)
+    {
+        public double Right => Marker?.Right ?? Word.Right;
     }
 
     [GeneratedRegex(@"(?<![A-Za-z])STATEMENT\s*DATE\s*:\s*(?<date>\d{2}/\d{2}/\d{2})(?![\d/])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]


### PR DESCRIPTION
## Summary
- bump the private contained PDF worker protocol to v2 and supplement existing page text with bounded normalized word layout metadata
- parse compact Sunflower electronic rows from deterministic date/description/amount geometry while preserving existing financial semantics and fail-closed behavior
- add sanitized protocol adversarial, positional parser, contained extractor, and authenticated preview API coverage

Refs #70

## Risk
HIGH — approved in issue comment #5371282670 for the bounded plan in #5371257942. No schema, migration, dependency, frontend, authentication/ownership, Expense persistence, configuration, or production-operation changes.

## Verification
- `dotnet restore backend.Tests/backend.Tests.csproj`
- `dotnet build backend/backend.csproj --configuration Release --no-restore`
- `dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-restore --filter "Category!=PostgreSQL"` — 210 passed
- focused protocol-v2/positional/API tests
- private aggregate-only contained worker -> parser -> authenticated preview check — extraction/API success, 7 pages, 44 rows, 40 expense candidates, 4 invalid rows, unsupported-row presence reported, 1 preview batch, 0 Expense writes
- temporary Release publish plus packaged worker artifact and 6-byte smoke-frame verification
- production Docker image build, contained-worker smoke test, entrypoint verification, and isolated CI-configured container startup
- `git diff --check`

PostgreSQL behavior is unchanged; the required PostgreSQL integration lane passed in CI.

## Scope boundaries
No merge, deployment/redeployment, production access, migration/schema operation, confirmation work, Expense persistence, issue closure, or changes to the unrelated untracked `debug/` directory were performed.