### PR TITLE
Add atomic import confirmation and Expense persistence

### DIFF
--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 using Xunit;
 using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
 using BudgetPlanner.Import;
@@ -48,6 +49,105 @@ public sealed class PostgreSqlFinancialApiTests
               AND column_name = 'Date';
             """;
         Assert.Equal("date", await command.ExecuteScalarAsync());
+
+        var expenseAmountType = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT data_type || ':' || numeric_precision || ':' || numeric_scale AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'Expenses'
+              AND column_name = 'Amount'
+            """).SingleAsync();
+        Assert.Equal("numeric:18:2", expenseAmountType);
+
+        var confirmedAtType = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT data_type || ':' || is_nullable AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'ImportPreviewBatches'
+              AND column_name = 'ConfirmedAt'
+            """).SingleAsync();
+        Assert.Equal("timestamp with time zone:YES", confirmedAtType);
+
+        var provenanceColumns = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT column_name || ':' || data_type || ':' || is_nullable AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'ImportExpenseProvenances'
+            ORDER BY ordinal_position
+            """).ToListAsync();
+        Assert.Equal(
+            [
+                "BatchId:uuid:NO",
+                "SourceRowOrdinal:integer:NO",
+                "ExpenseId:integer:YES"
+            ],
+            provenanceColumns);
+
+        var batchConfirmationCheck = await ReadConstraintDefinitionAsync(
+            context,
+            "CK_ImportPreviewBatch_ConfirmedAt");
+        Assert.StartsWith("CHECK", batchConfirmationCheck);
+        Assert.Contains("\"Lifecycle\"", batchConfirmationCheck);
+        Assert.Contains("'Confirmed'", batchConfirmationCheck);
+        Assert.Contains("\"ConfirmedAt\" IS NOT NULL", batchConfirmationCheck);
+        Assert.Contains("\"ConfirmedAt\" IS NULL", batchConfirmationCheck);
+
+        var positiveOrdinalCheck = await ReadConstraintDefinitionAsync(
+            context,
+            "CK_ImportExpenseProvenance_PositiveSourceRowOrdinal");
+        Assert.Contains("\"SourceRowOrdinal\" > 0", positiveOrdinalCheck);
+
+        var provenancePrimaryKey = await ReadConstraintDefinitionAsync(
+            context,
+            "PK_ImportExpenseProvenances");
+        Assert.Equal("PRIMARY KEY (\"BatchId\", \"SourceRowOrdinal\")", provenancePrimaryKey);
+
+        var batchForeignKey = await ReadConstraintDefinitionAsync(
+            context,
+            "FK_ImportExpenseProvenances_ImportPreviewBatches_BatchId");
+        Assert.Contains("FOREIGN KEY (\"BatchId\")", batchForeignKey);
+        Assert.Contains("REFERENCES \"ImportPreviewBatches\"(\"Id\")", batchForeignKey);
+        Assert.EndsWith("ON DELETE CASCADE", batchForeignKey);
+
+        var expenseForeignKey = await ReadConstraintDefinitionAsync(
+            context,
+            "FK_ImportExpenseProvenances_Expenses_ExpenseId");
+        Assert.Contains("FOREIGN KEY (\"ExpenseId\")", expenseForeignKey);
+        Assert.Contains("REFERENCES \"Expenses\"(\"Id\")", expenseForeignKey);
+        Assert.EndsWith("ON DELETE SET NULL", expenseForeignKey);
+
+        var confirmedDocumentIndex = await ReadIndexDefinitionAsync(
+            context,
+            "IX_ImportPreviewBatches_ConfirmedDocument");
+        Assert.Contains("CREATE UNIQUE INDEX", confirmedDocumentIndex);
+        Assert.Contains(
+            "(\"OwnerId\", \"SourceType\", \"ParserRuleVersion\", \"DocumentDigest\")",
+            confirmedDocumentIndex);
+        Assert.Contains("WHERE", confirmedDocumentIndex);
+        Assert.Contains("\"Lifecycle\"", confirmedDocumentIndex);
+        Assert.Contains("'Confirmed'", confirmedDocumentIndex);
+
+        var activeDocumentIndex = await ReadIndexDefinitionAsync(
+            context,
+            "IX_ImportPreviewBatches_ActiveDocument");
+        Assert.Contains("CREATE UNIQUE INDEX", activeDocumentIndex);
+        Assert.Contains(
+            "(\"OwnerId\", \"SourceType\", \"ParserRuleVersion\", \"DocumentDigest\")",
+            activeDocumentIndex);
+        Assert.Contains("WHERE", activeDocumentIndex);
+        Assert.Contains("\"Lifecycle\"", activeDocumentIndex);
+        Assert.Contains("'Open'", activeDocumentIndex);
+        Assert.Contains("'Confirmed'", activeDocumentIndex);
+
+        var provenanceExpenseIndex = await ReadIndexDefinitionAsync(
+            context,
+            "IX_ImportExpenseProvenances_ExpenseId");
+        Assert.Contains("CREATE UNIQUE INDEX", provenanceExpenseIndex);
+        Assert.Contains("(\"ExpenseId\")", provenanceExpenseIndex);
+        Assert.Contains("WHERE (\"ExpenseId\" IS NOT NULL)", provenanceExpenseIndex);
     }
 
     [PostgreSqlFact]
