### PR TITLE
Fix parser-version-compatible import preview reuse

### DIFF
--- a/backend.Tests/Financial/FinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/FinancialApiTestApplication.cs
@@ -1,7 +1,10 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using System.Text.Json;
 using BudgetPlanner.Data;
+using BudgetPlanner.Import;
+using BudgetPlanner.Import.Sunflower;
 using BudgetPlanner.Models;
 using BudgetPlanner.Services;
 using Microsoft.AspNetCore.Hosting;
@@ -172,6 +175,60 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
         using var scope = Services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
         return await context.ImportPreviewBatches.CountAsync(value => value.OwnerId == userId);
+    }
+
+    public async Task<ImportPreviewBatch> SeedImportPreviewBatchAsync(
+        string userId,
+        byte[] pdf,
+        string parserRuleVersion,
+        DateTime? createdAt = null)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var created = createdAt ?? DateTime.UtcNow;
+        var batch = new ImportPreviewBatch
+        {
+            Id = Guid.NewGuid(),
+            OwnerId = userId,
+            SourceType = SunflowerStatementParser.SourceType,
+            ParserRuleVersion = parserRuleVersion,
+            DocumentDigest = SHA256.HashData(pdf),
+            CreatedAt = created,
+            ExpiresAt = created.AddHours(24),
+            Lifecycle = ImportPreviewLifecycle.Open,
+            Rows =
+            [
+                new ImportPreviewRow
+                {
+                    Id = Guid.NewGuid(),
+                    SourceRowOrdinal = 1,
+                    Direction = ImportedTransactionDirection.Unresolved,
+                    SourceDescription = "STALE SYNTHETIC ROW",
+                    SourceSection = "electronic_transactions",
+                    SourcePageNumber = 1,
+                    Classification = ImportedRowClassification.Invalid,
+                    IsEligible = false,
+                    ValidationErrorCodes = "[\"unsupported_transaction_row\"]",
+                    WarningCodes = "[]",
+                    DuplicateExpenseIds = "[]",
+                    SelectedForImport = false
+                }
+            ]
+        };
+        context.ImportPreviewBatches.Add(batch);
+        await context.SaveChangesAsync();
+        return batch;
+    }
+
+    public async Task<IReadOnlyList<ImportPreviewBatch>> FindImportPreviewBatchesAsync(string userId)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return await context.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Where(value => value.OwnerId == userId)
+            .OrderBy(value => value.CreatedAt)
+            .ToListAsync();
     }
 
     public async Task<IReadOnlyList<BudgetLimit>> FindBudgetLimitsAsync(

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using BudgetPlanner.Data;
+using BudgetPlanner.Import.Sunflower;
+using BudgetPlanner.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -181,6 +183,104 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Equal(32, batch.DocumentDigest.Length);
         Assert.Equal(13, batch.Rows.Count);
         Assert.False(await context.Expenses.AnyAsync());
+
+        var indexDefinition = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT indexdef AS "Value"
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = 'IX_ImportPreviewBatches_OwnerId_SourceType_DocumentDigest'
+            """).SingleAsync();
+        Assert.Contains("\"OwnerId\", \"SourceType\", \"DocumentDigest\"", indexDefinition);
+        Assert.Contains("WHERE", indexDefinition);
+        Assert.Contains("\"Lifecycle\"", indexDefinition);
+        Assert.Contains("'Open'", indexDefinition);
+        Assert.DoesNotContain("ParserRuleVersion", indexDefinition);
+    }
+
+    [PostgreSqlFact]
+    public async Task Concurrent_version_replacements_resolve_to_one_current_open_batch()
+    {
+        await using var app = new PostgreSqlConcurrentImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-preview-race@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var predecessor = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
+
+        async Task<ImportPreviewOperation> CreateAsync()
+        {
+            using var scope = app.Services.CreateScope();
+            var service = scope.ServiceProvider.GetRequiredService<IImportPreviewService>();
+            await using var stream = new MemoryStream(pdf, writable: false);
+            return await service.CreateSunflowerAsync(owner.Id, stream, pdf.Length, CancellationToken.None);
+        }
+
+        var firstTask = CreateAsync();
+        var secondTask = CreateAsync();
+        var results = await Task.WhenAll(firstTask, secondTask);
+
+        Assert.All(results, result => Assert.True(result.IsSuccess));
+        Assert.Single(results, result => result.Reused);
+        Assert.Single(results, result => !result.Reused);
+        var firstPreview = results[0].Preview!;
+        var secondPreview = results[1].Preview!;
+        Assert.Equal(firstPreview.BatchId, secondPreview.BatchId);
+        Assert.Equal("sunflower-v2", firstPreview.ParserRuleVersion);
+
+        var batches = await app.FindImportPreviewBatchesAsync(owner.Id);
+        Assert.Equal(2, batches.Count);
+        var stale = Assert.Single(batches, value => value.Id == predecessor.Id);
+        Assert.Equal(ImportPreviewLifecycle.Expired, stale.Lifecycle);
+        Assert.Equal("sunflower-v1", stale.ParserRuleVersion);
+        var current = Assert.Single(batches, value => value.ParserRuleVersion == "sunflower-v2");
+        Assert.Equal(ImportPreviewLifecycle.Open, current.Lifecycle);
+        Assert.Equal(firstPreview.BatchId, current.Id);
+        Assert.Equal(2, app.Extractor.CallCount);
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Failed_replacement_insert_rolls_back_predecessor_supersession()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-preview-rollback@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var predecessor = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
+
+        using (var setupScope = app.Services.CreateScope())
+        {
+            var setupContext = setupScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await setupContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE FUNCTION reject_current_parser_preview() RETURNS trigger
+                LANGUAGE plpgsql AS $function$
+                BEGIN
+                    IF NEW."ParserRuleVersion" = 'sunflower-v2' THEN
+                        RAISE EXCEPTION 'intentional disposable-test insert rejection';
+                    END IF;
+                    RETURN NEW;
+                END;
+                $function$;
+
+                CREATE TRIGGER reject_current_parser_preview_insert
+                BEFORE INSERT ON "ImportPreviewBatches"
+                FOR EACH ROW EXECUTE FUNCTION reject_current_parser_preview();
+                """);
+        }
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var service = scope.ServiceProvider.GetRequiredService<IImportPreviewService>();
+            await using var stream = new MemoryStream(pdf, writable: false);
+            await Assert.ThrowsAsync<DbUpdateException>(() =>
+                service.CreateSunflowerAsync(owner.Id, stream, pdf.Length, CancellationToken.None));
+        }
+
+        var batches = await app.FindImportPreviewBatchesAsync(owner.Id);
+        var preserved = Assert.Single(batches);
+        Assert.Equal(predecessor.Id, preserved.Id);
+        Assert.Equal(ImportPreviewLifecycle.Open, preserved.Lifecycle);
+        Assert.Equal("sunflower-v1", preserved.ParserRuleVersion);
+        Assert.Equal(0, await app.CountExpensesAsync());
     }
 
     [PostgreSqlFact]
