### PR TITLE
Require explicit statement source and support Sunflower layouts

### DIFF
--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -166,9 +166,10 @@ public sealed class PostgreSqlFinancialApiTests
         await using var app = new PostgreSqlImportPreviewTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("postgres-preview@example.com");
         using var upload = new MultipartFormDataContent();
+        upload.Add(new StringContent(SunflowerStatementParser.SourceType), "sourceType");
         upload.Add(new ByteArrayContent(SunflowerFixtureCorpus.CreateRepresentativePdf()), "file", "synthetic.pdf");
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", upload);
+        var response = await owner.Client.PostAsync("/api/import-previews", upload);
         var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.True(
@@ -211,7 +212,7 @@ public sealed class PostgreSqlFinancialApiTests
             using var scope = app.Services.CreateScope();
             var service = scope.ServiceProvider.GetRequiredService<IImportPreviewService>();
             await using var stream = new MemoryStream(pdf, writable: false);
-            return await service.CreateSunflowerAsync(owner.Id, stream, pdf.Length, CancellationToken.None);
+            return await service.CreateAsync(owner.Id, SunflowerStatementParser.SourceType, stream, pdf.Length, CancellationToken.None);
         }
 
         var firstTask = CreateAsync();
@@ -224,14 +225,14 @@ public sealed class PostgreSqlFinancialApiTests
         var firstPreview = results[0].Preview!;
         var secondPreview = results[1].Preview!;
         Assert.Equal(firstPreview.BatchId, secondPreview.BatchId);
-        Assert.Equal("sunflower-v2", firstPreview.ParserRuleVersion);
+        Assert.Equal("sunflower-v3", firstPreview.ParserRuleVersion);
 
         var batches = await app.FindImportPreviewBatchesAsync(owner.Id);
         Assert.Equal(2, batches.Count);
         var stale = Assert.Single(batches, value => value.Id == predecessor.Id);
         Assert.Equal(ImportPreviewLifecycle.Expired, stale.Lifecycle);
         Assert.Equal("sunflower-v1", stale.ParserRuleVersion);
-        var current = Assert.Single(batches, value => value.ParserRuleVersion == "sunflower-v2");
+        var current = Assert.Single(batches, value => value.ParserRuleVersion == "sunflower-v3");
         Assert.Equal(ImportPreviewLifecycle.Open, current.Lifecycle);
         Assert.Equal(firstPreview.BatchId, current.Id);
         Assert.Equal(2, app.Extractor.CallCount);
@@ -254,7 +255,7 @@ public sealed class PostgreSqlFinancialApiTests
                 CREATE FUNCTION reject_current_parser_preview() RETURNS trigger
                 LANGUAGE plpgsql AS $function$
                 BEGIN
-                    IF NEW."ParserRuleVersion" = 'sunflower-v2' THEN
+                    IF NEW."ParserRuleVersion" = 'sunflower-v3' THEN
                         RAISE EXCEPTION 'intentional disposable-test insert rejection';
                     END IF;
                     RETURN NEW;
@@ -272,7 +273,7 @@ public sealed class PostgreSqlFinancialApiTests
             var service = scope.ServiceProvider.GetRequiredService<IImportPreviewService>();
             await using var stream = new MemoryStream(pdf, writable: false);
             await Assert.ThrowsAsync<DbUpdateException>(() =>
-                service.CreateSunflowerAsync(owner.Id, stream, pdf.Length, CancellationToken.None));
+                service.CreateAsync(owner.Id, SunflowerStatementParser.SourceType, stream, pdf.Length, CancellationToken.None));
         }
 
         var batches = await app.FindImportPreviewBatchesAsync(owner.Id);

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -22,11 +22,36 @@ public sealed class ImportPreviewApiTests
         using var client = app.CreateTestClient();
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
 
-        var create = await client.PostAsync("/api/import-previews/sunflower", content);
+        var create = await client.PostAsync("/api/import-previews", content);
         var read = await client.GetAsync("/api/import-previews/open?sourceType=sunflower_pdf");
 
         Assert.Equal(HttpStatusCode.Unauthorized, create.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, read.StatusCode);