@@ -285,6 +385,516 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Confirmation_persists_selected_expenses_and_minimum_provenance()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-confirm@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var preview = await CreatePreviewAsync(owner.Client, pdf);
+        var batchId = preview.GetProperty("batchId").GetGuid();
+
+        using var response = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var confirmation = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(batchId, confirmation.GetProperty("batchId").GetGuid());
+        Assert.Equal("confirmed", confirmation.GetProperty("status").GetString());
+        Assert.Equal(10, confirmation.GetProperty("importedExpenseCount").GetInt32());
+        var responseConfirmedAt = confirmation.GetProperty("confirmedAt").GetDateTime();
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batch = await context.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Include(value => value.Provenance)
+            .SingleAsync(value => value.Id == batchId);
+        var expenses = await context.Expenses.AsNoTracking()
+            .Where(value => value.UserId == owner.Id)
+            .OrderBy(value => value.Date)
+            .ThenBy(value => value.Id)
+            .ToListAsync();
+
+        Assert.Equal(ImportPreviewLifecycle.Confirmed, batch.Lifecycle);
+        Assert.Equal(owner.Id, batch.OwnerId);
+        Assert.Equal(SunflowerStatementParser.SourceType, batch.SourceType);
+        Assert.Equal(SunflowerStatementParser.RuleVersion, batch.ParserRuleVersion);
+        Assert.Equal(32, batch.DocumentDigest.Length);
+        Assert.NotNull(batch.ConfirmedAt);
+        Assert.InRange(
+            (responseConfirmedAt - batch.ConfirmedAt.Value).Duration(),
+            TimeSpan.Zero,
+            TimeSpan.FromMilliseconds(1));
+        Assert.Empty(batch.Rows);
+        Assert.Equal(Enumerable.Range(3, 10),
+            batch.Provenance.OrderBy(value => value.SourceRowOrdinal)
+                .Select(value => value.SourceRowOrdinal));
+        Assert.All(batch.Provenance, value => Assert.NotNull(value.ExpenseId));
+        Assert.Equal(10, batch.Provenance.Select(value => value.ExpenseId).Distinct().Count());
+        Assert.Equal(10, expenses.Count);
+        Assert.All(expenses, value => Assert.Equal(owner.Id, value.UserId));
+
+        var market = Assert.Single(expenses, value => value.Description == "NORTH STAR MARKET");
+        Assert.Equal(new DateOnly(2026, 2, 5), market.Date);
+        Assert.Equal(42.16m, market.Amount);
+        Assert.Equal("uncategorized", market.Category);
+        Assert.Contains(batch.Provenance, value =>
+            value.SourceRowOrdinal == 4 && value.ExpenseId == market.Id);
+    }
+
+    [PostgreSqlFact]
+    public async Task Confirmation_database_failure_rolls_back_all_import_writes_and_preview_changes()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-confirm-rollback@example.com");
+        var preview = await CreatePreviewAsync(
+            owner.Client,
+            SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+
+        using (var setupScope = app.Services.CreateScope())
+        {
+            var setupContext = setupScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await setupContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE FUNCTION reject_one_import_provenance() RETURNS trigger
+                LANGUAGE plpgsql AS $function$
+                BEGIN
+                    IF NEW."SourceRowOrdinal" = 4 THEN
+                        RAISE EXCEPTION 'intentional disposable-test confirmation rejection';
+                    END IF;
+                    RETURN NEW;
+                END;
+                $function$;
+
+                CREATE TRIGGER reject_one_import_provenance_insert
+                BEFORE INSERT ON "ImportExpenseProvenances"
+                FOR EACH ROW EXECUTE FUNCTION reject_one_import_provenance();
+                """);
+        }
+
+        using var response = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("confirmation_failed", error.GetProperty("code").GetString());
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batch = await context.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Include(value => value.Provenance)
+            .SingleAsync(value => value.Id == batchId);
+        Assert.Equal(ImportPreviewLifecycle.Open, batch.Lifecycle);
+        Assert.Null(batch.ConfirmedAt);
+        Assert.Equal(13, batch.Rows.Count);
+        Assert.Equal(10, batch.Rows.Count(value => value.SelectedForImport));
+        Assert.Empty(batch.Provenance);
+        Assert.False(await context.Expenses.AnyAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Concurrent_confirmations_serialize_to_confirmed_and_already_confirmed()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-confirm-race@example.com");
+        var preview = await CreatePreviewAsync(
+            owner.Client,
+            SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+
+        using var lockScope = app.Services.CreateScope();
+        var lockContext = lockScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        await using var lockTransaction = await lockContext.Database.BeginTransactionAsync();
+        await lockContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT 1 FROM \"ImportPreviewBatches\" WHERE \"Id\" = {batchId} FOR UPDATE");
+
+        var firstTask = owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var secondTask = owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var bothWaitingForBatchLock = await app.WaitForBlockedBatchMutationsAsync(2);
+        await lockTransaction.CommitAsync();
+
+        using var first = await firstTask;
+        using var second = await secondTask;
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.True(bothWaitingForBatchLock,
+            "Both confirmations must reach the PostgreSQL batch mutation lock before it is released.");
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal(
+            ["already_confirmed", "confirmed"],
+            new[]
+            {
+                firstBody.GetProperty("status").GetString(),
+                secondBody.GetProperty("status").GetString()
+            }.Order());
+        Assert.Equal(10, firstBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(10, secondBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(
+            firstBody.GetProperty("confirmedAt").GetDateTime(),
+            secondBody.GetProperty("confirmedAt").GetDateTime());
+
+        using var assertScope = app.Services.CreateScope();
+        var context = assertScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(10, await context.Expenses.CountAsync(value => value.UserId == owner.Id));
+        Assert.Equal(10, await context.ImportExpenseProvenances.CountAsync(
+            value => value.BatchId == batchId));
+        Assert.Equal(10, await context.ImportExpenseProvenances
+            .Where(value => value.BatchId == batchId)
+            .Select(value => value.ExpenseId)
+            .Distinct()
+            .CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Row_update_queued_before_confirmation_cannot_bypass_new_duplicate_review()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-row-confirm-order@example.com");
+        var preview = await CreatePreviewAsync(
+            owner.Client,
+            SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var target = preview.GetProperty("rows").EnumerateArray().Single(value =>
+            value.GetProperty("sourceDescription").GetString() == "NORTH STAR MARKET");
+        var targetRowId = target.GetProperty("rowId").GetGuid();
+
+        using (var selectionScope = app.Services.CreateScope())
+        {
+            var context = selectionScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await context.ImportPreviewRows.Where(value => value.BatchId == batchId)
+                .ExecuteUpdateAsync(setters => setters.SetProperty(
+                    value => value.SelectedForImport,
+                    false));
+        }
+        var existing = await app.SeedExpenseAsync(
+            owner.Id,
+            "NORTH STAR MARKET",
+            42.16m,
+            new DateOnly(2026, 2, 5));
+
+        using var lockScope = app.Services.CreateScope();
+        var lockContext = lockScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        await using var lockTransaction = await lockContext.Database.BeginTransactionAsync();
+        await lockContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT 1 FROM \"ImportPreviewBatches\" WHERE \"Id\" = {batchId} FOR UPDATE");
+
+        var updateTask = owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{targetRowId}",
+            new
+            {
+                editableExpenseDescription = target.GetProperty("editableExpenseDescription").GetString(),
+                category = target.GetProperty("category").GetString(),
+                selectedForImport = true
+            });
+        var updateWaitingForBatchLock = await app.WaitForBlockedBatchMutationsAsync(1);
+        var confirmationTask = owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var bothWaitingForBatchLock = await app.WaitForBlockedBatchMutationsAsync(2);
+        await lockTransaction.CommitAsync();
+
+        using var update = await updateTask;
+        using var confirmation = await confirmationTask;
+        var confirmationBody = await confirmation.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.True(updateWaitingForBatchLock,
+            "The row update must reach the PostgreSQL batch mutation lock before confirmation is queued.");
+        Assert.True(bothWaitingForBatchLock,
+            "The row update and confirmation must both wait on the same PostgreSQL batch mutation lock.");
+        Assert.Equal(HttpStatusCode.OK, update.StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict, confirmation.StatusCode);
+        Assert.Equal("duplicate_review_required", confirmationBody.GetProperty("code").GetString());
+        var errorRow = Assert.Single(confirmationBody.GetProperty("rows").EnumerateArray());
+        Assert.Equal(targetRowId, errorRow.GetProperty("rowId").GetGuid());
+        Assert.Equal(
+            ["possible_duplicate"],
+            errorRow.GetProperty("codes").EnumerateArray().Select(value => value.GetString()));
+
+        using var assertScope = app.Services.CreateScope();
+        var assertContext = assertScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batch = await assertContext.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Include(value => value.Provenance)
+            .SingleAsync(value => value.Id == batchId);
+        var refreshed = batch.Rows.Single(value => value.Id == targetRowId);
+        Assert.Equal(ImportPreviewLifecycle.Open, batch.Lifecycle);
+        Assert.Empty(batch.Provenance);
+        Assert.True(refreshed.IsPossibleDuplicate);
+        Assert.False(refreshed.SelectedForImport);
+        Assert.Equal(
+            [existing.Id],
+            JsonSerializer.Deserialize<int[]>(refreshed.DuplicateExpenseIds)!);
+        Assert.Equal(1, await assertContext.Expenses.CountAsync(value => value.UserId == owner.Id));
+    }
+
+    [PostgreSqlFact]
+    public async Task Existing_duplicate_warning_can_be_explicitly_selected_and_confirmed()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-warned-confirm@example.com");
+        var existing = await app.SeedExpenseAsync(
+            owner.Id,
+            "NORTH STAR MARKET",
+            42.16m,
+            new DateOnly(2026, 2, 5));
+        var preview = await CreatePreviewAsync(
+            owner.Client,
+            SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var target = preview.GetProperty("rows").EnumerateArray().Single(value =>
+            value.GetProperty("sourceDescription").GetString() == "NORTH STAR MARKET");
+        var targetRowId = target.GetProperty("rowId").GetGuid();
+
+        Assert.True(target.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.False(target.GetProperty("selectedForImport").GetBoolean());
+        Assert.Equal(
+            [existing.Id],
+            target.GetProperty("duplicateExpenseIds").EnumerateArray()
+                .Select(value => value.GetInt32()));
+
+        using var selection = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{targetRowId}",
+            new
+            {
+                editableExpenseDescription = target.GetProperty("editableExpenseDescription").GetString(),
+                category = target.GetProperty("category").GetString(),
+                selectedForImport = true
+            });
+        Assert.Equal(HttpStatusCode.OK, selection.StatusCode);
+
+        using var confirmation = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var confirmationBody = await confirmation.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.OK, confirmation.StatusCode);
+        Assert.Equal("confirmed", confirmationBody.GetProperty("status").GetString());
+        Assert.Equal(10, confirmationBody.GetProperty("importedExpenseCount").GetInt32());
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(11, await context.Expenses.CountAsync(value => value.UserId == owner.Id));
+        Assert.Equal(10, await context.ImportExpenseProvenances.CountAsync(
+            value => value.BatchId == batchId));
+        Assert.DoesNotContain(
+            await context.ImportExpenseProvenances
+                .Where(value => value.BatchId == batchId)
+                .Select(value => value.ExpenseId)
+                .ToListAsync(),
+            value => value == existing.Id);
+    }
+
+    [PostgreSqlFact]
+    public async Task Duplicate_refresh_queued_before_row_update_requires_later_confirmation()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-duplicate-refresh@example.com");
+        var preview = await CreatePreviewAsync(
+            owner.Client,
+            SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var previewRows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var target = previewRows.Single(value =>
+            value.GetProperty("sourceDescription").GetString() == "NORTH STAR MARKET");
+        var targetRowId = target.GetProperty("rowId").GetGuid();
+        Assert.False(target.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.True(target.GetProperty("selectedForImport").GetBoolean());
+
+        var existing = await app.SeedExpenseAsync(
+            owner.Id,
+            "NORTH STAR MARKET",
+            42.16m,
+            new DateOnly(2026, 2, 5));
+
+        using var lockScope = app.Services.CreateScope();
+        var lockContext = lockScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        await using var lockTransaction = await lockContext.Database.BeginTransactionAsync();
+        await lockContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT 1 FROM \"ImportPreviewBatches\" WHERE \"Id\" = {batchId} FOR UPDATE");
+
+        var refreshTask = owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var refreshWaitingForBatchLock = await app.WaitForBlockedBatchMutationsAsync(1);
+        var reselectionTask = owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{targetRowId}",
+            new
+            {
+                editableExpenseDescription = target.GetProperty("editableExpenseDescription").GetString(),
+                category = target.GetProperty("category").GetString(),
+                selectedForImport = true
+            });
+        var bothWaitingForBatchLock = await app.WaitForBlockedBatchMutationsAsync(2);
+        await lockTransaction.CommitAsync();
+
+        using var refresh = await refreshTask;
+        using var reselection = await reselectionTask;
+        var refreshBody = await refresh.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.True(refreshWaitingForBatchLock,
+            "Confirmation must reach the PostgreSQL batch mutation lock before reselection is queued.");
+        Assert.True(bothWaitingForBatchLock,
+            "Confirmation and reselection must both wait on the same PostgreSQL batch mutation lock.");
+        Assert.Equal(HttpStatusCode.Conflict, refresh.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, reselection.StatusCode);
+        Assert.Equal("duplicate_review_required", refreshBody.GetProperty("code").GetString());
+        var refreshRow = Assert.Single(refreshBody.GetProperty("rows").EnumerateArray());
+        Assert.Equal(targetRowId, refreshRow.GetProperty("rowId").GetGuid());
+        Assert.Equal(
+            ["possible_duplicate"],
+            refreshRow.GetProperty("codes").EnumerateArray().Select(value => value.GetString()));
+
+        using (var refreshScope = app.Services.CreateScope())
+        {
+            var context = refreshScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var batch = await context.ImportPreviewBatches.AsNoTracking()
+                .Include(value => value.Rows)
+                .Include(value => value.Provenance)
+                .SingleAsync(value => value.Id == batchId);
+            var refreshed = batch.Rows.Single(value => value.Id == targetRowId);
+            Assert.Equal(ImportPreviewLifecycle.Open, batch.Lifecycle);
+            Assert.Null(batch.ConfirmedAt);
+            Assert.Empty(batch.Provenance);
+            Assert.True(refreshed.IsPossibleDuplicate);
+            Assert.True(refreshed.SelectedForImport);
+            Assert.Contains("possible_duplicate",
+                JsonSerializer.Deserialize<string[]>(refreshed.WarningCodes)!);
+            Assert.Equal(
+                [existing.Id],
+                JsonSerializer.Deserialize<int[]>(refreshed.DuplicateExpenseIds)!);
+            Assert.Equal(1, await context.Expenses.CountAsync());
+        }
+
+        using var confirmation = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var confirmationBody = await confirmation.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.OK, confirmation.StatusCode);
+        Assert.Equal("confirmed", confirmationBody.GetProperty("status").GetString());
+        Assert.Equal(10, confirmationBody.GetProperty("importedExpenseCount").GetInt32());
+
+        using var assertScope = app.Services.CreateScope();
+        var assertContext = assertScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(11, await assertContext.Expenses.CountAsync());
+        Assert.Equal(10, await assertContext.ImportExpenseProvenances.CountAsync(
+            value => value.BatchId == batchId));
+        Assert.DoesNotContain(
+            await assertContext.ImportExpenseProvenances
+                .Where(value => value.BatchId == batchId)
+                .Select(value => value.ExpenseId)
+                .ToListAsync(),
+            value => value == existing.Id);
+    }
+
+    [PostgreSqlFact]
+    public async Task Confirmed_exact_reupload_is_already_imported_without_extraction_or_new_writes()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-confirm-reupload@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var preview = await CreatePreviewAsync(owner.Client, pdf);
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        using var confirmation = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        Assert.Equal(HttpStatusCode.OK, confirmation.StatusCode);
+        Assert.Equal(1, app.Extractor.CallCount);
+
+        using (var constraintScope = app.Services.CreateScope())
+        {
+            var constraintContext = constraintScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var confirmed = await constraintContext.ImportPreviewBatches.AsNoTracking()
+                .SingleAsync(value => value.Id == batchId);
+            constraintContext.ImportPreviewBatches.Add(new ImportPreviewBatch
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = confirmed.OwnerId,
+                SourceType = confirmed.SourceType,
+                ParserRuleVersion = confirmed.ParserRuleVersion,
+                DocumentDigest = confirmed.DocumentDigest.ToArray(),
+                CreatedAt = confirmed.CreatedAt.AddMinutes(1),
+                ExpiresAt = confirmed.ExpiresAt.AddMinutes(1),
+                Lifecycle = ImportPreviewLifecycle.Open
+            });
+            var exception = await Assert.ThrowsAsync<DbUpdateException>(() =>
+                constraintContext.SaveChangesAsync());
+            var postgres = Assert.IsType<PostgresException>(exception.InnerException);
+            Assert.Equal(PostgresErrorCodes.UniqueViolation, postgres.SqlState);
+            Assert.Equal("IX_ImportPreviewBatches_ActiveDocument", postgres.ConstraintName);
+        }
+
+        using var upload = CreatePdfUpload(pdf);
+        using var reupload = await owner.Client.PostAsync("/api/import-previews", upload);
+        var error = await reupload.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Conflict, reupload.StatusCode);
+        Assert.Equal("already_imported", error.GetProperty("code").GetString());
+        Assert.Equal(1, app.Extractor.CallCount);
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(10, await context.Expenses.CountAsync(value => value.UserId == owner.Id));
+        Assert.Equal(10, await context.ImportExpenseProvenances.CountAsync(
+            value => value.BatchId == batchId));
+        Assert.Equal(1, await context.ImportPreviewBatches.CountAsync(
+            value => value.OwnerId == owner.Id));
+    }
+
+    [PostgreSqlFact]
+    public async Task Expense_delete_sets_provenance_link_to_null_without_reopening_import_identity()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-provenance-delete@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var preview = await CreatePreviewAsync(owner.Client, pdf);
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        using var confirmation = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        Assert.Equal(HttpStatusCode.OK, confirmation.StatusCode);
+
+        int expenseId;
+        int sourceRowOrdinal;
+        using (var readScope = app.Services.CreateScope())
+        {
+            var context = readScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var provenance = await context.ImportExpenseProvenances.AsNoTracking()
+                .Where(value => value.BatchId == batchId)
+                .OrderBy(value => value.SourceRowOrdinal)
+                .FirstAsync();
+            expenseId = Assert.IsType<int>(provenance.ExpenseId);
+            sourceRowOrdinal = provenance.SourceRowOrdinal;
+        }
+
+        using var delete = await owner.Client.DeleteAsync($"/api/expenses/{expenseId}");
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+        using (var assertScope = app.Services.CreateScope())
+        {
+            var context = assertScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var provenance = await context.ImportExpenseProvenances.AsNoTracking()
+                .SingleAsync(value => value.BatchId == batchId
+                    && value.SourceRowOrdinal == sourceRowOrdinal);
+            Assert.Null(provenance.ExpenseId);
+            var batch = await context.ImportPreviewBatches.AsNoTracking()
+                .SingleAsync(value => value.Id == batchId);
+            Assert.Equal(ImportPreviewLifecycle.Confirmed, batch.Lifecycle);
+            Assert.NotNull(batch.ConfirmedAt);
+        }
+
+        using var upload = CreatePdfUpload(pdf);
+        using var reupload = await owner.Client.PostAsync("/api/import-previews", upload);
+        var error = await reupload.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.Conflict, reupload.StatusCode);
+        Assert.Equal("already_imported", error.GetProperty("code").GetString());
+    }
+
+    [PostgreSqlFact]
     public async Task Budget_create_read_upsert_and_delete_use_relational_month_query()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
@@ -330,10 +940,82 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Empty(await app.FindBudgetLimitsAsync(owner.Id, "food"));
         Assert.Single(await app.FindBudgetLimitsAsync(other.Id, "hidden"));
     }
+
+    private static async Task<JsonElement> CreatePreviewAsync(HttpClient client, byte[] pdf)
+    {
+        using var upload = CreatePdfUpload(pdf);
+        using var response = await client.PostAsync("/api/import-previews", upload);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Created,
+            $"Expected preview creation, received {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        return body;
+    }
+
+    private static MultipartFormDataContent CreatePdfUpload(byte[] pdf)
+    {
+        var upload = new MultipartFormDataContent();
+        upload.Add(new StringContent(SunflowerStatementParser.SourceType), "sourceType");
+        upload.Add(new ByteArrayContent(pdf), "file", "synthetic.pdf");
+        return upload;
+    }
+
+    private static Task<string> ReadConstraintDefinitionAsync(
+        BudgetContext context,
+        string constraintName) => context.Database.SqlQueryRaw<string>(
+            """
+            SELECT pg_get_constraintdef(oid) AS "Value"
+            FROM pg_constraint
+            WHERE conname = {0}
+            """,
+            constraintName).SingleAsync();
+
+    private static Task<string> ReadIndexDefinitionAsync(
+        BudgetContext context,
+        string indexName) => context.Database.SqlQueryRaw<string>(
+            """
+            SELECT indexdef AS "Value"
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = {0}
+            """,
+            indexName).SingleAsync();
 }
 
 internal sealed class PostgreSqlImportPreviewTestApplication : PostgreSqlFinancialApiTestApplication
 {
+    public BudgetPlanner.Tests.Import.ImmediateSyntheticExtractor Extractor =>
+        (BudgetPlanner.Tests.Import.ImmediateSyntheticExtractor)
+        Services.GetRequiredService<IPdfTextExtractor>();
+
+    public async Task<bool> WaitForBlockedBatchMutationsAsync(int expectedCount)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var scope = Services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var count = await context.Database.SqlQueryRaw<int>(
+                """
+                SELECT COUNT(*)::integer AS "Value"
+                FROM pg_stat_activity
+                WHERE datname = current_database()
+                  AND pid <> pg_backend_pid()
+                  AND wait_event_type = 'Lock'
+                  AND query ILIKE '%ImportPreviewBatches%'
+                  AND query ILIKE '%FOR UPDATE%'
+                """).SingleAsync();
+            if (count >= expectedCount)
+            {
+                return true;
+            }
+
+            await Task.Delay(25);
+        }
+
+        return false;
+    }
+
     protected override void ConfigureAdditionalServices(IServiceCollection services)
     {
         services.RemoveAll<IPdfTextExtractor>();

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -276,6 +276,7 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(batchId, firstBody.GetProperty("batchId").GetGuid());
         Assert.Equal("confirmed", firstBody.GetProperty("status").GetString());
         Assert.Equal(1, firstBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(0, confirmedAt.Ticks % TimeSpan.TicksPerMicrosecond);
         var expenses = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
         var expense = Assert.Single(expenses.EnumerateArray());
         Assert.Equal("Server-edited description", expense.GetProperty("description").GetString());

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -1,11 +1,14 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using System.Text.Json;
+using BudgetPlanner.Data;
 using BudgetPlanner.Tests.Financial;
 using BudgetPlanner.Tests.Import.Fixtures.Sunflower;
 using BudgetPlanner.Import;
 using BudgetPlanner.Import.Sunflower;
 using BudgetPlanner.Models;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
@@ -24,9 +27,11 @@ public sealed class ImportPreviewApiTests
 
         var create = await client.PostAsync("/api/import-previews", content);
         var read = await client.GetAsync("/api/import-previews/open?sourceType=sunflower_pdf");
+        var confirm = await client.PostAsync($"/api/import-previews/{Guid.NewGuid()}/confirm", null);
 
         Assert.Equal(HttpStatusCode.Unauthorized, create.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, read.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, confirm.StatusCode);
     }
 
     [Fact]
@@ -235,6 +240,408 @@ public sealed class ImportPreviewApiTests
         Assert.Equal("home supplies", updated.GetProperty("category").GetString());
         Assert.False(updated.GetProperty("selectedForImport").GetBoolean());
         Assert.Equal(HttpStatusCode.BadRequest, rejected.StatusCode);
+    }
+
+    [Fact]
+    public async Task Confirmation_uses_only_server_owned_selected_fields_and_is_retry_safe()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var preview = await UploadPreviewAsync(owner, pdf);
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var selected = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "STREAMCO SUBSCRIPTION");
+        var selectedRowId = selected.GetProperty("rowId").GetGuid();
+        await SelectOnlyAsync(owner, batchId, rows, selectedRowId);
+        var edit = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{selectedRowId}",
+            new
+            {
+                editableExpenseDescription = "  Server-edited description  ",
+                category = " HOME   Supplies ",
+                selectedForImport = true
+            });
+        var edited = await edit.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, edit.StatusCode);
+        Assert.Equal("Server-edited description", edited.GetProperty("editableExpenseDescription").GetString());
+        Assert.Equal("home supplies", edited.GetProperty("category").GetString());
+
+        var first = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        var confirmedAt = firstBody.GetProperty("confirmedAt").GetDateTime();
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(batchId, firstBody.GetProperty("batchId").GetGuid());
+        Assert.Equal("confirmed", firstBody.GetProperty("status").GetString());
+        Assert.Equal(1, firstBody.GetProperty("importedExpenseCount").GetInt32());
+        var expenses = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
+        var expense = Assert.Single(expenses.EnumerateArray());
+        Assert.Equal("Server-edited description", expense.GetProperty("description").GetString());
+        Assert.Equal("home supplies", expense.GetProperty("category").GetString());
+        Assert.Equal(7.99m, expense.GetProperty("amount").GetDecimal());
+        Assert.Equal("2026-02-04", expense.GetProperty("date").GetString());
+
+        var retry = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var retryBody = await retry.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+        Assert.Equal(batchId, retryBody.GetProperty("batchId").GetGuid());
+        Assert.Equal("already_confirmed", retryBody.GetProperty("status").GetString());
+        Assert.Equal(confirmedAt, retryBody.GetProperty("confirmedAt").GetDateTime());
+        Assert.Equal(1, retryBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, await app.CountExpensesAsync());
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var batch = await context.ImportPreviewBatches.AsNoTracking()
+                .Include(value => value.Rows)
+                .Include(value => value.Provenance)
+                .SingleAsync(value => value.Id == batchId);
+            Assert.Equal(ImportPreviewLifecycle.Confirmed, batch.Lifecycle);
+            Assert.Equal(confirmedAt, batch.ConfirmedAt);
+            Assert.Empty(batch.Rows);
+            var provenance = Assert.Single(batch.Provenance);
+            Assert.Equal(selected.GetProperty("sourceRowOrdinal").GetInt32(), provenance.SourceRowOrdinal);
+            Assert.Equal(expense.GetProperty("id").GetInt32(), provenance.ExpenseId);
+        }
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var provenance = await context.ImportExpenseProvenances
+                .Include(value => value.Expense)
+                .SingleAsync(value => value.BatchId == batchId);
+            context.Expenses.Remove(Assert.IsType<Expense>(provenance.Expense));
+            await context.SaveChangesAsync();
+            Assert.Null(provenance.ExpenseId);
+        }
+
+        using var reuploadContent = PdfUpload(pdf);
+        var reupload = await owner.Client.PostAsync("/api/import-previews", reuploadContent);
+        var reuploadBody = await reupload.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Conflict, reupload.StatusCode);
+        Assert.Equal("already_imported", reuploadBody.GetProperty("code").GetString());
+        Assert.Equal(0, await app.CountExpensesAsync());
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(1, ((ImmediateSyntheticExtractor)app.Services
+            .GetRequiredService<IPdfTextExtractor>()).CallCount);
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var provenance = await context.ImportExpenseProvenances.AsNoTracking()
+                .SingleAsync(value => value.BatchId == batchId);
+            Assert.Null(provenance.ExpenseId);
+        }
+    }
+
+    [Fact]
+    public async Task Confirmation_with_no_selected_rows_is_rejected_and_remains_open()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-empty@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        await SelectOnlyAsync(owner, batchId, rows, selectedRowId: null);
+
+        var response = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var stillOpen = await owner.Client.GetAsync($"/api/import-previews/{batchId}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("no_rows_selected", error.GetProperty("code").GetString());
+        Assert.Empty(error.GetProperty("rows").EnumerateArray());
+        Assert.Equal(HttpStatusCode.OK, stillOpen.StatusCode);
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Confirmation_uses_bare_not_found_for_missing_foreign_and_stale_batches()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-not-found@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("preview-confirm-foreign@example.com");
+        var foreignPreview = await UploadPreviewAsync(other, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var foreignBatchId = foreignPreview.GetProperty("batchId").GetGuid();
+        var stale = await app.SeedImportPreviewBatchAsync(
+            owner.Id,
+            SunflowerFixtureCorpus.CreateRepresentativePdf(),
+            "sunflower-v1");
+        var expiredStale = await app.SeedImportPreviewBatchAsync(
+            owner.Id,
+            SunflowerFixtureCorpus.CreateRepresentativePdf().Concat(new byte[] { 0 }).ToArray(),
+            "sunflower-v1");
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var batch = await context.ImportPreviewBatches.SingleAsync(value => value.Id == expiredStale.Id);
+            batch.Lifecycle = ImportPreviewLifecycle.Expired;
+            await context.SaveChangesAsync();
+        }
+
+        var missing = await owner.Client.PostAsync($"/api/import-previews/{Guid.NewGuid()}/confirm", null);
+        var foreign = await owner.Client.PostAsync($"/api/import-previews/{foreignBatchId}/confirm", null);
+        var incompatible = await owner.Client.PostAsync($"/api/import-previews/{stale.Id}/confirm", null);
+        var expiredIncompatible = await owner.Client.PostAsync(
+            $"/api/import-previews/{expiredStale.Id}/confirm",
+            null);
+
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, foreign.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, incompatible.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, expiredIncompatible.StatusCode);
+        Assert.Equal("", await missing.Content.ReadAsStringAsync());
+        Assert.Equal("", await foreign.Content.ReadAsStringAsync());
+        Assert.Equal("", await incompatible.Content.ReadAsStringAsync());
+        Assert.Equal("", await expiredIncompatible.Content.ReadAsStringAsync());
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Confirmation_at_the_exact_expiry_boundary_returns_gone_without_writes()
+    {
+        var clock = new MutableTimeProvider(new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-expired@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        clock.Advance(TimeSpan.FromHours(24));
+
+        var response = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+        Assert.Equal("preview_expired", error.GetProperty("code").GetString());
+        Assert.Empty(error.GetProperty("rows").EnumerateArray());
+        Assert.Equal(0, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Cancelled_confirmation_returns_a_safe_failure_and_preserves_the_open_preview()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-cancelled@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        using var scope = app.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IImportPreviewService>();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var result = await service.ConfirmAsync(owner.Id, batchId, cancellation.Token);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("confirmation_failed", result.Error!.Code);
+        Assert.Empty(result.Error.Rows);
+        Assert.Equal(0, await app.CountExpensesAsync());
+        var batch = Assert.Single(await app.FindImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(ImportPreviewLifecycle.Open, batch.Lifecycle);
+        Assert.NotEmpty(batch.Rows);
+    }
+
+    [Fact]
+    public async Task Invalid_selected_row_rejects_the_whole_confirmation_with_safe_row_errors()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-invalid@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var selected = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "STREAMCO SUBSCRIPTION");
+        var selectedRowId = selected.GetProperty("rowId").GetGuid();
+        await SelectOnlyAsync(owner, batchId, rows, selectedRowId);
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var persisted = await context.ImportPreviewRows.SingleAsync(value => value.Id == selectedRowId);
+            persisted.EditableExpenseDescription = "   ";
+            await context.SaveChangesAsync();
+        }
+
+        var response = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var responseText = await response.Content.ReadAsStringAsync();
+        using var errorDocument = JsonDocument.Parse(responseText);
+        var error = errorDocument.RootElement;
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        Assert.Equal("confirmation_validation_failed", error.GetProperty("code").GetString());
+        AssertSafeRowError(error, selectedRowId, "description_required");
+        Assert.DoesNotContain("STREAMCO SUBSCRIPTION", responseText);
+        Assert.Equal(0, await app.CountExpensesAsync());
+        using var verificationScope = app.Services.CreateScope();
+        var verificationContext = verificationScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batch = await verificationContext.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Include(value => value.Provenance)
+            .SingleAsync(value => value.Id == batchId);
+        Assert.Equal(ImportPreviewLifecycle.Open, batch.Lifecycle);
+        Assert.Equal(rows.Count, batch.Rows.Count);
+        Assert.Empty(batch.Provenance);
+    }
+
+    [Fact]
+    public async Task Already_warned_row_imports_after_explicit_selection()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-warned@example.com");
+        await app.SeedExpenseAsync(owner.Id, "NORTH STAR MARKET", 42.16m, new DateOnly(2026, 2, 5));
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var duplicate = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "NORTH STAR MARKET");
+        var duplicateRowId = duplicate.GetProperty("rowId").GetGuid();
+
+        Assert.True(duplicate.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.False(duplicate.GetProperty("selectedForImport").GetBoolean());
+        Assert.Contains("possible_duplicate", duplicate.GetProperty("warnings").EnumerateArray()
+            .Select(value => value.GetString()));
+        await SelectOnlyAsync(owner, batchId, rows, duplicateRowId);
+
+        var response = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("confirmed", body.GetProperty("status").GetString());
+        Assert.Equal(1, body.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(2, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Cross_user_expense_matches_do_not_trigger_confirmation_duplicate_review()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-owner-scope@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("preview-confirm-other-scope@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var selected = rows.Single(row =>
+            row.GetProperty("sourceDescription").GetString() == "STREAMCO SUBSCRIPTION");
+        var selectedRowId = selected.GetProperty("rowId").GetGuid();
+        await SelectOnlyAsync(owner, batchId, rows, selectedRowId);
+        await app.SeedExpenseAsync(
+            other.Id,
+            "streamco subscription",
+            7.99m,
+            new DateOnly(2026, 2, 4));
+
+        var response = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("confirmed", body.GetProperty("status").GetString());
+        Assert.Equal(1, body.GetProperty("importedExpenseCount").GetInt32());
+        var ownerExpenses = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
+        Assert.Single(ownerExpenses.EnumerateArray());
+        Assert.Equal(2, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Newly_discovered_duplicate_requires_review_before_explicit_reselection_imports()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-new-duplicate@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var candidate = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "NORTH STAR MARKET");
+        var candidateRowId = candidate.GetProperty("rowId").GetGuid();
+        await SelectOnlyAsync(owner, batchId, rows, candidateRowId);
+        var matchingExpense = await app.SeedExpenseAsync(
+            owner.Id,
+            "  north   star market ",
+            42.16m,
+            new DateOnly(2026, 2, 5));
+
+        var first = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var firstText = await first.Content.ReadAsStringAsync();
+        using var firstDocument = JsonDocument.Parse(firstText);
+        var firstBody = firstDocument.RootElement;
+
+        Assert.Equal(HttpStatusCode.Conflict, first.StatusCode);
+        Assert.Equal("duplicate_review_required", firstBody.GetProperty("code").GetString());
+        AssertSafeRowError(firstBody, candidateRowId, "possible_duplicate");
+        Assert.DoesNotContain("NORTH STAR MARKET", firstText);
+        Assert.Equal(1, await app.CountExpensesAsync());
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            Assert.Empty(await context.ImportExpenseProvenances.Where(value => value.BatchId == batchId).ToListAsync());
+        }
+
+        var refreshedResponse = await owner.Client.GetAsync($"/api/import-previews/{batchId}");
+        var refreshed = await refreshedResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var refreshedRow = refreshed.GetProperty("rows").EnumerateArray()
+            .Single(row => row.GetProperty("rowId").GetGuid() == candidateRowId);
+        Assert.Equal(HttpStatusCode.OK, refreshedResponse.StatusCode);
+        Assert.True(refreshedRow.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.False(refreshedRow.GetProperty("selectedForImport").GetBoolean());
+        Assert.Contains("possible_duplicate", refreshedRow.GetProperty("warnings").EnumerateArray()
+            .Select(value => value.GetString()));
+        Assert.Equal(
+            new[] { matchingExpense.Id },
+            refreshedRow.GetProperty("duplicateExpenseIds").EnumerateArray().Select(value => value.GetInt32()));
+
+        var reselection = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{candidateRowId}",
+            new
+            {
+                editableExpenseDescription = refreshedRow.GetProperty("editableExpenseDescription").GetString(),
+                category = refreshedRow.GetProperty("category").GetString(),
+                selectedForImport = true
+            });
+        var second = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, reselection.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("confirmed", secondBody.GetProperty("status").GetString());
+        Assert.Equal(1, secondBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(2, await app.CountExpensesAsync());
+    }
+
+    [Fact]
+    public async Task Confirmation_committed_during_reupload_cannot_create_a_second_open_preview()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-confirm-upload-race@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var extractor = (ImmediateSyntheticExtractor)app.Services.GetRequiredService<IPdfTextExtractor>();
+        extractor.BeforeResultAsync = async cancellationToken =>
+        {
+            using var scope = app.Services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var now = DateTime.UtcNow;
+            context.ImportPreviewBatches.Add(new ImportPreviewBatch
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = owner.Id,
+                SourceType = SunflowerStatementParser.SourceType,
+                ParserRuleVersion = SunflowerStatementParser.RuleVersion,
+                DocumentDigest = SHA256.HashData(pdf),
+                CreatedAt = now,
+                ExpiresAt = now.AddHours(24),
+                Lifecycle = ImportPreviewLifecycle.Confirmed,
+                ConfirmedAt = now
+            });
+            await context.SaveChangesAsync(cancellationToken);
+        };
+
+        using var content = PdfUpload(pdf);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.Equal("already_imported", error.GetProperty("code").GetString());
+        Assert.Equal(1, extractor.CallCount);
+        Assert.Equal(1, await app.CountImportPreviewBatchesAsync(owner.Id));
+        var batch = Assert.Single(await app.FindImportPreviewBatchesAsync(owner.Id));
+        Assert.Equal(ImportPreviewLifecycle.Confirmed, batch.Lifecycle);
+        Assert.Equal(0, await app.CountExpensesAsync());
     }
 
     [Fact]
@@ -518,6 +925,49 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(0, await app.CountExpensesAsync());
     }
 
+    private static async Task<JsonElement> UploadPreviewAsync(TestUser owner, byte[] pdf)
+    {
+        using var content = PdfUpload(pdf);
+        var response = await owner.Client.PostAsync("/api/import-previews", content);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var preview = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("sunflower_pdf", preview.GetProperty("sourceType").GetString());
+        return preview;
+    }
+
+    private static async Task SelectOnlyAsync(
+        TestUser owner,
+        Guid batchId,
+        IReadOnlyList<JsonElement> rows,
+        Guid? selectedRowId)
+    {
+        foreach (var row in rows.Where(row => row.GetProperty("isEligible").GetBoolean()))
+        {
+            var response = await owner.Client.PatchAsJsonAsync(
+                $"/api/import-previews/{batchId}/rows/{row.GetProperty("rowId").GetGuid()}",
+                new
+                {
+                    editableExpenseDescription = row.GetProperty("editableExpenseDescription").GetString(),
+                    category = row.GetProperty("category").GetString(),
+                    selectedForImport = row.GetProperty("rowId").GetGuid() == selectedRowId
+                });
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    private static void AssertSafeRowError(JsonElement error, Guid rowId, string code)
+    {
+        Assert.Equal(
+            new[] { "code", "message", "rows" },
+            error.EnumerateObject().Select(property => property.Name).OrderBy(value => value));
+        var row = Assert.Single(error.GetProperty("rows").EnumerateArray());
+        Assert.Equal(
+            new[] { "codes", "rowId" },
+            row.EnumerateObject().Select(property => property.Name).OrderBy(value => value));
+        Assert.Equal(rowId, row.GetProperty("rowId").GetGuid());
+        Assert.Equal(new[] { code }, row.GetProperty("codes").EnumerateArray().Select(value => value.GetString()));
+    }
+
     private static MultipartFormDataContent PdfUpload(byte[] bytes, string? sourceType = SunflowerStatementParser.SourceType)
     {
         var content = new MultipartFormDataContent();
@@ -555,16 +1005,19 @@ internal sealed class ImmediateSyntheticExtractor : IPdfTextExtractor
     private int _callCount;
 
     public int CallCount => Volatile.Read(ref _callCount);
+    public Func<CancellationToken, Task>? BeforeResultAsync { get; set; }
 
-    public Task<PdfTextExtractionOutcome> ExtractAsync(ReadOnlyMemory<byte> pdf, CancellationToken cancellationToken = default)
+    public async Task<PdfTextExtractionOutcome> ExtractAsync(ReadOnlyMemory<byte> pdf, CancellationToken cancellationToken = default)
     {
         Interlocked.Increment(ref _callCount);
         cancellationToken.ThrowIfCancellationRequested();
+        if (BeforeResultAsync is not null)
+            await BeforeResultAsync(cancellationToken);
         var pages = SunflowerFixtureCorpus.RepresentativePages
             .Select((page, index) => new PdfExtractedPage(index + 1, string.Join('\n', page.Lines)))
             .ToList();
-        return Task.FromResult(PdfTextExtractionOutcome.Success(new PdfTextExtractionResult(
-            pdf.Length, pages.Count, pages.Sum(page => page.Text.Length), pages)));
+        return PdfTextExtractionOutcome.Success(new PdfTextExtractionResult(
+            pdf.Length, pages.Count, pages.Sum(page => page.Text.Length), pages));
     }
 }
 

--- a/backend/Contracts/ImportPreviews/ImportPreviewContracts.cs
+++ b/backend/Contracts/ImportPreviews/ImportPreviewContracts.cs
@@ -2,6 +2,21 @@ namespace BudgetPlanner.Contracts.ImportPreviews;
 
 public sealed record ImportPreviewError(string Code, string Message);
 
+public sealed record ImportConfirmationRowError(
+    Guid RowId,
+    IReadOnlyList<string> Codes);
+
+public sealed record ImportConfirmationError(
+    string Code,
+    string Message,
+    IReadOnlyList<ImportConfirmationRowError> Rows);
+
+public sealed record ImportConfirmationResponse(
+    Guid BatchId,
+    string Status,
+    DateTime ConfirmedAt,
+    int ImportedExpenseCount);
+
 public sealed record ImportPreviewResponse(
     Guid BatchId,
     string SourceType,

--- a/backend/Controllers/ImportPreviewsController.cs
+++ b/backend/Controllers/ImportPreviewsController.cs
@@ -66,6 +66,17 @@ public sealed class ImportPreviewsController(
         return preview is null ? NotFound() : Ok(preview);
     }
 
+    [HttpPost("{batchId:guid}/confirm")]
+    public async Task<IActionResult> Confirm(Guid batchId, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+        var result = await previews.ConfirmAsync(userId, batchId, cancellationToken);
+        return result.IsSuccess
+            ? Ok(result.Confirmation)
+            : ConfirmationErrorResult(result.Error!);
+    }
+
     [HttpPatch("{batchId:guid}/rows/{rowId:guid}")]
     public async Task<IActionResult> UpdateRow(Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken)
     {
@@ -83,10 +94,27 @@ public sealed class ImportPreviewsController(
         "preview_not_found" => NotFound(),
         "processing_cancelled" => StatusCode(499, error),
         "processing_timed_out" => StatusCode(StatusCodes.Status408RequestTimeout, error),
-        "import_in_progress" => Conflict(error),
+        "import_in_progress" or "already_imported" => Conflict(error),
         "row_not_selectable" or "row_validation_failed" or "file_required"
             or "source_required" or "unsupported_statement_source" => BadRequest(error),
         _ => UnprocessableEntity(error)
     };
+
+    private IActionResult ConfirmationErrorResult(ImportConfirmationError error) => error.Code switch
+    {
+        "preview_not_found" => EmptyNotFound(),
+        "preview_expired" => StatusCode(StatusCodes.Status410Gone, error),
+        "no_rows_selected" => BadRequest(error),
+        "duplicate_review_required" or "confirmation_conflict" => Conflict(error),
+        "confirmation_validation_failed" => UnprocessableEntity(error),
+        "confirmation_failed" => StatusCode(StatusCodes.Status500InternalServerError, error),
+        _ => UnprocessableEntity(error)
+    };
+
+    private IActionResult EmptyNotFound()
+    {
+        Response.StatusCode = StatusCodes.Status404NotFound;
+        return new EmptyResult();
+    }
 
 }

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -14,6 +14,7 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
     public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
     public DbSet<ImportPreviewBatch> ImportPreviewBatches { get; set; }
     public DbSet<ImportPreviewRow> ImportPreviewRows { get; set; }
+    public DbSet<ImportExpenseProvenance> ImportExpenseProvenances { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -44,6 +45,10 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
                 table.HasCheckConstraint("CK_ImportPreviewBatch_DigestLength", "octet_length(\"DocumentDigest\") = 32");
                 table.HasCheckConstraint("CK_ImportPreviewBatch_Expiry", "\"ExpiresAt\" > \"CreatedAt\"");
                 table.HasCheckConstraint("CK_ImportPreviewBatch_SourceType", "\"SourceType\" = 'sunflower_pdf'");
+                table.HasCheckConstraint(
+                    "CK_ImportPreviewBatch_ConfirmedAt",
+                    "(\"Lifecycle\" = 'Confirmed' AND \"ConfirmedAt\" IS NOT NULL) OR " +
+                    "(\"Lifecycle\" <> 'Confirmed' AND \"ConfirmedAt\" IS NULL)");
             });
             batch.Property(value => value.SourceType).HasMaxLength(50);
             batch.Property(value => value.ParserRuleVersion).HasMaxLength(100);
@@ -54,6 +59,26 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             batch.HasIndex(value => new { value.OwnerId, value.SourceType, value.DocumentDigest })
                 .IsUnique()
                 .HasFilter("\"Lifecycle\" = 'Open'");
+            batch.HasIndex(value => new
+                {
+                    value.OwnerId,
+                    value.SourceType,
+                    value.ParserRuleVersion,
+                    value.DocumentDigest
+                }, "IX_ImportPreviewBatches_ConfirmedDocument")
+                .IsUnique()
+                .HasDatabaseName("IX_ImportPreviewBatches_ConfirmedDocument")
+                .HasFilter("\"Lifecycle\" = 'Confirmed'");
+            batch.HasIndex(value => new
+                {
+                    value.OwnerId,
+                    value.SourceType,
+                    value.ParserRuleVersion,
+                    value.DocumentDigest
+                }, "IX_ImportPreviewBatches_ActiveDocument")
+                .IsUnique()
+                .HasDatabaseName("IX_ImportPreviewBatches_ActiveDocument")
+                .HasFilter("\"Lifecycle\" IN ('Open', 'Confirmed')");
             batch.HasIndex(value => value.ExpiresAt);
         });
 
@@ -75,6 +100,25 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             row.HasOne(value => value.Batch).WithMany(value => value.Rows).HasForeignKey(value => value.BatchId)
                 .OnDelete(DeleteBehavior.Cascade);
             row.HasIndex(value => new { value.BatchId, value.SourceRowOrdinal }).IsUnique();
+        });
+
+        modelBuilder.Entity<ImportExpenseProvenance>(provenance =>
+        {
+            provenance.ToTable(table => table.HasCheckConstraint(
+                "CK_ImportExpenseProvenance_PositiveSourceRowOrdinal",
+                "\"SourceRowOrdinal\" > 0"));
+            provenance.HasKey(value => new { value.BatchId, value.SourceRowOrdinal });
+            provenance.HasOne(value => value.Batch)
+                .WithMany(value => value.Provenance)
+                .HasForeignKey(value => value.BatchId)
+                .OnDelete(DeleteBehavior.Cascade);
+            provenance.HasOne(value => value.Expense)
+                .WithMany()
+                .HasForeignKey(value => value.ExpenseId)
+                .OnDelete(DeleteBehavior.SetNull);
+            provenance.HasIndex(value => value.ExpenseId)
+                .IsUnique()
+                .HasFilter("\"ExpenseId\" IS NOT NULL");
         });
 
         modelBuilder.Entity<BudgetLimit>()

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -18,11 +18,19 @@ public sealed record ImportPreviewOperation(
     public bool IsSuccess => Preview is not null;
 }
 
+public sealed record ImportConfirmationOperation(
+    ImportConfirmationResponse? Confirmation,
+    ImportConfirmationError? Error)
+{
+    public bool IsSuccess => Confirmation is not null;
+}
+
 public interface IImportPreviewService
 {
     Task<ImportPreviewOperation> CreateAsync(string userId, string? sourceType, Stream file, long? declaredLength, CancellationToken cancellationToken);
     Task<ImportPreviewResponse?> GetOpenAsync(string userId, string sourceType, CancellationToken cancellationToken);
     Task<ImportPreviewResponse?> GetAsync(string userId, Guid batchId, CancellationToken cancellationToken);
+    Task<ImportConfirmationOperation> ConfirmAsync(string userId, Guid batchId, CancellationToken cancellationToken);
     Task<ImportPreviewOperation> UpdateRowAsync(string userId, Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken);
 }
 
@@ -42,6 +50,8 @@ public sealed class ImportPreviewService(
     private static readonly TimeSpan PreviewLifetime = TimeSpan.FromHours(24);
     private const string OpenDigestIndexName =
         "IX_ImportPreviewBatches_OwnerId_SourceType_DocumentDigest";
+    private const string ActiveDocumentIndexName = "IX_ImportPreviewBatches_ActiveDocument";
+    private const string ConfirmedDigestIndexName = "IX_ImportPreviewBatches_ConfirmedDocument";
 
     public async Task<ImportPreviewOperation> CreateAsync(
         string userId,
@@ -89,6 +99,15 @@ public sealed class ImportPreviewService(
             using var processingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             processingCts.CancelAfter(processingOptions.Timeout);
             var processingToken = processingCts.Token;
+
+            var confirmed = await FindConfirmedByDigestAsync(
+                userId,
+                sourceType,
+                SunflowerStatementParser.RuleVersion,
+                digest,
+                processingToken);
+            if (confirmed is not null)
+                return Failed("already_imported", "This statement was already imported.");
 
             var existing = await FindCompatibleOpenByDigestAsync(
                 userId,
@@ -226,37 +245,245 @@ public sealed class ImportPreviewService(
         return batch is null ? null : ToResponse(batch);
     }
 
+    public async Task<ImportConfirmationOperation> ConfirmAsync(
+        string userId,
+        Guid batchId,
+        CancellationToken cancellationToken)
+    {
+        IDbContextTransaction? transaction = null;
+        try
+        {
+            transaction = await BeginMutationTransactionAsync(cancellationToken);
+            await LockOwnedBatchAsync(userId, batchId, cancellationToken);
+
+            var batch = await context.ImportPreviewBatches
+                .Include(value => value.Rows)
+                .Include(value => value.Provenance)
+                .SingleOrDefaultAsync(
+                    value => value.OwnerId == userId && value.Id == batchId,
+                    cancellationToken);
+            if (batch is null)
+                return ConfirmationFailed("preview_not_found", "The preview is unavailable.");
+
+            if (batch.Lifecycle == ImportPreviewLifecycle.Confirmed)
+            {
+                return ConfirmationSucceeded(batch, "already_confirmed", batch.Provenance.Count);
+            }
+
+            if (batch.SourceType != SunflowerStatementParser.SourceType
+                || batch.ParserRuleVersion != SunflowerStatementParser.RuleVersion)
+            {
+                return ConfirmationFailed("preview_not_found", "The preview is unavailable.");
+            }
+
+            var now = clock.GetUtcNow().UtcDateTime;
+            if (batch.Lifecycle == ImportPreviewLifecycle.Expired
+                || (batch.Lifecycle == ImportPreviewLifecycle.Open && batch.ExpiresAt <= now))
+            {
+                if (batch.Lifecycle == ImportPreviewLifecycle.Open)
+                {
+                    batch.Lifecycle = ImportPreviewLifecycle.Expired;
+                    await context.SaveChangesAsync(cancellationToken);
+                    await CommitAsync(transaction, cancellationToken);
+                }
+                return ConfirmationFailed("preview_expired", "The preview has expired. Re-upload the statement.");
+            }
+
+            if (batch.Lifecycle != ImportPreviewLifecycle.Open)
+            {
+                return ConfirmationFailed("preview_not_found", "The preview is unavailable.");
+            }
+
+            if (batch.Provenance.Count > 0)
+            {
+                return ConfirmationFailed("confirmation_conflict", "The preview cannot be confirmed safely.");
+            }
+
+            var selectedRows = batch.Rows.Where(value => value.SelectedForImport)
+                .OrderBy(value => value.SourceRowOrdinal)
+                .ToList();
+            if (selectedRows.Count == 0)
+            {
+                return ConfirmationFailed("no_rows_selected", "Select at least one eligible row before confirming.");
+            }
+
+            var selectedDates = selectedRows.Where(value => value.PostedDate.HasValue)
+                .Select(value => value.PostedDate!.Value)
+                .Distinct()
+                .ToList();
+            var currentExpenses = await context.Expenses.AsNoTracking()
+                .Where(value => value.UserId == userId && selectedDates.Contains(value.Date))
+                .ToListAsync(cancellationToken);
+
+            var newlyWarnedRows = new List<ImportConfirmationRowError>();
+            foreach (var row in selectedRows)
+            {
+                var duplicateIds = FindPossibleDuplicateExpenseIds(row, currentExpenses);
+                if (row.IsPossibleDuplicate || duplicateIds.Count == 0) continue;
+
+                row.IsPossibleDuplicate = true;
+                row.DuplicateExpenseIds = JsonSerializer.Serialize(duplicateIds);
+                var warnings = DeserializeCodes(row.WarningCodes).ToList();
+                if (!warnings.Contains("possible_duplicate")) warnings.Add("possible_duplicate");
+                row.WarningCodes = JsonSerializer.Serialize(warnings.Distinct());
+                row.SelectedForImport = false;
+                newlyWarnedRows.Add(new(row.Id, ["possible_duplicate"]));
+            }
+
+            if (newlyWarnedRows.Count > 0)
+            {
+                await context.SaveChangesAsync(cancellationToken);
+                await CommitAsync(transaction, cancellationToken);
+                return ConfirmationFailed(
+                    "duplicate_review_required",
+                    "One or more selected rows now require duplicate review.",
+                    newlyWarnedRows);
+            }
+
+            var validationErrors = new List<ImportConfirmationRowError>();
+            var normalizedRows = new List<(ImportPreviewRow Row, string Description, string Category)>();
+            foreach (var row in selectedRows)
+            {
+                var description = ExpenseInputRules.NormalizeDescription(row.EditableExpenseDescription);
+                var category = ExpenseInputRules.NormalizeCategory(row.Category);
+                var errors = new List<string>();
+                if (!row.IsEligible
+                    || row.Classification != ImportedRowClassification.ExpenseCandidate
+                    || row.Direction != ImportedTransactionDirection.Debit)
+                {
+                    errors.Add("row_not_selectable");
+                }
+                errors.AddRange(ExpenseInputRules.Validate(row.Amount, row.PostedDate, description, category));
+
+                var distinctErrors = errors.Distinct().ToList();
+                if (distinctErrors.Count > 0)
+                {
+                    validationErrors.Add(new(row.Id, distinctErrors));
+                }
+                else
+                {
+                    normalizedRows.Add((row, description, category));
+                }
+            }
+
+            if (validationErrors.Count > 0)
+            {
+                return ConfirmationFailed(
+                    "confirmation_validation_failed",
+                    "One or more selected rows are no longer valid.",
+                    validationErrors);
+            }
+
+            foreach (var normalized in normalizedRows)
+            {
+                var expense = new Expense
+                {
+                    UserId = userId,
+                    Description = normalized.Description,
+                    Amount = normalized.Row.Amount!.Value,
+                    Date = normalized.Row.PostedDate!.Value,
+                    Category = normalized.Category
+                };
+                context.Expenses.Add(expense);
+                batch.Provenance.Add(new ImportExpenseProvenance
+                {
+                    BatchId = batch.Id,
+                    SourceRowOrdinal = normalized.Row.SourceRowOrdinal,
+                    Expense = expense
+                });
+            }
+
+            batch.Lifecycle = ImportPreviewLifecycle.Confirmed;
+            batch.ConfirmedAt = now;
+            context.ImportPreviewRows.RemoveRange(batch.Rows);
+            await context.SaveChangesAsync(cancellationToken);
+            await CommitAsync(transaction, cancellationToken);
+            return ConfirmationSucceeded(batch, "confirmed", normalizedRows.Count);
+        }
+        catch (OperationCanceledException)
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            return ConfirmationFailed("confirmation_failed", "The preview could not be confirmed safely.");
+        }
+        catch (DbUpdateException exception)
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            return IsConfirmedDigestUniqueViolation(exception)
+                ? ConfirmationFailed("confirmation_conflict", "The statement was already confirmed.")
+                : ConfirmationFailed("confirmation_failed", "The preview could not be confirmed safely.");
+        }
+        catch (NpgsqlException)
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            return ConfirmationFailed("confirmation_failed", "The preview could not be confirmed safely.");
+        }
+        finally
+        {
+            if (transaction is not null) await transaction.DisposeAsync();
+        }
+    }
+
     public async Task<ImportPreviewOperation> UpdateRowAsync(string userId, Guid batchId, Guid rowId, UpdateImportPreviewRowRequest request, CancellationToken cancellationToken)
     {
-        await ExpireOwnedAsync(userId, cancellationToken);
-        var batch = await context.ImportPreviewBatches.Include(value => value.Rows)
-            .Where(value => value.OwnerId == userId
-                && value.Id == batchId
-                && value.SourceType == SunflowerStatementParser.SourceType
-                && value.ParserRuleVersion == SunflowerStatementParser.RuleVersion
-                && value.Lifecycle == ImportPreviewLifecycle.Open)
-            .SingleOrDefaultAsync(cancellationToken);
-        var row = batch?.Rows.SingleOrDefault(value => value.Id == rowId);
-        if (batch is null || row is null) return Failed("preview_not_found", "The preview is unavailable.");
-        if (!row.IsEligible && request.SelectedForImport)
-            return Failed("row_not_selectable", "This row cannot be selected for import.");
+        IDbContextTransaction? transaction = null;
+        try
+        {
+            transaction = await BeginMutationTransactionAsync(cancellationToken);
+            await LockOwnedBatchAsync(userId, batchId, cancellationToken);
 
-        if (row.IsEligible)
-        {
-            var description = ExpenseInputRules.NormalizeDescription(request.EditableExpenseDescription);
-            var category = ExpenseInputRules.NormalizeCategory(request.Category);
-            var errors = ExpenseInputRules.Validate(row.Amount, row.PostedDate, description, category);
-            if (errors.Count > 0) return Failed("row_validation_failed", "The row changes are invalid.");
-            row.EditableExpenseDescription = description;
-            row.Category = category;
-            row.SelectedForImport = request.SelectedForImport;
+            var batch = await context.ImportPreviewBatches.Include(value => value.Rows)
+                .SingleOrDefaultAsync(
+                    value => value.OwnerId == userId && value.Id == batchId,
+                    cancellationToken);
+            if (batch is null)
+                return Failed("preview_not_found", "The preview is unavailable.");
+
+            if (batch.Lifecycle == ImportPreviewLifecycle.Open
+                && batch.ExpiresAt <= clock.GetUtcNow().UtcDateTime)
+            {
+                batch.Lifecycle = ImportPreviewLifecycle.Expired;
+                await context.SaveChangesAsync(cancellationToken);
+                await CommitAsync(transaction, cancellationToken);
+                return Failed("preview_not_found", "The preview is unavailable.");
+            }
+
+            if (batch.Lifecycle != ImportPreviewLifecycle.Open
+                || batch.SourceType != SunflowerStatementParser.SourceType
+                || batch.ParserRuleVersion != SunflowerStatementParser.RuleVersion)
+            {
+                return Failed("preview_not_found", "The preview is unavailable.");
+            }
+
+            var row = batch.Rows.SingleOrDefault(value => value.Id == rowId);
+            if (row is null) return Failed("preview_not_found", "The preview is unavailable.");
+            if (!row.IsEligible && request.SelectedForImport)
+                return Failed("row_not_selectable", "This row cannot be selected for import.");
+
+            if (row.IsEligible)
+            {
+                var description = ExpenseInputRules.NormalizeDescription(request.EditableExpenseDescription);
+                var category = ExpenseInputRules.NormalizeCategory(request.Category);
+                var errors = ExpenseInputRules.Validate(row.Amount, row.PostedDate, description, category);
+                if (errors.Count > 0) return Failed("row_validation_failed", "The row changes are invalid.");
+                row.EditableExpenseDescription = description;
+                row.Category = category;
+                row.SelectedForImport = request.SelectedForImport;
+            }
+            else
+            {
+                row.SelectedForImport = false;
+            }
+            await context.SaveChangesAsync(cancellationToken);
+            await CommitAsync(transaction, cancellationToken);
+            return new(ToResponse(batch), null);
         }
-        else
+        finally
         {
-            row.SelectedForImport = false;
+            if (transaction is not null) await transaction.DisposeAsync();
         }
-        await context.SaveChangesAsync(cancellationToken);
-        return new(ToResponse(batch), null);
     }
 
     private IQueryable<ImportPreviewBatch> OwnedOpenQuery(string userId) => context.ImportPreviewBatches
@@ -283,6 +510,71 @@ public sealed class ImportPreviewService(
         return candidates.SingleOrDefault(value => CryptographicOperations.FixedTimeEquals(value.DocumentDigest, digest));
     }
 
+    private async Task<ImportPreviewBatch?> FindConfirmedByDigestAsync(
+        string userId,
+        string sourceType,
+        string parserRuleVersion,
+        byte[] digest,
+        CancellationToken cancellationToken)
+    {
+        var candidates = await context.ImportPreviewBatches.AsNoTracking()
+            .Where(value => value.OwnerId == userId
+                && value.SourceType == sourceType
+                && value.ParserRuleVersion == parserRuleVersion
+                && value.Lifecycle == ImportPreviewLifecycle.Confirmed)
+            .ToListAsync(cancellationToken);
+        return candidates.SingleOrDefault(value =>
+            CryptographicOperations.FixedTimeEquals(value.DocumentDigest, digest));
+    }
+
+    private async Task<IDbContextTransaction?> BeginMutationTransactionAsync(CancellationToken cancellationToken) =>
+        context.Database.IsRelational()
+            ? await context.Database.BeginTransactionAsync(cancellationToken)
+            : null;
+
+    private async Task LockOwnedBatchAsync(
+        string userId,
+        Guid batchId,
+        CancellationToken cancellationToken)
+    {
+        if (!context.Database.IsRelational()) return;
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $@"SELECT 1 FROM ""ImportPreviewBatches""
+               WHERE ""Id"" = {batchId} AND ""OwnerId"" = {userId}
+               FOR UPDATE",
+            cancellationToken);
+    }
+
+    private static List<int> FindPossibleDuplicateExpenseIds(
+        ImportPreviewRow row,
+        IReadOnlyList<Expense> expenses)
+    {
+        if (!row.PostedDate.HasValue || !row.Amount.HasValue) return [];
+        var description = ExpenseInputRules.NormalizeDescriptionForComparison(row.EditableExpenseDescription);
+        return expenses.Where(expense => expense.Date == row.PostedDate.Value
+                && expense.Amount == row.Amount.Value
+                && ExpenseInputRules.NormalizeDescriptionForComparison(expense.Description) == description)
+            .Select(expense => expense.Id)
+            .Distinct()
+            .OrderBy(value => value)
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> DeserializeCodes(string value) =>
+        JsonSerializer.Deserialize<string[]>(value) ?? [];
+
+    private static async Task CommitAsync(
+        IDbContextTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (transaction is not null) await transaction.CommitAsync(cancellationToken);
+    }
+
+    private static async Task RollbackAsync(IDbContextTransaction? transaction)
+    {
+        if (transaction is not null) await transaction.RollbackAsync(CancellationToken.None);
+    }
+
     private async Task<ImportPreviewOperation> PersistOrReuseAsync(
         ImportPreviewBatch batch,
         CancellationToken cancellationToken)
@@ -293,6 +585,17 @@ public sealed class ImportPreviewService(
             if (context.Database.IsRelational())
             {
                 transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+            }
+
+            var confirmed = await FindConfirmedByDigestAsync(
+                batch.OwnerId,
+                batch.SourceType,
+                batch.ParserRuleVersion,
+                batch.DocumentDigest,
+                cancellationToken);
+            if (confirmed is not null)
+            {
+                return Failed("already_imported", "This statement was already imported.");
             }
 
             var winner = await FindCompatibleOpenByDigestAsync(
@@ -328,7 +631,8 @@ public sealed class ImportPreviewService(
             }
             return new(ToResponse(batch), null);
         }
-        catch (DbUpdateException exception) when (IsOpenDigestUniqueViolation(exception))
+        catch (DbUpdateException exception) when (
+            IsOpenDigestUniqueViolation(exception) || IsActiveDocumentUniqueViolation(exception))
         {
             if (transaction is not null)
             {
@@ -343,11 +647,21 @@ public sealed class ImportPreviewService(
                 batch.ParserRuleVersion,
                 batch.DocumentDigest,
                 cancellationToken);
-            if (winner is null)
+            if (winner is not null)
+            {
+                return new(ToResponse(winner), null, true);
+            }
+            var confirmed = await FindConfirmedByDigestAsync(
+                batch.OwnerId,
+                batch.SourceType,
+                batch.ParserRuleVersion,
+                batch.DocumentDigest,
+                cancellationToken);
+            if (confirmed is null)
             {
                 throw;
             }
-            return new(ToResponse(winner), null, true);
+            return Failed("already_imported", "This statement was already imported.");
         }
         finally
         {
@@ -380,11 +694,36 @@ public sealed class ImportPreviewService(
             ConstraintName: OpenDigestIndexName
         };
 
+    private static bool IsActiveDocumentUniqueViolation(DbUpdateException exception) =>
+        exception.InnerException is PostgresException
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            ConstraintName: ActiveDocumentIndexName
+        };
+
+    private static bool IsConfirmedDigestUniqueViolation(DbUpdateException exception) =>
+        exception.InnerException is PostgresException
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            ConstraintName: ConfirmedDigestIndexName
+        };
+
     private async Task ExpireOwnedAsync(string userId, CancellationToken cancellationToken)
     {
         var now = clock.GetUtcNow().UtcDateTime;
-        var expired = await context.ImportPreviewBatches
-            .Where(value => value.OwnerId == userId && value.Lifecycle == ImportPreviewLifecycle.Open && value.ExpiresAt <= now)
+        var query = context.ImportPreviewBatches
+            .Where(value => value.OwnerId == userId
+                && value.Lifecycle == ImportPreviewLifecycle.Open
+                && value.ExpiresAt <= now);
+        if (context.Database.IsRelational())
+        {
+            await query.ExecuteUpdateAsync(
+                setters => setters.SetProperty(value => value.Lifecycle, ImportPreviewLifecycle.Expired),
+                cancellationToken);
+            return;
+        }
+
+        var expired = await query
             .ToListAsync(cancellationToken);
         if (expired.Count == 0) return;
         foreach (var value in expired) value.Lifecycle = ImportPreviewLifecycle.Expired;
@@ -414,6 +753,23 @@ public sealed class ImportPreviewService(
     };
 
     private static ImportPreviewOperation Failed(string code, string message) => new(null, new(code, message));
+
+    private static ImportConfirmationOperation ConfirmationSucceeded(
+        ImportPreviewBatch batch,
+        string status,
+        int importedExpenseCount) => new(
+            new(
+                batch.Id,
+                status,
+                batch.ConfirmedAt ?? throw new InvalidOperationException("A confirmed batch requires a confirmation time."),
+                importedExpenseCount),
+            null);
+
+    private static ImportConfirmationOperation ConfirmationFailed(
+        string code,
+        string message,
+        IReadOnlyList<ImportConfirmationRowError>? rows = null) =>
+        new(null, new(code, message, rows ?? []));
 
     private static ImportPreviewOperation ProcessingInterrupted(CancellationToken requestToken) =>
         requestToken.IsCancellationRequested

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -394,7 +394,7 @@ public sealed class ImportPreviewService(
             }
 
             batch.Lifecycle = ImportPreviewLifecycle.Confirmed;
-            batch.ConfirmedAt = now;
+            batch.ConfirmedAt = TruncateToPostgreSqlTimestampPrecision(now);
             context.ImportPreviewRows.RemoveRange(batch.Rows);
             await context.SaveChangesAsync(cancellationToken);
             await CommitAsync(transaction, cancellationToken);
@@ -574,6 +574,9 @@ public sealed class ImportPreviewService(
     {
         if (transaction is not null) await transaction.RollbackAsync(CancellationToken.None);
     }
+
+    private static DateTime TruncateToPostgreSqlTimestampPrecision(DateTime value) =>
+        new(value.Ticks - (value.Ticks % TimeSpan.TicksPerMicrosecond), value.Kind);
 
     private async Task<ImportPreviewOperation> PersistOrReuseAsync(
         ImportPreviewBatch batch,

--- a/backend/Migrations/20260825155557_AddImportConfirmation.Designer.cs
+++ b/backend/Migrations/20260825155557_AddImportConfirmation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260825155557_AddImportConfirmation")]
+    partial class AddImportConfirmation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260825155557_AddImportConfirmation.cs
+++ b/backend/Migrations/20260825155557_AddImportConfirmation.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportConfirmation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ConfirmedAt",
+                table: "ImportPreviewBatches",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ImportExpenseProvenances",
+                columns: table => new
+                {
+                    BatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceRowOrdinal = table.Column<int>(type: "integer", nullable: false),
+                    ExpenseId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportExpenseProvenances", x => new { x.BatchId, x.SourceRowOrdinal });
+                    table.CheckConstraint("CK_ImportExpenseProvenance_PositiveSourceRowOrdinal", "\"SourceRowOrdinal\" > 0");
+                    table.ForeignKey(
+                        name: "FK_ImportExpenseProvenances_Expenses_ExpenseId",
+                        column: x => x.ExpenseId,
+                        principalTable: "Expenses",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ImportExpenseProvenances_ImportPreviewBatches_BatchId",
+                        column: x => x.BatchId,
+                        principalTable: "ImportPreviewBatches",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportPreviewBatches_ActiveDocument",
+                table: "ImportPreviewBatches",
+                columns: new[] { "OwnerId", "SourceType", "ParserRuleVersion", "DocumentDigest" },
+                unique: true,
+                filter: "\"Lifecycle\" IN ('Open', 'Confirmed')");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportPreviewBatches_ConfirmedDocument",
+                table: "ImportPreviewBatches",
+                columns: new[] { "OwnerId", "SourceType", "ParserRuleVersion", "DocumentDigest" },
+                unique: true,
+                filter: "\"Lifecycle\" = 'Confirmed'");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_ImportPreviewBatch_ConfirmedAt",
+                table: "ImportPreviewBatches",
+                sql: "(\"Lifecycle\" = 'Confirmed' AND \"ConfirmedAt\" IS NOT NULL) OR (\"Lifecycle\" <> 'Confirmed' AND \"ConfirmedAt\" IS NULL)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportExpenseProvenances_ExpenseId",
+                table: "ImportExpenseProvenances",
+                column: "ExpenseId",
+                unique: true,
+                filter: "\"ExpenseId\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DO $migration$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM "ImportPreviewBatches"
+                        WHERE "Lifecycle" = 'Confirmed' OR "ConfirmedAt" IS NOT NULL
+                    ) OR EXISTS (
+                        SELECT 1
+                        FROM "ImportExpenseProvenances"
+                    ) THEN
+                        RAISE EXCEPTION 'Cannot remove import confirmation schema while confirmed import data exists.';
+                    END IF;
+                END $migration$;
+                """);
+
+            migrationBuilder.DropTable(
+                name: "ImportExpenseProvenances");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ImportPreviewBatches_ActiveDocument",
+                table: "ImportPreviewBatches");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ImportPreviewBatches_ConfirmedDocument",
+                table: "ImportPreviewBatches");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_ImportPreviewBatch_ConfirmedAt",
+                table: "ImportPreviewBatches");
+
+            migrationBuilder.DropColumn(
+                name: "ConfirmedAt",
+                table: "ImportPreviewBatches");
+        }
+    }
+}