@@ -237,6 +337,43 @@ internal sealed class PostgreSqlImportPreviewTestApplication : PostgreSqlFinanci
     {
         services.RemoveAll<IPdfTextExtractor>();
         services.AddSingleton<IPdfTextExtractor, BudgetPlanner.Tests.Import.ImmediateSyntheticExtractor>();
+    }
+}
+
+internal sealed class PostgreSqlConcurrentImportPreviewTestApplication : PostgreSqlFinancialApiTestApplication
+{
+    public CoordinatedSyntheticExtractor Extractor =>
+        Services.GetRequiredService<CoordinatedSyntheticExtractor>();
+
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<IPdfTextExtractor>();
+        services.AddSingleton<CoordinatedSyntheticExtractor>();
+        services.AddSingleton<IPdfTextExtractor>(provider =>
+            provider.GetRequiredService<CoordinatedSyntheticExtractor>());
+    }
+}
+
+internal sealed class CoordinatedSyntheticExtractor : IPdfTextExtractor
+{
+    private readonly TaskCompletionSource _bothCallersReady =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly BudgetPlanner.Tests.Import.ImmediateSyntheticExtractor _inner = new();
+    private int _callCount;
+
+    public int CallCount => Volatile.Read(ref _callCount);
+
+    public async Task<PdfTextExtractionOutcome> ExtractAsync(
+        ReadOnlyMemory<byte> pdf,
+        CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Increment(ref _callCount) == 2)
+        {
+            _bothCallersReady.TrySetResult();
+        }
+
+        await _bothCallersReady.Task.WaitAsync(cancellationToken);
+        return await _inner.ExtractAsync(pdf, cancellationToken);
     }
 }
 

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -5,6 +5,7 @@ using BudgetPlanner.Tests.Financial;
 using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
 using BudgetPlanner.Import;
 using BudgetPlanner.Import.Sunflower;