+    }
+
+    [Fact]
+    public async Task Upload_requires_a_closed_supported_source_before_extraction()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-source@example.com");
+        using var missing = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf(), sourceType: null);
+        using var unknown = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf(), "prairie_pdf");
+
+        var missingResponse = await owner.Client.PostAsync("/api/import-previews", missing);
+        var unknownResponse = await owner.Client.PostAsync("/api/import-previews", unknown);
+        var missingOpenResponse = await owner.Client.GetAsync("/api/import-previews/open");
+        var unknownOpenResponse = await owner.Client.GetAsync("/api/import-previews/open?sourceType=prairie_pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, missingResponse.StatusCode);
+        Assert.Equal("source_required", (await missingResponse.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString());
+        Assert.Equal(HttpStatusCode.BadRequest, unknownResponse.StatusCode);
+        Assert.Equal("unsupported_statement_source", (await unknownResponse.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString());
+        Assert.Equal(HttpStatusCode.BadRequest, missingOpenResponse.StatusCode);
+        Assert.Equal("source_required", (await missingOpenResponse.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString());
+        Assert.Equal(HttpStatusCode.BadRequest, unknownOpenResponse.StatusCode);
+        Assert.Equal("unsupported_statement_source", (await unknownOpenResponse.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString());
+        Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(0, await app.CountExpensesAsync());
     }
 
     [Fact]
@@ -39,7 +64,7 @@ public sealed class ImportPreviewApiTests
         await app.SeedExpenseAsync(other.Id, "STREAMCO SUBSCRIPTION", 7.99m, new DateOnly(2026, 2, 4));
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -69,16 +94,16 @@ public sealed class ImportPreviewApiTests
         using var firstContent = PdfUpload(pdf);
         using var secondContent = PdfUpload(pdf);
 
-        var first = await owner.Client.PostAsync("/api/import-previews/sunflower", firstContent);
+        var first = await owner.Client.PostAsync("/api/import-previews", firstContent);
         var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
-        var second = await owner.Client.PostAsync("/api/import-previews/sunflower", secondContent);
+        var second = await owner.Client.PostAsync("/api/import-previews", secondContent);
         var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
         var resumed = await owner.Client.GetFromJsonAsync<JsonElement>("/api/import-previews/open?sourceType=sunflower_pdf");
 
         Assert.Equal(HttpStatusCode.Created, first.StatusCode);
         Assert.Equal(HttpStatusCode.OK, second.StatusCode);
-        Assert.Equal("sunflower-v2", firstBody.GetProperty("parserRuleVersion").GetString());
-        Assert.Equal("sunflower-v2", secondBody.GetProperty("parserRuleVersion").GetString());
+        Assert.Equal("sunflower-v3", firstBody.GetProperty("parserRuleVersion").GetString());
+        Assert.Equal("sunflower-v3", secondBody.GetProperty("parserRuleVersion").GetString());
         Assert.Equal(firstBody.GetProperty("batchId").GetGuid(), secondBody.GetProperty("batchId").GetGuid());
         Assert.Equal(firstBody.GetProperty("batchId").GetGuid(), resumed.GetProperty("batchId").GetGuid());
         Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
@@ -104,7 +129,7 @@ public sealed class ImportPreviewApiTests
         var crossUserRead = await other.Client.GetAsync($"/api/import-previews/{stale.Id}");
         using var content = PdfUpload(pdf);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var replacement = await response.Content.ReadFromJsonAsync<JsonElement>();
         var resumed = await owner.Client.GetFromJsonAsync<JsonElement>(
             "/api/import-previews/open?sourceType=sunflower_pdf");
@@ -115,7 +140,7 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(HttpStatusCode.NotFound, crossUserRead.StatusCode);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotEqual(stale.Id, replacement.GetProperty("batchId").GetGuid());
-        Assert.Equal("sunflower-v2", replacement.GetProperty("parserRuleVersion").GetString());
+        Assert.Equal("sunflower-v3", replacement.GetProperty("parserRuleVersion").GetString());
         Assert.Equal(13, replacement.GetProperty("rows").GetArrayLength());
         Assert.DoesNotContain(
             replacement.GetProperty("rows").EnumerateArray(),
@@ -134,7 +159,7 @@ public sealed class ImportPreviewApiTests
             current =>
             {
                 Assert.Equal(ImportPreviewLifecycle.Open, current.Lifecycle);
-                Assert.Equal("sunflower-v2", current.ParserRuleVersion);
+                Assert.Equal("sunflower-v3", current.ParserRuleVersion);
             });
         var preservedOther = Assert.Single(await app.FindImportPreviewBatchesAsync(other.Id));
         Assert.Equal(otherStale.Id, preservedOther.Id);
@@ -151,7 +176,7 @@ public sealed class ImportPreviewApiTests
         var stale = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
         using var content = PdfUpload(pdf);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
@@ -172,7 +197,7 @@ public sealed class ImportPreviewApiTests
         var stale = await app.SeedImportPreviewBatchAsync(owner.Id, pdf, "sunflower-v1");
         using var content = PdfUpload(pdf);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.RequestTimeout, response.StatusCode);
@@ -190,7 +215,7 @@ public sealed class ImportPreviewApiTests
         await using var app = new SyntheticExtractionFinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync("preview-edit@example.com");
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
-        var create = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var create = await owner.Client.PostAsync("/api/import-previews", content);
         var preview = await create.Content.ReadFromJsonAsync<JsonElement>();
         var batchId = preview.GetProperty("batchId").GetGuid();
         var rows = preview.GetProperty("rows").EnumerateArray().ToList();
@@ -219,7 +244,7 @@ public sealed class ImportPreviewApiTests
         using var owner = await app.CreateAuthenticatedUserAsync("preview-size@example.com");
         using var content = PdfUpload(new byte[(10 * 1024 * 1024) + 1]);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
@@ -238,7 +263,7 @@ public sealed class ImportPreviewApiTests
         Array.Fill(padded, (byte)' ', fixture.Length, padded.Length - fixture.Length);
         using var content = PdfUpload(padded);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
@@ -250,7 +275,7 @@ public sealed class ImportPreviewApiTests
         await using var app = new ClockedFinancialApiTestApplication(clock);
         using var owner = await app.CreateAuthenticatedUserAsync("preview-expiry@example.com");
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
-        var create = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var create = await owner.Client.PostAsync("/api/import-previews", content);
         var preview = await create.Content.ReadFromJsonAsync<JsonElement>();
         var batchId = preview.GetProperty("batchId").GetGuid();
 
@@ -287,7 +312,7 @@ public sealed class ImportPreviewApiTests
         using var lease = admission.TryAcquire(owner.Id);
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
@@ -302,7 +327,7 @@ public sealed class ImportPreviewApiTests
         using var owner = await app.CreateAuthenticatedUserAsync("preview-real-path@example.com");
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -326,7 +351,7 @@ public sealed class ImportPreviewApiTests
         };
         using var content = PdfUpload(SyntheticPdfBuilder.Build(new IReadOnlyList<string>[] { lines }));
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -356,7 +381,7 @@ public sealed class ImportPreviewApiTests
         };
         using var content = PdfUpload(SyntheticPdfBuilder.Build(pages));
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -396,7 +421,7 @@ public sealed class ImportPreviewApiTests
         Assert.True(parsed.IsSuccess, parsed.Failure?.Code);
         using var content = PdfUpload(pdf);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -425,7 +450,7 @@ public sealed class ImportPreviewApiTests
         };
         using var content = PdfUpload(pdf);
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
@@ -436,23 +461,23 @@ public sealed class ImportPreviewApiTests
     }
 
     [Theory]
-    [InlineData("unsupported_source", "unsupported_statement_source")]
-    [InlineData("unsupported_format", "unsupported_statement_format")]
-    public async Task Unsupported_statement_failures_have_stable_safe_api_errors(string kind, string expectedCode)
+    [InlineData("lookalike")]
+    [InlineData("unsupported_format")]
+    public async Task Routed_but_structurally_incompatible_statements_fail_safely(string kind)
     {
         await using var app = new FinancialApiTestApplication();
         using var owner = await app.CreateAuthenticatedUserAsync($"preview-{kind}@example.com");
-        var header = kind == "unsupported_source" ? "PRAIRIE BANK" : "SUNFLOWER BANKFIRST NATIONAL 1870";
-        var lines = kind == "unsupported_source"
+        var header = kind == "lookalike" ? "PRAIRIE BANK" : "SUNFLOWER BANKFIRST NATIONAL 1870";
+        var lines = kind == "lookalike"
             ? new[] { header, "STATEMENT DATE: 02/28/26", "Days in Statement Period: 28", "Electronic Transactions", "Posted Description Amount" }
             : new[] { header, "STATEMENT DATE: 02/28/26", "Electronic Transactions", "Posted Description Amount" };
         using var content = PdfUpload(SyntheticPdfBuilder.Build(new IReadOnlyList<string>[] { lines }));
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-        Assert.Equal(expectedCode, error.GetProperty("code").GetString());
+        Assert.Equal("unsupported_statement_format", error.GetProperty("code").GetString());
         Assert.Equal(0, await app.CountImportPreviewBatchesAsync(owner.Id));
     }
 
@@ -463,7 +488,7 @@ public sealed class ImportPreviewApiTests
         using var owner = await app.CreateAuthenticatedUserAsync("preview-timeout@example.com");
         using var content = PdfUpload(SunflowerFixtureCorpus.CreateRepresentativePdf());
 
-        var response = await owner.Client.PostAsync("/api/import-previews/sunflower", content);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
         var admission = app.Services.GetRequiredService<IImportPreviewAdmission>();
         using var releasedLease = admission.TryAcquire(owner.Id);
@@ -484,7 +509,7 @@ public sealed class ImportPreviewApiTests
         using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            owner.Client.PostAsync("/api/import-previews/sunflower", content, cancellation.Token));
+            owner.Client.PostAsync("/api/import-previews", content, cancellation.Token));
         var admission = app.Services.GetRequiredService<IImportPreviewAdmission>();
         using var releasedLease = admission.TryAcquire(owner.Id);
 
@@ -493,9 +518,11 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(0, await app.CountExpensesAsync());
     }
 