--- a/backend/Models/ImportExpenseProvenance.cs
+++ b/backend/Models/ImportExpenseProvenance.cs
@@ -1,0 +1,10 @@
+namespace BudgetPlanner.Models;
+
+public class ImportExpenseProvenance
+{
+    public Guid BatchId { get; set; }
+    public ImportPreviewBatch? Batch { get; set; }
+    public int SourceRowOrdinal { get; set; }
+    public int? ExpenseId { get; set; }
+    public Expense? Expense { get; set; }
+}

--- a/backend/Models/ImportPreviewBatch.cs
+++ b/backend/Models/ImportPreviewBatch.cs
@@ -3,7 +3,8 @@ namespace BudgetPlanner.Models;
 public enum ImportPreviewLifecycle
 {
     Open,
-    Expired
+    Expired,
+    Confirmed
 }
 
 public class ImportPreviewBatch
@@ -17,5 +18,7 @@ public class ImportPreviewBatch
     public DateTime CreatedAt { get; set; }
     public DateTime ExpiresAt { get; set; }
     public ImportPreviewLifecycle Lifecycle { get; set; }
+    public DateTime? ConfirmedAt { get; set; }
     public List<ImportPreviewRow> Rows { get; set; } = [];
+    public List<ImportExpenseProvenance> Provenance { get; set; } = [];
 }