+using BudgetPlanner.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
@@ -76,9 +77,111 @@ public sealed class ImportPreviewApiTests
 
         Assert.Equal(HttpStatusCode.Created, first.StatusCode);
         Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("sunflower-v2", firstBody.GetProperty("parserRuleVersion").GetString());
+        Assert.Equal("sunflower-v2", secondBody.GetProperty("parserRuleVersion").GetString());
         Assert.Equal(firstBody.GetProperty("batchId").GetGuid(), secondBody.GetProperty("batchId").GetGuid());
         Assert.Equal(firstBody.GetProperty("batchId").GetGuid(), resumed.GetProperty("batchId").GetGuid());
         Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(1, ((ImmediateSyntheticExtractor)app.Services
+            .GetRequiredService<IPdfTextExtractor>()).CallCount);
+    }
+
+    [Fact]
+    public async Task Incompatible_preview_is_hidden_then_atomically_superseded_after_successful_reparse()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-version-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("preview-version-other@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var stale = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
+        var otherStale = await app.SeedImportPreviewBatchAsync(other.Id, pdf, "sunflower-v1");
+
+        var staleRead = await owner.Client.GetAsync($"/api/import-previews/{stale.Id}");
+        var staleResume = await owner.Client.GetAsync("/api/import-previews/open?sourceType=sunflower_pdf");
+        var staleUpdate = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{stale.Id}/rows/{stale.Rows.Single().Id}",
+            new { editableExpenseDescription = "changed", category = "food", selectedForImport = false });
+        var crossUserRead = await other.Client.GetAsync($"/api/import-previews/{stale.Id}");
+        using var content = PdfUpload(pdf);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var replacement = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var resumed = await owner.Client.GetFromJsonAsync<JsonElement>(
+            "/api/import-previews/open?sourceType=sunflower_pdf");
+
+        Assert.Equal(HttpStatusCode.NotFound, staleRead.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, staleResume.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, staleUpdate.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, crossUserRead.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotEqual(stale.Id, replacement.GetProperty("batchId").GetGuid());
+        Assert.Equal("sunflower-v2", replacement.GetProperty("parserRuleVersion").GetString());
+        Assert.Equal(13, replacement.GetProperty("rows").GetArrayLength());
+        Assert.DoesNotContain(
+            replacement.GetProperty("rows").EnumerateArray(),
+            row => row.GetProperty("sourceDescription").GetString() == "STALE SYNTHETIC ROW");
+        Assert.Equal(replacement.GetProperty("batchId").GetGuid(), resumed.GetProperty("batchId").GetGuid());
+
+        var ownerBatches = await app.FindImportPreviewBatchesAsync(owner.Id);
+        Assert.Collection(
+            ownerBatches,
+            predecessor =>
+            {
+                Assert.Equal(stale.Id, predecessor.Id);
+                Assert.Equal(ImportPreviewLifecycle.Expired, predecessor.Lifecycle);
+                Assert.Equal("sunflower-v1", predecessor.ParserRuleVersion);
+            },
+            current =>
+            {
+                Assert.Equal(ImportPreviewLifecycle.Open, current.Lifecycle);
+                Assert.Equal("sunflower-v2", current.ParserRuleVersion);
+            });
+        var preservedOther = Assert.Single(await app.FindImportPreviewBatchesAsync(other.Id));
+        Assert.Equal(otherStale.Id, preservedOther.Id);
+        Assert.Equal(ImportPreviewLifecycle.Open, preservedOther.Lifecycle);
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Failed_reparse_does_not_supersede_incompatible_preview_or_write_expenses()
+    {
+        await using var app = new RejectingParserFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-version-failure@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var stale = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
+        using var content = PdfUpload(pdf);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        Assert.Equal("unsupported_statement_format", error.GetProperty("code").GetString());
+        var preserved = Assert.Single(await app.FindImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(stale.Id, preserved.Id);
+        Assert.Equal(ImportPreviewLifecycle.Open, preserved.Lifecycle);
+        Assert.Equal("sunflower-v1", preserved.ParserRuleVersion);
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Timed_out_reparse_does_not_supersede_incompatible_preview_or_write_expenses()
+    {
+        await using var app = new BlockingParserFinancialApiTestApplication(TimeSpan.FromMilliseconds(50));
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-version-timeout@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var stale = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
+        using var content = PdfUpload(pdf);
+
+        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.RequestTimeout, response.StatusCode);
+        Assert.Equal("processing_timed_out", error.GetProperty("code").GetString());
+        var preserved = Assert.Single(await app.FindImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(stale.Id, preserved.Id);
+        Assert.Equal(ImportPreviewLifecycle.Open, preserved.Lifecycle);
+        Assert.Equal("sunflower-v1", preserved.ParserRuleVersion);
+        Assert.Equal(0, await app.CountExpensesAsync());
     }
 
     [Fact]
@@ -422,8 +525,13 @@ internal sealed class SyntheticExtractionFinancialApiTestApplication : Financial
 
 internal sealed class ImmediateSyntheticExtractor : IPdfTextExtractor
 {
+    private int _callCount;
+
+    public int CallCount => Volatile.Read(ref _callCount);
+
     public Task<PdfTextExtractionOutcome> ExtractAsync(ReadOnlyMemory<byte> pdf, CancellationToken cancellationToken = default)
     {
+        Interlocked.Increment(ref _callCount);
         cancellationToken.ThrowIfCancellationRequested();
         var pages = SunflowerFixtureCorpus.RepresentativePages
             .Select((page, index) => new PdfExtractedPage(index + 1, string.Join('\n', page.Lines)))
@@ -443,6 +551,28 @@ internal sealed class BlockingParserFinancialApiTestApplication(TimeSpan timeout
         services.AddSingleton<ISunflowerStatementParser, BlockingSunflowerParser>();
         services.RemoveAll<ImportPreviewProcessingOptions>();
         services.AddSingleton(new ImportPreviewProcessingOptions { Timeout = timeout });
+    }
+}
+
+internal sealed class RejectingParserFinancialApiTestApplication : FinancialApiTestApplication
+{
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<IPdfTextExtractor>();
+        services.AddSingleton<IPdfTextExtractor, ImmediateSyntheticExtractor>();
+        services.RemoveAll<ISunflowerStatementParser>();
+        services.AddSingleton<ISunflowerStatementParser, RejectingSunflowerParser>();
+    }
+}
+
+internal sealed class RejectingSunflowerParser : ISunflowerStatementParser
+{
+    public SunflowerStatementParseResult Parse(
+        PdfTextExtractionResult extraction,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedFormat);
     }
 }
 

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -5,6 +5,8 @@ using BudgetPlanner.Data;
 using BudgetPlanner.Import.Sunflower;
 using BudgetPlanner.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
 
 namespace BudgetPlanner.Import;
 
@@ -38,6 +40,8 @@ public sealed class ImportPreviewService(
 {
     public const int MaximumUploadBytes = 10 * 1024 * 1024;
     private static readonly TimeSpan PreviewLifetime = TimeSpan.FromHours(24);
+    private const string OpenDigestIndexName =
+        "IX_ImportPreviewBatches_OwnerId_SourceType_DocumentDigest";
 
     public async Task<ImportPreviewOperation> CreateSunflowerAsync(
         string userId, Stream file, long? declaredLength, CancellationToken cancellationToken)
@@ -78,8 +82,12 @@ public sealed class ImportPreviewService(
             processingCts.CancelAfter(processingOptions.Timeout);
             var processingToken = processingCts.Token;
 
-            var existing = await FindOpenByDigestAsync(
-                userId, SunflowerStatementParser.SourceType, digest, processingToken);
+            var existing = await FindCompatibleOpenByDigestAsync(
+                userId,
+                SunflowerStatementParser.SourceType,
+                SunflowerStatementParser.RuleVersion,
+                digest,
+                processingToken);
             if (existing is not null)
                 return new(ToResponse(existing), null, true);
 
@@ -187,28 +195,17 @@ public sealed class ImportPreviewService(
             });
         }
 
-        context.ImportPreviewBatches.Add(batch);
-        try
-        {
-            await context.SaveChangesAsync(cancellationToken);
-        }
-        catch (DbUpdateException)
-        {
-            context.Entry(batch).State = EntityState.Detached;
-            var winner = await FindOpenByDigestAsync(userId, SunflowerStatementParser.SourceType, digest, cancellationToken);
-            if (winner is null) throw;
-            return new(ToResponse(winner), null, true);
-        }
+        var persisted = await PersistOrReuseAsync(batch, cancellationToken);
 
         await CleanupExpiredAsync(now, cancellationToken);
-        return new(ToResponse(batch), null);
+        return persisted;
     }
 
     public async Task<ImportPreviewResponse?> GetOpenAsync(string userId, string sourceType, CancellationToken cancellationToken)
     {
         if (sourceType != SunflowerStatementParser.SourceType) return null;
         await ExpireOwnedAsync(userId, cancellationToken);
-        var batch = await OwnedOpenQuery(userId).Where(value => value.SourceType == sourceType)
+        var batch = await OwnedCompatibleOpenQuery(userId).Where(value => value.SourceType == sourceType)
             .OrderByDescending(value => value.CreatedAt).FirstOrDefaultAsync(cancellationToken);
         return batch is null ? null : ToResponse(batch);
     }
@@ -216,7 +213,8 @@ public sealed class ImportPreviewService(
     public async Task<ImportPreviewResponse?> GetAsync(string userId, Guid batchId, CancellationToken cancellationToken)
     {
         await ExpireOwnedAsync(userId, cancellationToken);
-        var batch = await OwnedOpenQuery(userId).SingleOrDefaultAsync(value => value.Id == batchId, cancellationToken);
+        var batch = await OwnedCompatibleOpenQuery(userId)
+            .SingleOrDefaultAsync(value => value.Id == batchId, cancellationToken);
         return batch is null ? null : ToResponse(batch);
     }
 
@@ -224,7 +222,11 @@ public sealed class ImportPreviewService(
     {
         await ExpireOwnedAsync(userId, cancellationToken);
         var batch = await context.ImportPreviewBatches.Include(value => value.Rows)
-            .Where(value => value.OwnerId == userId && value.Id == batchId && value.Lifecycle == ImportPreviewLifecycle.Open)
+            .Where(value => value.OwnerId == userId
+                && value.Id == batchId
+                && value.SourceType == SunflowerStatementParser.SourceType
+                && value.ParserRuleVersion == SunflowerStatementParser.RuleVersion
+                && value.Lifecycle == ImportPreviewLifecycle.Open)
             .SingleOrDefaultAsync(cancellationToken);
         var row = batch?.Rows.SingleOrDefault(value => value.Id == rowId);
         if (batch is null || row is null) return Failed("preview_not_found", "The preview is unavailable.");
@@ -253,12 +255,122 @@ public sealed class ImportPreviewService(
         .AsNoTracking().Include(value => value.Rows)
         .Where(value => value.OwnerId == userId && value.Lifecycle == ImportPreviewLifecycle.Open);
 
-    private async Task<ImportPreviewBatch?> FindOpenByDigestAsync(string userId, string sourceType, byte[] digest, CancellationToken cancellationToken)
+    private IQueryable<ImportPreviewBatch> OwnedCompatibleOpenQuery(string userId) =>
+        OwnedOpenQuery(userId).Where(value =>
+            value.SourceType == SunflowerStatementParser.SourceType
+            && value.ParserRuleVersion == SunflowerStatementParser.RuleVersion);
+
+    private async Task<ImportPreviewBatch?> FindCompatibleOpenByDigestAsync(
+        string userId,
+        string sourceType,
+        string parserRuleVersion,
+        byte[] digest,
+        CancellationToken cancellationToken)
     {
         await ExpireOwnedAsync(userId, cancellationToken);
-        var candidates = await OwnedOpenQuery(userId).Where(value => value.SourceType == sourceType).ToListAsync(cancellationToken);
+        var candidates = await OwnedOpenQuery(userId)
+            .Where(value => value.SourceType == sourceType
+                && value.ParserRuleVersion == parserRuleVersion)
+            .ToListAsync(cancellationToken);
         return candidates.SingleOrDefault(value => CryptographicOperations.FixedTimeEquals(value.DocumentDigest, digest));
     }
+
+    private async Task<ImportPreviewOperation> PersistOrReuseAsync(
+        ImportPreviewBatch batch,
+        CancellationToken cancellationToken)
+    {
+        IDbContextTransaction? transaction = null;
+        try
+        {
+            if (context.Database.IsRelational())
+            {
+                transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+            }
+
+            var winner = await FindCompatibleOpenByDigestAsync(
+                batch.OwnerId,
+                batch.SourceType,
+                batch.ParserRuleVersion,
+                batch.DocumentDigest,
+                cancellationToken);
+            if (winner is not null)
+            {
+                return new(ToResponse(winner), null, true);
+            }
+
+            var predecessor = await FindTrackedOpenByDigestAsync(
+                batch.OwnerId,
+                batch.SourceType,
+                batch.DocumentDigest,
+                cancellationToken);
+            if (predecessor is not null)
+            {
+                predecessor.Lifecycle = ImportPreviewLifecycle.Expired;
+                if (transaction is not null)
+                {
+                    await context.SaveChangesAsync(cancellationToken);
+                }
+            }
+
+            context.ImportPreviewBatches.Add(batch);
+            await context.SaveChangesAsync(cancellationToken);
+            if (transaction is not null)
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
+            return new(ToResponse(batch), null);
+        }
+        catch (DbUpdateException exception) when (IsOpenDigestUniqueViolation(exception))
+        {
+            if (transaction is not null)
+            {
+                await transaction.RollbackAsync(CancellationToken.None);
+                await transaction.DisposeAsync();
+                transaction = null;
+            }
+            context.ChangeTracker.Clear();
+            var winner = await FindCompatibleOpenByDigestAsync(
+                batch.OwnerId,
+                batch.SourceType,
+                batch.ParserRuleVersion,
+                batch.DocumentDigest,
+                cancellationToken);
+            if (winner is null)
+            {
+                throw;
+            }
+            return new(ToResponse(winner), null, true);
+        }
+        finally
+        {
+            if (transaction is not null)
+            {
+                await transaction.DisposeAsync();
+            }
+        }
+    }
+
+    private async Task<ImportPreviewBatch?> FindTrackedOpenByDigestAsync(
+        string userId,
+        string sourceType,
+        byte[] digest,
+        CancellationToken cancellationToken)
+    {
+        var candidates = await context.ImportPreviewBatches
+            .Where(value => value.OwnerId == userId
+                && value.SourceType == sourceType
+                && value.Lifecycle == ImportPreviewLifecycle.Open)
+            .ToListAsync(cancellationToken);
+        return candidates.SingleOrDefault(value =>
+            CryptographicOperations.FixedTimeEquals(value.DocumentDigest, digest));
+    }
+
+    private static bool IsOpenDigestUniqueViolation(DbUpdateException exception) =>
+        exception.InnerException is PostgresException
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            ConstraintName: OpenDigestIndexName
+        };
 
     private async Task ExpireOwnedAsync(string userId, CancellationToken cancellationToken)
     {

--- a/backend/Import/Sunflower/SunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/SunflowerStatementParser.cs
@@ -6,7 +6,7 @@ namespace BudgetPlanner.Import.Sunflower;
 public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 {
     public const string SourceType = "sunflower_pdf";
-    public const string RuleVersion = "sunflower-v1";
+    public const string RuleVersion = "sunflower-v2";
     public const int MaximumCandidateRows = 1_000;
 
     private const string DepositsSection = "deposits";

--- a/docs/import-pipeline.md
+++ b/docs/import-pipeline.md
@@ -127,10 +127,17 @@ During bounded processing, compute a SHA-256 digest of the uploaded PDF bytes. A
 
 The digest is used only as an exact-document identity aid; it does not replace structural PDF validation and must not be logged.
 
-For the same authenticated user and source type:
+For the same authenticated user, source type, and parser/rule version:
 
 - if an unexpired open preview exists for the same digest, reuse/return that batch rather than creating a second independent preview; and
 - if that statement was already confirmed, report it as already imported and do not create duplicate expenses by default.
+
+An open preview produced by an incompatible parser/rule version must not be
+resumed, mutated, or reused as current financial interpretation. A successful
+re-upload may atomically supersede that exact owned/source/digest predecessor
+with a current-version preview. The predecessor must remain unchanged if fresh
+extraction or parsing fails, and no cross-user preview may participate in the
+replacement decision.
 
 ## Row-level duplicate policy
 


### PR DESCRIPTION
## Summary

- bump Sunflower preview provenance to `sunflower-v2`
- require current parser-version compatibility for reuse, resume, direct reads, and row mutation
- reparse incompatible same-digest previews before atomically expiring the exact owned predecessor and inserting the replacement
- retain the existing partial unique index as the PostgreSQL race guard and only recover its specific unique-key conflict
- document the parser-version-compatible reuse contract

Relates to #70. This draft PR intentionally does not close the issue.

## Risk classification

HIGH — import preview lifecycle correctness affects temporary financial interpretation. Implementation follows approved issue plan comment #5372271064 and approval comment #5372914979.

## Verification

Passed locally:

- `dotnet restore backend.Tests/backend.Tests.csproj`
- `dotnet build backend/backend.csproj --configuration Release --no-restore` (0 errors; existing local NuGet cache timeout warnings)
- focused API/version/fail-closed tests: 4 passed
- full non-PostgreSQL backend suite: 213 passed
- focused PostgreSQL concurrency/rollback tests: 2 passed
- PostgreSQL non-migration integration lane: 7 passed
- private contained-worker aggregate-only replacement check: fresh v2 preview, 44 rows (40 candidates, 4 invalid), stale preview hidden/superseded, one current batch, zero Expenses
- `git diff --check`

Passed in independent PR CI:

- Backend build and tests
- PostgreSQL financial integration, including migration-chain evidence
- Frontend test, lint, and build
- Vercel preview checks

The local migration-chain invocation was blocked by the no-schema-operation safety boundary and was proven by the green PostgreSQL CI lane. A local unchanged-frontend verify attempt stalled in the Desktop-backed filesystem; the corresponding CI lane passed.

## Scope boundaries and impact

- no EF model, migration, schema, or index change
- no API payload shape change; fresh replacement remains 201, compatible reuse 200, unavailable/incompatible reads 404/204
- no parser geometry, classification, duplicate, selection, authentication, or Expense persistence change
- no dependency or configuration change
- no production access, deployment, migration, confirmation, merge, or issue closure performed
- `debug/` was not modified