-    private static MultipartFormDataContent PdfUpload(byte[] bytes)
+    private static MultipartFormDataContent PdfUpload(byte[] bytes, string? sourceType = SunflowerStatementParser.SourceType)
     {
         var content = new MultipartFormDataContent();
+        if (sourceType is not null)
+            content.Add(new StringContent(sourceType), "sourceType");
         var file = new ByteArrayContent(bytes);
         file.Headers.ContentType = new("text/plain");
         content.Add(file, "file", "advisory-name.bin");

--- a/backend.Tests/Import/SunflowerStatementParserTests.cs
+++ b/backend.Tests/Import/SunflowerStatementParserTests.cs
@@ -47,71 +47,48 @@ public sealed class SunflowerStatementParserTests
     }
 
     [Fact]
-    public void Statement_recognition_requires_source_metadata_and_transaction_structure()
+    public void Routed_parser_requires_transaction_structure_but_not_textual_bank_identity()
     {
         var parser = new SunflowerStatementParser();
-        Assert.Equal(
-            "unsupported_statement_source",
-            parser.Parse(Result("PRAIRIE BANK\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount"))
-                .Failure?.Code);
+        var withoutTextIdentity = parser.Parse(Result(
+            "SYNTHETIC HEADER\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\n" +
+            "Electronic Transactions\nPosted Description Amount\n02/01/26 PURCHASE 1.00-"));
+        Assert.True(withoutTextIdentity.IsSuccess);
+        Assert.Single(withoutTextIdentity.Rows);
+
         Assert.Equal(
             "unsupported_statement_format",
             parser.Parse(Result("SUNFLOWER BANK\nSTATEMENT DATE: 02/28/26\nDays in Statement Period 28\nElectronic Transactions\nPosted Description Amount"))
                 .Failure?.Code);
-        Assert.Equal(
-            "unsupported_statement_source",
-            parser.Parse(Result("GENERIC HEADER\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount\nA GENERIC SUNFLOWER REFERENCE"))
-                .Failure?.Code);
-        Assert.Equal(
-            "unsupported_statement_source",
-            parser.Parse(Result("GENERIC HEADER\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount\nA LATE SunflowerBank REFERENCE"))
-                .Failure?.Code);
-
-        foreach (var nearMiss in new[] { "SunflowerBanking", "SunflowerAnything" })
-        {
-            Assert.Equal(
-                "unsupported_statement_source",
-                parser.Parse(Result($"{nearMiss}\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\nPosted Description Amount"))
-                    .Failure?.Code);
-        }
-
-        var preamble = parser.Parse(Result(
-            "SYNTHETIC PREAMBLE\nHEADER CODE 123\nSUNFLOWER BANK ADJACENT HEADER\n" +
-            "STATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\n" +
-            "Posted Description Amount\n02/01/26 PURCHASE 1.00-"));
-        Assert.True(preamble.IsSuccess);
-        Assert.Single(preamble.Rows);
-
-        var concatenatedBrand = parser.Parse(Result(
-            "SYNTHETIC PREAMBLE\nSunflowerBank FIRST NATIONAL 1870\n" +
-            "STATEMENT DATE: 02/28/26\nDays in Statement Period: 28\nElectronic Transactions\n" +
-            "Posted Description Amount\n02/01/26 PURCHASE 1.00-"));
-        Assert.True(concatenatedBrand.IsSuccess);
-        Assert.Single(concatenatedBrand.Rows);
     }
 
     [Fact]
-    public void Page_local_source_identity_accepts_only_brand_before_strong_same_page_metadata()
+    public void Compact_header_requires_exact_geometry_and_uses_the_common_row_grammar()
+    {
+        var parsed = new SunflowerStatementParser().Parse(CompactHeaderResult());
+
+        Assert.True(parsed.IsSuccess, parsed.Failure?.Code);
+        var row = Assert.Single(parsed.Rows);
+        Assert.Equal("SYNTHETIC PURCHASE", row.SourceDescription);
+        Assert.Equal(10.00m, row.Amount);
+        Assert.Equal(ImportedRowClassification.ExpenseCandidate, row.Classification);
+        Assert.Equal("sunflower-v3", row.Provenance.ParserRuleVersion);
+    }
+
+    [Fact]
+    public void Compact_header_near_misses_fail_closed()
     {
         var parser = new SunflowerStatementParser();
-        var derivedLayout = parser.Parse(MultiPageResult(
-            "Deposits\nElectronic Transactions",
-            "Deposits\nSunflowerBank SYNTHETIC HEADER\nSTATEMENTDATE:02/28/26\n" +
-            "DaysinStatementPeriod:28Deposits\nElectronic Transactions\n" +
-            "PostedDescriptionAmount\n02/01/26 SYNTHETIC PURCHASE 1.00-"));
+        var withoutGeometry = CompactHeaderResult(words: Array.Empty<PdfExtractedWord>());
+        var multipleTextMatches = CompactHeaderResult(
+            textSuffix: "YPostedDescriptionAmount02/02/26 SECOND 11.00-");
+        var rotatedWords = CompactHeaderWords();
+        rotatedWords[0] = rotatedWords[0] with { Orientation = PdfWordOrientation.Rotate90 };
+        var rotated = CompactHeaderResult(words: rotatedWords);
 
-        Assert.True(derivedLayout.IsSuccess, derivedLayout.Failure?.Code);
-        Assert.Single(derivedLayout.Rows);
-
-        var lateBrand = parser.Parse(Result(
-            "STATEMENTDATE:02/28/26\nSunflowerBank SYNTHETIC DISCLOSURE\n" +
-            "DaysinStatementPeriod:28\nElectronic Transactions\nPostedDescriptionAmount"));
-        Assert.Equal("unsupported_statement_source", lateBrand.Failure?.Code);
-
-        var disclosureOnly = parser.Parse(MultiPageResult(
-            "STATEMENTDATE:02/28/26\nDaysinStatementPeriod:28\nElectronic Transactions\nPostedDescriptionAmount",
-            "SunflowerBank SYNTHETIC DISCLOSURE"));
-        Assert.Equal("unsupported_statement_source", disclosureOnly.Failure?.Code);
+        Assert.Equal("unsupported_statement_format", parser.Parse(withoutGeometry).Failure?.Code);
+        Assert.Equal("unsupported_statement_format", parser.Parse(multipleTextMatches).Failure?.Code);
+        Assert.Equal("unsupported_statement_format", parser.Parse(rotated).Failure?.Code);
     }
 
     [Fact]
@@ -404,6 +381,33 @@ public sealed class SunflowerStatementParserTests
             text.Length,
             new[] { new PdfExtractedPage(1, text, words) });
     }