### PR DESCRIPTION
## Summary

- add bodyless, authenticated `POST /api/import-previews/{batchId}/confirm`
- serialize row edits and confirmation with an owned PostgreSQL batch lock, revalidate selected server-owned rows, and atomically create ordinary Expenses plus minimal provenance
- require renewed review when a duplicate first appears at confirmation, while allowing explicitly reselected warned rows
- add stable retry behavior, exact confirmed-document re-upload blocking, and database constraints preventing concurrent duplicate confirmation/open previews
- remove temporary preview rows only after successful confirmation while retaining confirmed batch identity and nullable Expense provenance links

Closes #84

## Risk

**HIGH** — financial persistence, transaction/concurrency behavior, durable idempotency, and an additive EF Core migration. Implementation follows the owner-approved plan and amendment recorded on #84.

## Important implementation details

- success moves `Open -> Confirmed`, sets `ConfirmedAt`, creates all selected Expenses/provenance, and deletes preview rows in one transaction
- retry returns stable `already_confirmed`; zero selection, expiry, stale/foreign access, validation failure, database failure, and duplicate-review outcomes create no Expenses
- newly discovered fuzzy duplicates refresh warning/current match state, deselect affected rows, keep the batch Open, and return privacy-safe `409 duplicate_review_required`
- exact owner/source/rule-version/digest identity is protected by filtered `Open`/`Confirmed` and confirmed-document unique indexes
- provenance stores only batch ID, source-row ordinal, and nullable Expense ID; Expense deletion uses `ON DELETE SET NULL`

## Verification

Passed locally:

- `dotnet restore backend.Tests/backend.Tests.csproj`
- `dotnet build backend/backend.csproj --configuration Release --no-restore`
- `dotnet build backend.Tests/backend.Tests.csproj --configuration Release --no-restore`
- focused `ImportPreviewApiTests`: 34 passed
- non-PostgreSQL backend suite: 225 passed
- `dotnet tool restore`
- `dotnet ef migrations has-pending-model-changes ... --no-build` — no pending model changes
- generated and completely inspected the full idempotent migration SQL; the #84 section is additive only
- generated and inspected downgrade SQL; it refuses before dropping schema when confirmed/provenance data exists
- `git diff --check`

Local restore/build emitted only existing NuGet vulnerability-feed connectivity warnings (`NU1900`).

Not run locally — capability unavailable:

- PostgreSQL migration-chain and financial integration tests; no disposable local PostgreSQL service/connection is available. Successful **PostgreSQL financial integration** CI is required.

## Impact and scope boundaries

- API: new confirmation endpoint and safe confirmation response/error contracts; upload may now return `409 already_imported`
- migration: additive `20260825155557_AddImportConfirmation`; generated and reviewed, **not applied**
- dependencies/configuration: none
- no frontend confirmation workflow, parser/bank expansion, deployment, production access, or production migration
- do not merge until required CI and independent review pass; human retains merge and production-operation authority