+
+    private static PdfTextExtractionResult CompactHeaderResult(
+        string textSuffix = "",
+        PdfExtractedWord[]? words = null)
+    {
+        var text = "SYNTHETIC HEADER\nSTATEMENT DATE: 02/28/26\nDays in Statement Period: 28\n" +
+                   "Electronic Transactions\nXPostedDescriptionAmount02/01/26 SYNTHETIC PURCHASE 10.00-" +
+                   textSuffix;
+        return new PdfTextExtractionResult(
+            0,
+            1,
+            text.Length,
+            new[] { new PdfExtractedPage(1, text, words ?? CompactHeaderWords()) });
+    }
+
+    private static PdfExtractedWord[] CompactHeaderWords() =>
+    [
+        PositionalWord(1, "Electronic", .08, .18, .85),
+        PositionalWord(2, "Transactions", .19, .32, .85),
+        PositionalWord(3, "Posted", .08, .16, .75),
+        PositionalWord(4, "Description", .25, .40, .75),
+        PositionalWord(5, "Amount", .85, .93, .75),
+        PositionalWord(6, "02/01/26", .08, .16, .65),
+        PositionalWord(7, "SYNTHETIC", .25, .36, .65),
+        PositionalWord(8, "PURCHASE", .37, .49, .65),
+        PositionalWord(9, "10.00-", .86, .93, .65)
+    ];
 
     private static PdfExtractedWord PositionalWord(
         int ordinal,

--- a/backend/Controllers/ImportPreviewsController.cs
+++ b/backend/Controllers/ImportPreviewsController.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using BudgetPlanner.Contracts.ImportPreviews;
 using BudgetPlanner.Import;
-using BudgetPlanner.Import.Sunflower;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -15,23 +14,30 @@ public sealed class ImportPreviewsController(
 {
     private const long MultipartRequestLimit = ImportPreviewService.MaximumUploadBytes + (64 * 1024);
 
-    [HttpPost("sunflower")]
+    [HttpPost]
     [RequestSizeLimit(MultipartRequestLimit)]
     [RequestFormLimits(
         MultipartBodyLengthLimit = MultipartRequestLimit,
         MemoryBufferThreshold = (int)MultipartRequestLimit)]
     [ServiceFilter(typeof(ImportPreviewAdmissionFilter))]
-    public async Task<IActionResult> CreateSunflower([FromForm] IFormFile? file, CancellationToken cancellationToken)
+    public async Task<IActionResult> Create(
+        [FromForm] string? sourceType,
+        [FromForm] IFormFile? file,
+        CancellationToken cancellationToken)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null) return Unauthorized();
+        if (string.IsNullOrWhiteSpace(sourceType))
+            return BadRequest(new ImportPreviewError("source_required", "Choose a supported bank before uploading."));
+        if (!ImportStatementSources.IsSupported(sourceType))
+            return BadRequest(new ImportPreviewError("unsupported_statement_source", "The selected statement source is not supported."));
         if (file is null) return BadRequest(new ImportPreviewError("file_required", "Choose a PDF to upload."));
         if (file.Length > ImportPreviewService.MaximumUploadBytes)
             return StatusCode(StatusCodes.Status413PayloadTooLarge,
                 new ImportPreviewError("upload_too_large", "The PDF exceeds the 10 MiB limit."));
 
         await using var stream = file.OpenReadStream();
-        var result = await previews.CreateSunflowerAsync(userId, stream, file.Length, cancellationToken);
+        var result = await previews.CreateAsync(userId, sourceType, stream, file.Length, cancellationToken);
         if (!result.IsSuccess) return ErrorResult(result.Error!);
         return result.Reused
             ? Ok(result.Preview)
@@ -39,11 +45,15 @@ public sealed class ImportPreviewsController(
     }
 
     [HttpGet("open")]
-    public async Task<IActionResult> GetOpen([FromQuery] string sourceType, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetOpen([FromQuery] string? sourceType, CancellationToken cancellationToken)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null) return Unauthorized();
-        var preview = await previews.GetOpenAsync(userId, sourceType, cancellationToken);
+        if (string.IsNullOrWhiteSpace(sourceType))
+            return BadRequest(new ImportPreviewError("source_required", "Choose a supported bank."));
+        if (!ImportStatementSources.IsSupported(sourceType))
+            return BadRequest(new ImportPreviewError("unsupported_statement_source", "The selected statement source is not supported."));
+        var preview = await previews.GetOpenAsync(userId, sourceType!, cancellationToken);
         return preview is null ? NoContent() : Ok(preview);
     }
 
@@ -74,7 +84,8 @@ public sealed class ImportPreviewsController(
         "processing_cancelled" => StatusCode(499, error),
         "processing_timed_out" => StatusCode(StatusCodes.Status408RequestTimeout, error),
         "import_in_progress" => Conflict(error),
-        "row_not_selectable" or "row_validation_failed" or "file_required" => BadRequest(error),
+        "row_not_selectable" or "row_validation_failed" or "file_required"
+            or "source_required" or "unsupported_statement_source" => BadRequest(error),
         _ => UnprocessableEntity(error)
     };
 

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -20,7 +20,7 @@ public sealed record ImportPreviewOperation(
 
 public interface IImportPreviewService
 {
-    Task<ImportPreviewOperation> CreateSunflowerAsync(string userId, Stream file, long? declaredLength, CancellationToken cancellationToken);
+    Task<ImportPreviewOperation> CreateAsync(string userId, string? sourceType, Stream file, long? declaredLength, CancellationToken cancellationToken);
     Task<ImportPreviewResponse?> GetOpenAsync(string userId, string sourceType, CancellationToken cancellationToken);
     Task<ImportPreviewResponse?> GetAsync(string userId, Guid batchId, CancellationToken cancellationToken);
     Task<ImportPreviewOperation> UpdateRowAsync(string userId, Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken);
@@ -43,9 +43,17 @@ public sealed class ImportPreviewService(
     private const string OpenDigestIndexName =
         "IX_ImportPreviewBatches_OwnerId_SourceType_DocumentDigest";
 
-    public async Task<ImportPreviewOperation> CreateSunflowerAsync(
-        string userId, Stream file, long? declaredLength, CancellationToken cancellationToken)
+    public async Task<ImportPreviewOperation> CreateAsync(
+        string userId,
+        string? sourceType,
+        Stream file,
+        long? declaredLength,
+        CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(sourceType))
+            return Failed("source_required", "Choose a supported bank before uploading.");
+        if (!ImportStatementSources.IsSupported(sourceType))
+            return Failed("unsupported_statement_source", "The selected statement source is not supported.");
         if (declaredLength > MaximumUploadBytes)
             return Failed("upload_too_large", "The PDF exceeds the 10 MiB limit.");
 
@@ -84,7 +92,7 @@ public sealed class ImportPreviewService(
 
             var existing = await FindCompatibleOpenByDigestAsync(
                 userId,
-                SunflowerStatementParser.SourceType,
+                sourceType,
                 SunflowerStatementParser.RuleVersion,
                 digest,
                 processingToken);
@@ -133,7 +141,7 @@ public sealed class ImportPreviewService(
         {
             Id = Guid.NewGuid(),
             OwnerId = userId,
-            SourceType = SunflowerStatementParser.SourceType,
+            SourceType = sourceType,
             ParserRuleVersion = SunflowerStatementParser.RuleVersion,
             DocumentDigest = digest,
             CreatedAt = now,
@@ -203,7 +211,7 @@ public sealed class ImportPreviewService(
 
     public async Task<ImportPreviewResponse?> GetOpenAsync(string userId, string sourceType, CancellationToken cancellationToken)
     {
-        if (sourceType != SunflowerStatementParser.SourceType) return null;
+        if (!ImportStatementSources.IsSupported(sourceType)) return null;
         await ExpireOwnedAsync(userId, cancellationToken);
         var batch = await OwnedCompatibleOpenQuery(userId).Where(value => value.SourceType == sourceType)
             .OrderByDescending(value => value.CreatedAt).FirstOrDefaultAsync(cancellationToken);

--- a/backend/Import/ImportStatementSources.cs
+++ b/backend/Import/ImportStatementSources.cs
@@ -1,0 +1,9 @@
+namespace BudgetPlanner.Import;
+
+public static class ImportStatementSources
+{
+    public const string SunflowerPdf = "sunflower_pdf";
+
+    public static bool IsSupported(string? sourceType) =>
+        string.Equals(sourceType, SunflowerPdf, StringComparison.Ordinal);
+}

--- a/backend/Import/Sunflower/SunflowerStatementParser.cs
+++ b/backend/Import/Sunflower/SunflowerStatementParser.cs
@@ -5,8 +5,8 @@ namespace BudgetPlanner.Import.Sunflower;
 
 public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 {
-    public const string SourceType = "sunflower_pdf";
-    public const string RuleVersion = "sunflower-v2";
+    public const string SourceType = ImportStatementSources.SunflowerPdf;
+    public const string RuleVersion = "sunflower-v3";
     public const int MaximumCandidateRows = 1_000;
 
     private const string DepositsSection = "deposits";
@@ -24,12 +24,6 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
             return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedFormat);
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        if (!HasSunflowerHeaderIdentity(extraction.Pages))
-        {
-            return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedSource);
-        }
-
         var statementDates = extraction.Pages
             .Select(page =>
             {
@@ -43,9 +37,12 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
             .Distinct()
             .ToList();
 
+        var headerFamilies = extraction.Pages.ToDictionary(page => page.PageNumber, ClassifyHeaderFamily);
         var hasDaysMarker = extraction.Pages.Any(page => DaysInStatementPeriodRegex().IsMatch(page.Text));
-        var hasTransactionHeading = extraction.Pages.SelectMany(SplitLines).Any(line => IsTransactionHeading(line.Trim()));
-        var hasColumnHeader = extraction.Pages.Any(page => PostedDescriptionAmountRegex().IsMatch(page.Text));
+        var hasTransactionHeading = extraction.Pages
+            .SelectMany(page => SplitLines(page, headerFamilies[page.PageNumber]))
+            .Any(line => IsTransactionHeading(line.Trim()));
+        var hasColumnHeader = headerFamilies.Values.Any(family => family != HeaderFamily.Unsupported);
         if (statementDates.Count != 1 || !hasDaysMarker || !hasTransactionHeading || !hasColumnHeader)
         {
             return SunflowerStatementParseResult.Failed(SunflowerStatementParseFailure.UnsupportedFormat);
@@ -76,7 +73,8 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
                 pendingRow = null;
             }
 
-            foreach (var sourceLine in SplitLines(page).Select(line => new SourceLine(page.PageNumber, line)))
+            foreach (var sourceLine in SplitLines(page, headerFamilies[page.PageNumber])
+                         .Select(line => new SourceLine(page.PageNumber, line)))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var trimmed = sourceLine.Text.Trim();
@@ -611,18 +609,98 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
         pages.Count > 0
         && pages.Select(page => page.PageNumber).SequenceEqual(Enumerable.Range(1, pages.Count));
 
-    private static bool HasSunflowerHeaderIdentity(IReadOnlyList<PdfExtractedPage> pages) =>
-        pages.Any(page =>
+    private static HeaderFamily ClassifyHeaderFamily(PdfExtractedPage page)
+    {
+        if (PostedDescriptionAmountRegex().IsMatch(page.Text))
         {
-            var statementDate = StatementDateRegex().Match(page.Text);
-            return statementDate.Success
-                   && SunflowerBrandRegex().Matches(page.Text)
-                       .Any(brand => brand.Index < statementDate.Index);
-        });
+            return HeaderFamily.Canonical;
+        }
 
-    private static IEnumerable<string> SplitLines(PdfExtractedPage page)
+        var compactMatches = CompactPostedDescriptionAmountRegex().Matches(page.Text);
+        return compactMatches.Count == 1 && HasExactCompactHeaderGeometry(page)
+            ? HeaderFamily.CompactGeometry
+            : HeaderFamily.Unsupported;
+    }
+
+    private static bool HasExactCompactHeaderGeometry(PdfExtractedPage page)
+    {
+        if (page.Words.Count == 0
+            || page.Words.Any(word => word.Orientation != PdfWordOrientation.Horizontal
+                || word.Ordinal <= 0
+                || string.IsNullOrEmpty(word.Text)
+                || !HasValidBox(word)))
+        {
+            return false;
+        }
+
+        var orderedWords = page.Words.OrderBy(word => word.Ordinal).ToList();
+        if (!orderedWords.Select(word => word.Ordinal).SequenceEqual(Enumerable.Range(1, orderedWords.Count)))
+        {
+            return false;
+        }
+
+        var medianHeight = Median(orderedWords.Select(word => word.Top - word.Bottom));
+        if (medianHeight <= 0)
+        {
+            return false;
+        }
+
+        var baselineTolerance = medianHeight * 0.45;
+        var lines = new List<PositionalLine>();
+        foreach (var word in orderedWords.OrderByDescending(word => word.Baseline).ThenBy(word => word.Left))
+        {
+            var line = lines
+                .Where(candidate => Math.Abs(candidate.Baseline - word.Baseline) <= baselineTolerance)
+                .OrderBy(candidate => Math.Abs(candidate.Baseline - word.Baseline))
+                .FirstOrDefault();
+            if (line is null)
+            {
+                lines.Add(new PositionalLine(word.Baseline, new List<PdfExtractedWord> { word }));
+            }
+            else
+            {
+                line.Words.Add(word);
+            }
+        }
+
+        lines = lines.OrderByDescending(line => line.Baseline).ToList();
+        foreach (var line in lines)
+        {
+            line.Words.Sort((left, right) => left.Left.CompareTo(right.Left));
+        }
+
+        var headingIndex = lines.FindIndex(line =>
+            line.Words.Count == 2
+            && line.Words[0].Text.Equals("Electronic", StringComparison.OrdinalIgnoreCase)
+            && line.Words[1].Text.Equals("Transactions", StringComparison.OrdinalIgnoreCase));
+        if (headingIndex < 0)
+        {
+            return false;
+        }
+
+        var candidates = lines
+            .Skip(headingIndex + 1)
+            .Where(line => line.Words.Count == 3
+                && line.Words[0].Text.Equals("Posted", StringComparison.OrdinalIgnoreCase)
+                && line.Words[1].Text.Equals("Description", StringComparison.OrdinalIgnoreCase)
+                && line.Words[2].Text.Equals("Amount", StringComparison.OrdinalIgnoreCase)
+                && line.Words[0].Right < line.Words[1].Left
+                && line.Words[1].Right < line.Words[2].Left
+                && line.Words.Max(word => word.Baseline) - line.Words.Min(word => word.Baseline)
+                    <= baselineTolerance)
+            .ToList();
+        return candidates.Count == 1;
+    }
+
+    private static IEnumerable<string> SplitLines(PdfExtractedPage page, HeaderFamily headerFamily)
     {
         var text = page.Text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        if (headerFamily == HeaderFamily.CompactGeometry)
+        {
+            text = CompactPostedDescriptionAmountRegex().Replace(
+                text,
+                match => $"{match.Groups["prefix"].Value}\n{match.Groups["header"].Value}\n");
+        }
         var fixedMarkers = new[]
         {
             "Important Account Information",
@@ -746,8 +824,8 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
     [GeneratedRegex(@"(?<![A-Za-z])Posted\s*Description\s*Amount(?![A-Za-z])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex PostedDescriptionAmountRegex();
 
-    [GeneratedRegex(@"\bSUNFLOWER(?:BANK)?\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
-    private static partial Regex SunflowerBrandRegex();
+    [GeneratedRegex(@"(?<prefix>[A-Za-z])(?<header>Posted\s*Description\s*Amount)(?=\d{2}/\d{2}/\d{2})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CompactPostedDescriptionAmountRegex();
 
     [GeneratedRegex(@"^(?:---\s*)?No Checks Paid(?: Electronically)? in this statement cycle\.(?:\s*---)?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex NoChecksMessageRegex();
@@ -757,6 +835,13 @@ public sealed partial class SunflowerStatementParser : ISunflowerStatementParser
 
     [GeneratedRegex(@"^(?:Posted\s*(?:/\s*)?Description\s*(?:/\s*)?Amount|Check Number\s*(?:/\s*)?Date\s*(?:/\s*)?Description\s*(?:/\s*)?Amount|Check Number\s+Date\s+Amount\s+Check Number\s+Date\s+Amount)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex CheckHeaderRegex();
+
+    private enum HeaderFamily
+    {
+        Unsupported,
+        Canonical,
+        CompactGeometry
+    }
 
     [GeneratedRegex(@"^(?<date>\d{2}/\d{2}/\d{2})\s+(?<description>.*?)\s+(?<amount>\S+?)(?<debit>-)?$", RegexOptions.CultureInvariant)]
     private static partial Regex TransactionRowRegex();

--- a/frontend/src/features/importPreview/api/importPreviewApi.js
+++ b/frontend/src/features/importPreview/api/importPreviewApi.js
@@ -1,14 +1,15 @@
 import client from "../../../shared/api/client";
 
 export const importPreviewApi = {
-  uploadSunflower(file, signal) {
+  upload(sourceType, file, signal) {
     const body = new FormData();
+    body.append("sourceType", sourceType);
     body.append("file", file);
-    return client.post("/api/import-previews/sunflower", body, { signal });
+    return client.post("/api/import-previews", body, { signal });
   },
-  getOpen(signal) {
+  getOpen(sourceType, signal) {
     return client.get("/api/import-previews/open", {
-      params: { sourceType: "sunflower_pdf" },
+      params: { sourceType },
       signal,
     });
   },

--- a/frontend/src/features/importPreview/api/importPreviewApi.test.js
+++ b/frontend/src/features/importPreview/api/importPreviewApi.test.js
@@ -13,16 +13,17 @@ describe('importPreviewApi', () => {
     const file = new File(['pdf'], 'private-name.pdf', { type: 'application/pdf' })
     const signal = new AbortController().signal
 
-    importPreviewApi.uploadSunflower(file, signal)
+    importPreviewApi.upload('sunflower_pdf', file, signal)
 
-    expect(client.post).toHaveBeenCalledWith('/api/import-previews/sunflower', expect.any(FormData), { signal })
+    expect(client.post).toHaveBeenCalledWith('/api/import-previews', expect.any(FormData), { signal })
     const form = client.post.mock.calls[0][1]
+    expect(form.get('sourceType')).toBe('sunflower_pdf')
     expect(form.get('file')).toBe(file)
   })
 
   it('uses server-authoritative resume and row mutation routes', () => {
     const signal = new AbortController().signal
-    importPreviewApi.getOpen(signal)
+    importPreviewApi.getOpen('sunflower_pdf', signal)
     importPreviewApi.getById('batch-id', signal)
     importPreviewApi.updateRow('batch-id', 'row-id', { selectedForImport: true })
 

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
@@ -3,13 +3,13 @@ import Card from "../../../shared/ui/Card";
 import ImportPreviewRow from "./ImportPreviewRow";
 
 export default function ImportPreviewPanel({ importState }) {
-  const { preview, loading, processing, error, upload, cancel, updateRow, clearForReupload } = importState;
+  const { preview, sourceType, loading, processing, error, selectSource, upload, cancel, updateRow, clearForReupload } = importState;
   const [dragging, setDragging] = useState(false);
   const fileInput = useRef(null);
   const resultsHeading = useRef(null);
 
   async function submitFile(file) {
-    if (!file) return;
+    if (!file || !sourceType) return;
     const result = await upload(file);
     if (result) requestAnimationFrame(() => resultsHeading.current?.focus());
   }
@@ -17,6 +17,7 @@ export default function ImportPreviewPanel({ importState }) {
   function drop(event) {
     event.preventDefault();
     setDragging(false);
+    if (!sourceType) return;
     submitFile(event.dataTransfer.files?.[0]);
   }
 
@@ -25,14 +26,29 @@ export default function ImportPreviewPanel({ importState }) {
       <div className="section__header import-preview__header">
         <div>
           <p className="page-header__eyebrow">Preview only</p>
-          <h2 className="h2" id="import-preview-title">Import Sunflower statement</h2>
-          <p className="muted">Upload a text-extractable Sunflower PDF, up to 10 MiB. Scanned statements are not supported.</p>
+          <h2 className="h2" id="import-preview-title">Import bank statement</h2>
+          <p className="muted">Choose the bank, then upload a text-extractable PDF up to 10 MiB. Scanned statements are not supported.</p>
         </div>
         {preview && <button type="button" className="button-ghost" onClick={clearForReupload}>Choose another statement</button>}
       </div>
 
       <div className="status-message status-message--info">
         Preview only — no expenses have been created. Confirmation is not available yet.
+      </div>
+
+      <div className="import-source-control">
+        <label htmlFor="statement-source">Bank</label>
+        <select
+          id="statement-source"
+          required
+          value={sourceType}
+          disabled={processing || Boolean(preview)}
+          onChange={(event) => selectSource(event.target.value)}
+        >
+          <option value="">Choose a bank</option>
+          <option value="sunflower_pdf">Sunflower Bank</option>
+        </select>
+        {!sourceType && <p className="muted">Choose a bank to enable PDF upload.</p>}
       </div>
 
       {error && <div className="status-message status-message--danger" role="alert">{error}</div>}
@@ -58,10 +74,11 @@ export default function ImportPreviewPanel({ importState }) {
             id="sunflower-statement-file"
             type="file"
             accept=".pdf,application/pdf"
+            disabled={!sourceType}
             onChange={(event) => submitFile(event.target.files?.[0])}
           />
           <p><strong>Drop a statement PDF here</strong> or choose it from your device.</p>
-          <button type="button" onClick={() => fileInput.current?.click()}>Choose PDF</button>
+          <button type="button" disabled={!sourceType} onClick={() => fileInput.current?.click()}>Choose PDF</button>
         </div>
       )}
 
@@ -73,7 +90,7 @@ export default function ImportPreviewPanel({ importState }) {
           </div>
           <div className="table-wrapper import-preview-table" role="region" aria-label="Statement import preview" tabIndex="0">
             <table className="data-table">
-              <caption>Sunflower statement rows</caption>
+              <caption>Sunflower Bank statement rows</caption>
               <thead><tr><th>Row</th><th>Statement details</th><th>Status</th><th>Selection</th><th>Expense fields</th></tr></thead>
               <tbody>
                 {preview.rows.map((row) => (

--- a/frontend/src/features/importPreview/hooks/useImportPreview.js
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.js
@@ -7,7 +7,8 @@ const SAFE_ERRORS = {
   invalid_pdf: "This file is not a valid supported PDF.",
   encrypted_pdf: "Encrypted or password-protected PDFs are not supported.",
   image_only_pdf: "This PDF has no extractable text. Scanned statements are not supported yet.",
-  unsupported_statement_source: "This statement is not from the supported Sunflower format.",
+  unsupported_statement_source: "The selected statement source is not supported.",
+  source_required: "Choose a supported bank before uploading.",
   unsupported_statement_format: "This Sunflower statement format is not supported.",
   candidate_row_limit_exceeded: "This statement contains more than 1,000 transaction rows.",
   processing_timed_out: "Statement processing timed out. Try the upload again.",
@@ -32,8 +33,15 @@ function rememberBatch(batchId) {
   window.history.replaceState({}, "", url);
 }
 
+function forgetBatch() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("importBatch");
+  window.history.replaceState({}, "", url);
+}
+
 export function useImportPreview() {
   const [preview, setPreview] = useState(null);
+  const [sourceType, setSourceType] = useState("");
   const [loading, setLoading] = useState(true);
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState("");
@@ -44,11 +52,11 @@ export function useImportPreview() {
     async function resume() {
       try {
         const batchId = batchIdFromLocation();
-        const response = batchId
-          ? await importPreviewApi.getById(batchId, controller.signal)
-          : await importPreviewApi.getOpen(controller.signal);
+        if (!batchId) return;
+        const response = await importPreviewApi.getById(batchId, controller.signal);
         if (response.status !== 204 && response.data) {
           setPreview(response.data);
+          setSourceType(response.data.sourceType);
           rememberBatch(response.data.batchId);
         }
       } catch (requestError) {
@@ -66,6 +74,38 @@ export function useImportPreview() {
     };
   }, []);
 
+  const selectSource = useCallback(async (nextSourceType) => {
+    processingController.current?.abort();
+    setSourceType(nextSourceType);
+    setPreview(null);
+    setError("");
+    if (!nextSourceType) {
+      setLoading(false);
+      return null;
+    }
+
+    const controller = new AbortController();
+    processingController.current = controller;
+    setLoading(true);
+    try {
+      const response = await importPreviewApi.getOpen(nextSourceType, controller.signal);
+      if (response.status !== 204 && response.data) {
+        setPreview(response.data);
+        rememberBatch(response.data.batchId);
+        return response.data;
+      }
+      return null;
+    } catch (requestError) {
+      if (!axios.isCancel(requestError)) {
+        setError(safeError(requestError, "The saved import preview could not be loaded."));
+      }
+      return null;
+    } finally {
+      if (processingController.current === controller) processingController.current = null;
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, []);
+
   const upload = useCallback(async (file) => {
     processingController.current?.abort();
     const controller = new AbortController();
@@ -73,7 +113,7 @@ export function useImportPreview() {
     setProcessing(true);
     setError("");
     try {
-      const response = await importPreviewApi.uploadSunflower(file, controller.signal);
+      const response = await importPreviewApi.upload(sourceType, file, controller.signal);
       setPreview(response.data);
       rememberBatch(response.data.batchId);
       return response.data;
@@ -88,7 +128,7 @@ export function useImportPreview() {
         setProcessing(false);
       }
     }
-  }, []);
+  }, [sourceType]);
 
   const cancel = useCallback(() => processingController.current?.abort(), []);
 
@@ -111,13 +151,16 @@ export function useImportPreview() {
   const clearForReupload = useCallback(() => {
     setPreview(null);
     setError("");
+    forgetBatch();
   }, []);
 
   return {
     preview,
+    sourceType,
     loading,
     processing,
     error,
+    selectSource,
     upload,
     cancel,
     updateRow,

--- a/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
@@ -4,11 +4,12 @@ import { importPreviewApi } from '../api/importPreviewApi'
 import { useImportPreview } from './useImportPreview'
 
 vi.mock('../api/importPreviewApi', () => ({ importPreviewApi: {
-  getOpen: vi.fn(), getById: vi.fn(), uploadSunflower: vi.fn(), updateRow: vi.fn(),
+  getOpen: vi.fn(), getById: vi.fn(), upload: vi.fn(), updateRow: vi.fn(),
 } }))
 
 const preview = {
   batchId: '11111111-1111-1111-1111-111111111111',
+  sourceType: 'sunflower_pdf',
   expiresAt: '2026-08-21T12:00:00Z',
   rows: [{ rowId: 'row-1', selectedForImport: false }],
 }
@@ -29,24 +30,28 @@ describe('useImportPreview', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(importPreviewApi.getById).toHaveBeenCalledWith(preview.batchId, expect.any(AbortSignal))
     expect(result.current.preview).toEqual(preview)
+    expect(result.current.sourceType).toBe('sunflower_pdf')
     expect(window.location.search).toContain(`importBatch=${preview.batchId}`)
   })
 
   it('maps safe upload errors and does not expose server internals', async () => {
-    importPreviewApi.uploadSunflower.mockRejectedValue({
+    importPreviewApi.upload.mockRejectedValue({
       response: { data: { code: 'encrypted_pdf', message: 'internal detail' } },
     })
     const { result } = renderHook(() => useImportPreview())
     await waitFor(() => expect(result.current.loading).toBe(false))
 
+    await act(() => result.current.selectSource('sunflower_pdf'))
     await act(() => result.current.upload(new File(['pdf'], 'statement.pdf')))
 
+    expect(importPreviewApi.upload).toHaveBeenCalledWith('sunflower_pdf', expect.any(File), expect.any(AbortSignal))
     expect(result.current.error).toBe('Encrypted or password-protected PDFs are not supported.')
     expect(result.current.error).not.toContain('internal detail')
   })
 
   it('persists a row update into the current preview', async () => {
-    importPreviewApi.getOpen.mockResolvedValue({ status: 200, data: preview })
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
     importPreviewApi.updateRow.mockResolvedValue({ data: { ...preview.rows[0], selectedForImport: true } })
     const { result } = renderHook(() => useImportPreview())
     await waitFor(() => expect(result.current.preview).toEqual(preview))
@@ -57,7 +62,8 @@ describe('useImportPreview', () => {
   })
 
   it('keeps the preview unchanged when the server rejects a row mutation', async () => {
-    importPreviewApi.getOpen.mockResolvedValue({ status: 200, data: preview })
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
     importPreviewApi.updateRow.mockRejectedValue({
       response: { data: { code: 'row_not_selectable', message: 'internal detail' } },
     })
@@ -69,5 +75,17 @@ describe('useImportPreview', () => {
     expect(result.current.preview).toEqual(preview)
     expect(result.current.error).toBe('That row cannot be selected for import.')
     expect(result.current.error).not.toContain('internal detail')
+  })
+
+  it('requires explicit source selection before looking for an open preview', async () => {
+    importPreviewApi.getOpen.mockResolvedValue({ status: 204, data: null })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(importPreviewApi.getOpen).not.toHaveBeenCalled()
+    await act(() => result.current.selectSource('sunflower_pdf'))
+
+    expect(importPreviewApi.getOpen).toHaveBeenCalledWith('sunflower_pdf', expect.any(AbortSignal))
+    expect(result.current.sourceType).toBe('sunflower_pdf')
   })
 })

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -18,9 +18,11 @@ const baseExpensesHook = {
 
 const baseImportHook = {
   preview: null,
+  sourceType: '',
   loading: false,
   processing: false,
   error: '',
+  selectSource: vi.fn(),
   upload: vi.fn(),
   cancel: vi.fn(),
   updateRow: vi.fn(),
@@ -43,7 +45,7 @@ describe('existing expense workflows', () => {
     await user.type(screen.getByPlaceholderText('Description'), '  Dinner With Friends  ')
     await user.type(screen.getByPlaceholderText('Amount'), '12.50')
     fireEvent.change(document.querySelector('input[type="date"]'), { target: { value: '2026-08-14' } })
-    await user.selectOptions(screen.getAllByRole('combobox')[0], 'food')
+    await user.selectOptions(screen.getByLabelText('Category'), 'food')
     await user.click(screen.getByRole('button', { name: 'Add' }))
 
     expect(addExpense).toHaveBeenCalledWith({
@@ -63,7 +65,7 @@ describe('existing expense workflows', () => {
     await user.type(screen.getByPlaceholderText('Description'), 'Prescription')
     await user.type(screen.getByPlaceholderText('Amount'), '8')
     fireEvent.change(document.querySelector('input[type="date"]'), { target: { value: '2026-08-14' } })
-    await user.selectOptions(screen.getAllByRole('combobox')[0], 'other')
+    await user.selectOptions(screen.getByLabelText('Category'), 'other')
     await user.type(screen.getByPlaceholderText('Custom Category'), '  Medical Care  ')
     await user.click(screen.getByRole('button', { name: 'Add' }))
 
@@ -162,7 +164,7 @@ describe('existing expense workflows', () => {
   it('uploads a PDF through the normal Transactions experience', async () => {
     const user = userEvent.setup()
     const upload = vi.fn().mockResolvedValue(null)
-    useImportPreview.mockReturnValue({ ...baseImportHook, upload })
+    useImportPreview.mockReturnValue({ ...baseImportHook, sourceType: 'sunflower_pdf', upload })
     render(<TransactionsPage />)
     const file = new File(['synthetic'], 'statement.pdf', { type: 'application/pdf' })
 
@@ -171,6 +173,18 @@ describe('existing expense workflows', () => {
     expect(upload).toHaveBeenCalledWith(file)
     expect(screen.getByText(/Preview only — no expenses have been created/)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /confirm|import expenses/i })).not.toBeInTheDocument()
+  })
+
+  it('requires an explicit bank selection before enabling upload', async () => {
+    const user = userEvent.setup()
+    const selectSource = vi.fn()
+    useImportPreview.mockReturnValue({ ...baseImportHook, selectSource })
+    render(<TransactionsPage />)
+
+    expect(screen.getByRole('button', { name: 'Choose PDF' })).toBeDisabled()
+    expect(screen.getByLabelText('Sunflower statement PDF')).toBeDisabled()
+    await user.selectOptions(screen.getByLabelText('Bank'), 'sunflower_pdf')
+    expect(selectSource).toHaveBeenCalledWith('sunflower_pdf')
   })
 
   it('shows processing and safe retry errors without statement details', async () => {

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -45,7 +45,8 @@ describe('existing expense workflows', () => {
     await user.type(screen.getByPlaceholderText('Description'), '  Dinner With Friends  ')
     await user.type(screen.getByPlaceholderText('Amount'), '12.50')
     fireEvent.change(document.querySelector('input[type="date"]'), { target: { value: '2026-08-14' } })
-    await user.selectOptions(screen.getByLabelText('Category'), 'food')
+    const addEntry = screen.getByRole('heading', { name: 'Add Entry' }).closest('section')
+    await user.selectOptions(within(addEntry).getByRole('combobox'), 'food')
     await user.click(screen.getByRole('button', { name: 'Add' }))
 
     expect(addExpense).toHaveBeenCalledWith({
@@ -65,7 +66,8 @@ describe('existing expense workflows', () => {
     await user.type(screen.getByPlaceholderText('Description'), 'Prescription')
     await user.type(screen.getByPlaceholderText('Amount'), '8')
     fireEvent.change(document.querySelector('input[type="date"]'), { target: { value: '2026-08-14' } })
-    await user.selectOptions(screen.getByLabelText('Category'), 'other')
+    const addEntry = screen.getByRole('heading', { name: 'Add Entry' }).closest('section')
+    await user.selectOptions(within(addEntry).getByRole('combobox'), 'other')
     await user.type(screen.getByPlaceholderText('Custom Category'), '  Medical Care  ')
     await user.click(screen.getByRole('button', { name: 'Add' }))
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -111,6 +111,9 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .import-preview { display: grid; gap: var(--space-4); }
 .import-preview__header { align-items: start; margin-bottom: 0; }
 .import-preview__header .muted { max-width: 720px; margin-bottom: 0; }
+.import-source-control { display: grid; gap: var(--space-2); max-width: 420px; }
+.import-source-control label { font-weight: 700; }
+.import-source-control .muted { margin: 0; }
 .import-processing { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-subtle); }
 .import-dropzone { display: grid; justify-items: center; gap: var(--space-3); padding: var(--space-7) var(--space-4); border: 2px dashed var(--color-border); border-radius: var(--radius-lg); text-align: center; background: var(--color-surface-subtle); transition: border-color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard); }
 .import-dropzone--active { border-color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface)); }


### PR DESCRIPTION
## Summary
- require an explicit, closed-set statement source before upload or open-preview lookup
- route the generic import-preview contract to the versioned Sunflower parser
- support the canonical and exact compact-geometry Sunflower layout families without fuzzy parsing
- make source selection explicit in the bank-neutral upload UI

Closes #82

## Risk
HIGH — changes statement routing and financial import parsing under the approved amended plan recorded on #82.

## Verification
- Backend build and tests CI: passed
- Frontend test, lint, and build CI: passed
- PostgreSQL financial integration CI: passed
- Vercel checks: passed
- Focused local backend/parser/API suite: 98 passed on the clean no-build retry
- New local source-contract and compact-layout tests: 3 passed
- Local frontend production build: passed
- Local frontend lint: passed with one pre-existing warning outside this scope
- Approved private full-folder acceptance: 8/8 passed across both explicit families; source-grounded reconciliation, aggregate checks, structural spot checks, and zero Expense writes passed. Only anonymous evidence is published in issue comment #5403822320.

## Local environment disclosure
- Full local frontend Vitest did not dispatch within the bounded host window; authoritative CI passed.
- Full local non-PostgreSQL backend reached 210 passes with five contained-worker timeouts under host load; the affected focused suite and authoritative CI passed.

## Scope boundaries
- no schema or migration changes
- no fuzzy source detection or parser fallback
- no expense confirmation/import behavior
- no production operations or deployment
- no private statement artifacts or private evidence included

## Rollback
Revert the PR commits to restore the prior Sunflower-specific route and parser version. Existing persisted preview batches remain isolated by source and parser version.