### PR TITLE
Finish Sunflower import confirmation frontend

### DIFF
--- a/frontend/src/features/importPreview/api/importPreviewApi.js
+++ b/frontend/src/features/importPreview/api/importPreviewApi.js
@@ -19,4 +19,7 @@ export const importPreviewApi = {
   updateRow(batchId, rowId, payload) {
     return client.patch(`/api/import-previews/${batchId}/rows/${rowId}`, payload);
   },
+  confirm(batchId) {
+    return client.post(`/api/import-previews/${batchId}/confirm`);
+  },
 };

--- a/frontend/src/features/importPreview/api/importPreviewApi.test.js
+++ b/frontend/src/features/importPreview/api/importPreviewApi.test.js
@@ -35,4 +35,10 @@ describe('importPreviewApi', () => {
       selectedForImport: true,
     })
   })
+
+  it('confirms the server-owned batch without a request body', () => {
+    importPreviewApi.confirm('batch-id')
+
+    expect(client.post).toHaveBeenCalledWith('/api/import-previews/batch-id/confirm')
+  })
 })

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
@@ -1,17 +1,100 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import Card from "../../../shared/ui/Card";
+import { isDefaultCategory, normalizeText } from "../../../utils/text";
 import ImportPreviewRow from "./ImportPreviewRow";
 
-export default function ImportPreviewPanel({ importState }) {
-  const { preview, sourceType, loading, processing, error, selectSource, upload, cancel, updateRow, clearForReupload } = importState;
+function createRowDraft(row, outcome = "idle") {
+  const category = row.category ?? "uncategorized";
+  const defaultCategory = isDefaultCategory(category, DEFAULT_CATEGORIES) || category === "uncategorized";
+  return {
+    description: row.editableExpenseDescription ?? "",
+    categoryChoice: defaultCategory ? normalizeText(category) : "other",
+    customCategory: defaultCategory ? "" : category,
+    dirty: false,
+    pending: false,
+    outcome,
+  };
+}
+
+function categoryFromDraft(draft) {
+  return draft.categoryChoice === "other"
+    ? normalizeText(draft.customCategory)
+    : draft.categoryChoice;
+}
+
+function isDraftDirty(draft, row) {
+  return draft.description.trim() !== (row.editableExpenseDescription ?? "")
+    || categoryFromDraft(draft) !== (row.category ?? "");
+}
+
+function formatConfirmationTime(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "an unavailable time" : date.toLocaleString();
+}
+
+function issueTitle(code) {
+  if (code === "duplicate_review_required") return "Review new duplicate warnings";
+  if (code === "preview_expired") return "Preview expired";
+  if (code === "preview_unavailable") return "Preview unavailable";
+  return "Expenses were not imported";
+}
+
+function focusAfterRender(ref) {
+  const focus = () => ref.current?.focus();
+  if (typeof window.requestAnimationFrame === "function") window.requestAnimationFrame(focus);
+  else window.setTimeout(focus, 0);
+}
+
+export default function ImportPreviewPanel({ importState, onImportConfirmed = async () => {} }) {
+  const {
+    preview,
+    sourceType,
+    loading,
+    processing,
+    error,
+    confirming,
+    confirmation,
+    confirmationIssue,
+    selectedCount,
+    selectSource,
+    upload,
+    cancel,
+    updateRow,
+    confirm,
+    clearForReupload,
+  } = importState;
   const [dragging, setDragging] = useState(false);
+  const [rowDrafts, setRowDrafts] = useState({ batchId: null, rows: {} });
+  const [refreshError, setRefreshError] = useState("");
+  const rowUpdatesInFlight = useRef(new Set());
   const fileInput = useRef(null);
   const resultsHeading = useRef(null);
+  const completionHeading = useRef(null);
+  const issueHeading = useRef(null);
+
+  useEffect(() => {
+    setRowDrafts((current) => {
+      if (!preview) return current.batchId === null ? current : { batchId: null, rows: {} };
+      const sameBatch = current.batchId === preview.batchId;
+      const rows = Object.fromEntries(preview.rows.map((row) => {
+        const existing = sameBatch ? current.rows[row.rowId] : null;
+        if (existing?.dirty || existing?.pending) return [row.rowId, existing];
+        return [row.rowId, createRowDraft(row, existing?.outcome === "saved" ? "saved" : "idle")];
+      }));
+      return { batchId: preview.batchId, rows };
+    });
+  }, [preview]);
+
+  useEffect(() => {
+    if (!confirmation) setRefreshError("");
+  }, [confirmation]);
 
   async function submitFile(file) {
     if (!file || !sourceType) return;
+    setRefreshError("");
     const result = await upload(file);
-    if (result) requestAnimationFrame(() => resultsHeading.current?.focus());
+    if (result) focusAfterRender(resultsHeading);
   }
 
   function drop(event) {
@@ -21,20 +104,207 @@ export default function ImportPreviewPanel({ importState }) {
     submitFile(event.dataTransfer.files?.[0]);
   }
 
+  function draftFor(row) {
+    return rowDrafts.batchId === preview?.batchId && rowDrafts.rows[row.rowId]
+      ? rowDrafts.rows[row.rowId]
+      : createRowDraft(row);
+  }
+
+  function changeDraft(row, changes) {
+    setRowDrafts((current) => {
+      const sameBatch = current.batchId === preview?.batchId;
+      const existing = sameBatch && current.rows[row.rowId]
+        ? current.rows[row.rowId]
+        : createRowDraft(row);
+      const updated = { ...existing, ...changes, outcome: "idle" };
+      updated.dirty = isDraftDirty(updated, row);
+      return {
+        batchId: preview.batchId,
+        rows: { ...(sameBatch ? current.rows : {}), [row.rowId]: updated },
+      };
+    });
+  }
+
+  function markRowPending(row) {
+    setRowDrafts((current) => {
+      const existing = current.batchId === preview?.batchId && current.rows[row.rowId]
+        ? current.rows[row.rowId]
+        : createRowDraft(row);
+      return {
+        batchId: preview.batchId,
+        rows: {
+          ...(current.batchId === preview?.batchId ? current.rows : {}),
+          [row.rowId]: { ...existing, pending: true, outcome: "idle" },
+        },
+      };
+    });
+  }
+
+  function finishRowUpdate(row, updatedRow, savedFields) {
+    setRowDrafts((current) => {
+      const existing = current.rows[row.rowId] ?? createRowDraft(row);
+      if (!updatedRow) {
+        return {
+          ...current,
+          rows: {
+            ...current.rows,
+            [row.rowId]: { ...existing, pending: false, outcome: "error" },
+          },
+        };
+      }
+      if (savedFields) {
+        return {
+          ...current,
+          rows: {
+            ...current.rows,
+            [row.rowId]: createRowDraft(updatedRow, "saved"),
+          },
+        };
+      }
+
+      const next = { ...existing, pending: false };
+      next.dirty = isDraftDirty(next, updatedRow);
+      next.outcome = next.dirty ? "idle" : "saved";
+      return {
+        ...current,
+        rows: { ...current.rows, [row.rowId]: next },
+      };
+    });
+  }
+
+  async function runRowUpdate(row, payload, savedFields) {
+    if (confirming || confirmationIssue?.requiresPreviewRefresh || rowUpdatesInFlight.current.has(row.rowId)) return null;
+    rowUpdatesInFlight.current.add(row.rowId);
+    markRowPending(row);
+    try {
+      const updatedRow = await updateRow(row.rowId, payload);
+      finishRowUpdate(row, updatedRow, savedFields);
+      return updatedRow;
+    } catch {
+      finishRowUpdate(row, null, savedFields);
+      return null;
+    } finally {
+      rowUpdatesInFlight.current.delete(row.rowId);
+    }
+  }
+
+  async function saveRow(row) {
+    const draft = draftFor(row);
+    if (!draft.dirty) return null;
+    return runRowUpdate(row, {
+      editableExpenseDescription: draft.description.trim(),
+      category: categoryFromDraft(draft),
+      selectedForImport: row.selectedForImport,
+    }, true);
+  }
+
+  async function updateSelection(row, selectedForImport) {
+    return runRowUpdate(row, {
+      editableExpenseDescription: row.editableExpenseDescription,
+      category: row.category,
+      selectedForImport,
+    }, false);
+  }
+
+  const drafts = Object.values(rowDrafts.rows);
+  const hasPendingRows = drafts.some((draft) => draft.pending);
+  const hasDirtyRows = drafts.some((draft) => draft.dirty);
+  const confirmationNeedsRefresh = Boolean(confirmationIssue?.requiresPreviewRefresh);
+  const confirmDisabled = selectedCount === 0
+    || hasPendingRows
+    || hasDirtyRows
+    || confirming
+    || confirmationNeedsRefresh;
+
+  async function handleConfirm() {
+    if (confirmDisabled || rowUpdatesInFlight.current.size > 0) return;
+    setRefreshError("");
+    const result = await confirm();
+    if (!result) {
+      focusAfterRender(issueHeading);
+      return;
+    }
+
+    focusAfterRender(completionHeading);
+    try {
+      await onImportConfirmed();
+    } catch {
+      setRefreshError("Expenses were imported, but Transactions could not be refreshed. Reload this page to see them.");
+    }
+  }
+
+  function confirmationGuidance() {
+    if (confirmationNeedsRefresh) return "Refresh this page to load the authoritative duplicate review before confirming.";
+    if (hasPendingRows) return "Wait for every row update to finish before confirming.";
+    if (hasDirtyRows) return "Save every row with unsaved changes before confirming.";
+    if (selectedCount === 0) return "Select at least one eligible row to import.";
+    return `${selectedCount} selected ${selectedCount === 1 ? "expense is" : "expenses are"} ready to import.`;
+  }
+
+  function confirmationCodesFor(rowId) {
+    return confirmationIssue?.rows.find((row) => row.rowId === rowId)?.codes ?? [];
+  }
+
+  function renderRow(row, presentation) {
+    return (
+      <ImportPreviewRow
+        key={row.rowId}
+        row={row}
+        draft={draftFor(row)}
+        confirmationCodes={confirmationCodesFor(row.rowId)}
+        disabled={confirming || confirmationNeedsRefresh}
+        presentation={presentation}
+        onDraftChange={(changes) => changeDraft(row, changes)}
+        onSave={() => saveRow(row)}
+        onSelectionChange={(selected) => updateSelection(row, selected)}
+      />
+    );
+  }
+
   return (
     <Card as="section" className="section import-preview" aria-labelledby="import-preview-title">
       <div className="section__header import-preview__header">
         <div>
-          <p className="page-header__eyebrow">Preview only</p>
+          <p className="page-header__eyebrow">
+            {confirmation ? "Import complete" : preview ? "Review and confirm" : "Bank statement import"}
+          </p>
           <h2 className="h2" id="import-preview-title">Import bank statement</h2>
           <p className="muted">Choose the bank, then upload a text-extractable PDF up to 10 MiB. Scanned statements are not supported.</p>
         </div>
-        {preview && <button type="button" className="button-ghost" onClick={clearForReupload}>Choose another statement</button>}
+        {preview && (
+          <button
+            type="button"
+            className="button-ghost"
+            disabled={confirming || hasPendingRows}
+            onClick={clearForReupload}
+          >
+            Choose another statement
+          </button>
+        )}
       </div>
 
-      <div className="status-message status-message--info">
-        Preview only — no expenses have been created. Confirmation is not available yet.
-      </div>
+      {!confirmation && (
+        <div className="status-message status-message--info">
+          Review and save any edits before importing. Expenses are created only after confirmation.
+        </div>
+      )}
+
+      {confirmation && (
+        <div className="status-message status-message--success import-completion" role="status" aria-live="polite">
+          <h3 className="h3" ref={completionHeading} tabIndex="-1">
+            {confirmation.status === "already_confirmed" ? "Statement already imported" : "Import complete"}
+          </h3>
+          <p>
+            {confirmation.importedExpenseCount} {confirmation.importedExpenseCount === 1 ? "expense" : "expenses"}
+            {confirmation.status === "already_confirmed"
+              ? confirmation.importedExpenseCount === 1 ? " was already imported" : " were already imported"
+              : " imported"}
+            {` at ${formatConfirmationTime(confirmation.confirmedAt)}.`}
+          </p>
+        </div>
+      )}
+
+      {refreshError && <div className="status-message status-message--danger" role="alert">{refreshError}</div>}
 
       <div className="import-source-control">
         <label htmlFor="statement-source">Bank</label>
@@ -42,8 +312,11 @@ export default function ImportPreviewPanel({ importState }) {
           id="statement-source"
           required
           value={sourceType}
-          disabled={processing || Boolean(preview)}
-          onChange={(event) => selectSource(event.target.value)}
+          disabled={processing || confirming || Boolean(preview)}
+          onChange={(event) => {
+            setRefreshError("");
+            selectSource(event.target.value);
+          }}
         >
           <option value="">Choose a bank</option>
           <option value="sunflower_pdf">Sunflower Bank</option>
@@ -52,6 +325,12 @@ export default function ImportPreviewPanel({ importState }) {
       </div>
 
       {error && <div className="status-message status-message--danger" role="alert">{error}</div>}
+      {confirmationIssue && (
+        <div className="status-message status-message--danger" role="alert">
+          <h3 className="h3" ref={issueHeading} tabIndex="-1">{issueTitle(confirmationIssue.code)}</h3>
+          <p>{confirmationIssue.message}</p>
+        </div>
+      )}
       {(loading || processing) && (
         <div className="import-processing" role="status" aria-live="polite">
           <span>{loading ? "Looking for an unfinished preview…" : "Processing the statement safely…"}</span>
@@ -85,24 +364,38 @@ export default function ImportPreviewPanel({ importState }) {
       {preview && (
         <div className="import-results">
           <div className="import-results__summary">
-            <h3 className="h3" ref={resultsHeading} tabIndex="-1">Statement preview</h3>
-            <p className="muted">{preview.rows.length} rows · available until {new Date(preview.expiresAt).toLocaleString()}</p>
+            <div>
+              <h3 className="h3" ref={resultsHeading} tabIndex="-1">Statement preview</h3>
+              <p className="muted">{preview.rows.length} rows · available until {new Date(preview.expiresAt).toLocaleString()}</p>
+            </div>
+            <div className="import-confirmation-actions">
+              <p id="import-confirmation-guidance" className="muted" role="status" aria-live="polite">
+                {confirmationGuidance()}
+              </p>
+              <button
+                type="button"
+                disabled={confirmDisabled}
+                aria-busy={confirming}
+                aria-describedby="import-confirmation-guidance"
+                onClick={handleConfirm}
+              >
+                {confirming
+                  ? "Importing expenses…"
+                  : selectedCount > 0
+                    ? `Import ${selectedCount} selected ${selectedCount === 1 ? "expense" : "expenses"}`
+                    : "Import selected expenses"}
+              </button>
+            </div>
           </div>
           <div className="table-wrapper import-preview-table" role="region" aria-label="Statement import preview" tabIndex="0">
             <table className="data-table">
               <caption>Sunflower Bank statement rows</caption>
               <thead><tr><th>Row</th><th>Statement details</th><th>Status</th><th>Selection</th><th>Expense fields</th></tr></thead>
-              <tbody>
-                {preview.rows.map((row) => (
-                  <ImportPreviewRow key={row.rowId} row={row} onUpdate={(payload) => updateRow(row.rowId, payload)} />
-                ))}
-              </tbody>
+              <tbody>{preview.rows.map((row) => renderRow(row, "table"))}</tbody>
             </table>
           </div>
           <div className="import-preview-cards">
-            {preview.rows.map((row) => (
-              <ImportPreviewRow key={row.rowId} row={row} presentation="card" onUpdate={(payload) => updateRow(row.rowId, payload)} />
-            ))}
+            {preview.rows.map((row) => renderRow(row, "card"))}
           </div>
         </div>
       )}

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
@@ -1,0 +1,235 @@
+import { act, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ImportPreviewPanel from './ImportPreviewPanel'
+
+const row = {
+  rowId: 'row-1',
+  sourceRowOrdinal: 1,
+  postedDate: '2026-08-12',
+  amount: 8.5,
+  direction: 'debit',
+  sourceDescription: 'SYNTHETIC CAFE',
+  sourceSection: 'electronic_transactions',
+  classification: 'expense_candidate',
+  isEligible: true,
+  errors: [],
+  warnings: [],
+  isPossibleDuplicate: false,
+  editableExpenseDescription: 'Coffee',
+  category: 'food',
+  selectedForImport: true,
+}
+
+const preview = {
+  batchId: '11111111-1111-1111-1111-111111111111',
+  sourceType: 'sunflower_pdf',
+  expiresAt: '2026-08-26T12:00:00Z',
+  rows: [row],
+}
+
+function importState(overrides = {}) {
+  return {
+    preview,
+    sourceType: 'sunflower_pdf',
+    loading: false,
+    processing: false,
+    error: '',
+    confirming: false,
+    confirmation: null,
+    confirmationIssue: null,
+    selectedCount: 1,
+    selectSource: vi.fn(),
+    upload: vi.fn(),
+    cancel: vi.fn(),
+    updateRow: vi.fn(),
+    confirm: vi.fn(),
+    clearForReupload: vi.fn(),
+    ...overrides,
+  }
+}
+
+function tableRegion() {
+  return screen.getByRole('region', { name: 'Statement import preview' })
+}
+
+describe('ImportPreviewPanel confirmation safety', () => {
+  it('shares one draft across desktop and mobile presentations and blocks confirmation while dirty', async () => {
+    const user = userEvent.setup()
+    const state = importState()
+    render(<ImportPreviewPanel importState={state} />)
+    const table = tableRegion()
+    const card = screen.getByRole('article', { name: 'Statement row 1' })
+
+    await user.clear(within(table).getByLabelText('Expense description'))
+    await user.type(within(table).getByLabelText('Expense description'), 'Morning coffee')
+
+    expect(within(card).getByLabelText('Expense description')).toHaveValue('Morning coffee')
+    expect(within(table).getByRole('status')).toHaveTextContent('Unsaved changes')
+    expect(screen.getByText('Save every row with unsaved changes before confirming.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(state.confirm).not.toHaveBeenCalled()
+  })
+
+  it('announces saving, saved, and dirty-again states while preventing a PATCH/confirm race', async () => {
+    const user = userEvent.setup()
+    let resolveUpdate
+    const updateRow = vi.fn().mockReturnValue(new Promise((resolve) => { resolveUpdate = resolve }))
+    const state = importState({ updateRow })
+    render(<ImportPreviewPanel importState={state} />)
+    const table = tableRegion()
+    const description = within(table).getByLabelText('Expense description')
+
+    await user.clear(description)
+    await user.type(description, 'Morning coffee')
+    await user.click(within(table).getByRole('button', { name: 'Save row' }))
+
+    expect(within(table).getByRole('status')).toHaveTextContent('Saving…')
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(updateRow).toHaveBeenCalledWith('row-1', {
+      editableExpenseDescription: 'Morning coffee',
+      category: 'food',
+      selectedForImport: true,
+    })
+
+    await act(async () => {
+      resolveUpdate({ ...row, editableExpenseDescription: 'Morning coffee' })
+    })
+    expect(within(table).getByRole('status')).toHaveTextContent('Saved')
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeEnabled()
+
+    await user.type(description, ' again')
+    expect(within(table).getByRole('status')).toHaveTextContent('Unsaved changes')
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+  })
+
+  it('keeps a failed save draft visible and customer-readable', async () => {
+    const user = userEvent.setup()
+    const state = importState({ updateRow: vi.fn().mockResolvedValue(null) })
+    render(<ImportPreviewPanel importState={state} />)
+    const table = tableRegion()
+    const description = within(table).getByLabelText('Expense description')
+
+    await user.clear(description)
+    await user.type(description, 'Unsaved coffee')
+    await user.click(within(table).getByRole('button', { name: 'Save row' }))
+
+    expect(await within(table).findByRole('alert')).toHaveTextContent('Save failed. Changes remain unsaved.')
+    expect(description).toHaveValue('Unsaved coffee')
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+  })
+
+  it('tracks selection PATCH state before enabling confirmation', async () => {
+    const user = userEvent.setup()
+    let resolveUpdate
+    const updateRow = vi.fn().mockReturnValue(new Promise((resolve) => { resolveUpdate = resolve }))
+    render(<ImportPreviewPanel importState={importState({ updateRow })} />)
+    const table = tableRegion()
+
+    await user.click(within(table).getByLabelText('Select for import'))
+
+    expect(within(table).getByLabelText('Select for import')).toBeDisabled()
+    expect(within(table).getByRole('status')).toHaveTextContent('Saving…')
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+
+    await act(async () => { resolveUpdate({ ...row, selectedForImport: false }) })
+    expect(within(table).getByRole('status')).toHaveTextContent('Saved')
+  })
+
+  it('shows one accessible responsive confirmation action and clear zero-selection guidance', () => {
+    render(<ImportPreviewPanel importState={importState({ selectedCount: 0 })} />)
+
+    const buttons = screen.getAllByRole('button', { name: 'Import selected expenses' })
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0]).toBeDisabled()
+    expect(buttons[0]).toHaveAttribute('aria-describedby', 'import-confirmation-guidance')
+    expect(buttons[0]).toHaveAttribute('aria-busy', 'false')
+    expect(screen.getByText('Select at least one eligible row to import.')).toHaveAttribute('role', 'status')
+    expect(screen.getByRole('region', { name: 'Statement import preview' })).toBeInTheDocument()
+    expect(screen.getByRole('article', { name: 'Statement row 1' })).toBeInTheDocument()
+  })
+
+  it('prevents duplicate UI submits while confirmation is in flight', async () => {
+    const state = importState({ confirming: true })
+    render(<ImportPreviewPanel importState={state} />)
+
+    const button = screen.getByRole('button', { name: 'Importing expenses…' })
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+    expect(within(tableRegion()).getByLabelText('Select for import')).toBeDisabled()
+  })
+
+  it('refreshes ordinary Expenses only after a successful confirmation result', async () => {
+    const user = userEvent.setup()
+    const confirmation = {
+      batchId: preview.batchId,
+      status: 'confirmed',
+      confirmedAt: '2026-08-25T21:00:00Z',
+      importedExpenseCount: 1,
+    }
+    const confirm = vi.fn().mockResolvedValue(confirmation)
+    const onImportConfirmed = vi.fn().mockResolvedValue(undefined)
+    render(<ImportPreviewPanel importState={importState({ confirm })} onImportConfirmed={onImportConfirmed} />)
+
+    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(onImportConfirmed).toHaveBeenCalledOnce()
+  })
+
+  it('does not refresh Expenses after a failed confirmation result', async () => {
+    const user = userEvent.setup()
+    const onImportConfirmed = vi.fn()
+    render(
+      <ImportPreviewPanel
+        importState={importState({ confirm: vi.fn().mockResolvedValue(null) })}
+        onImportConfirmed={onImportConfirmed}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+
+    expect(onImportConfirmed).not.toHaveBeenCalled()
+  })
+
+  it('keeps durable success distinct from a failed Transactions refresh', async () => {
+    const user = userEvent.setup()
+    const result = {
+      batchId: preview.batchId,
+      status: 'already_confirmed',
+      confirmedAt: '2026-08-25T21:00:00Z',
+      importedExpenseCount: 1,
+    }
+    const state = importState({ confirm: vi.fn().mockResolvedValue(result) })
+    const { rerender } = render(
+      <ImportPreviewPanel importState={state} onImportConfirmed={vi.fn().mockRejectedValue(new Error('offline'))} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Expenses were imported, but Transactions could not be refreshed')
+
+    rerender(<ImportPreviewPanel importState={importState({
+      preview: null,
+      selectedCount: 0,
+      confirmation: result,
+    })} />)
+    expect(screen.getByRole('heading', { name: 'Statement already imported' })).toBeInTheDocument()
+    expect(screen.getByText(/1 expense was already imported/)).toBeInTheDocument()
+  })
+
+  it('shows safe row-level duplicate guidance and blocks a stale review', () => {
+    render(<ImportPreviewPanel importState={importState({
+      confirmationIssue: {
+        code: 'duplicate_review_required',
+        message: 'New duplicate warnings were saved, but the latest preview could not be loaded. Refresh this page before confirming.',
+        rows: [{ rowId: 'row-1', codes: ['possible_duplicate'] }],
+        requiresPreviewRefresh: true,
+      },
+    })} />)
+
+    expect(screen.getByRole('heading', { name: 'Review new duplicate warnings' })).toBeInTheDocument()
+    expect(within(tableRegion()).getByText(/New possible duplicate/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByText(/Refresh this page to load the authoritative duplicate review/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
-import { displayText, isDefaultCategory, normalizeText } from "../../../utils/text";
+import { displayText } from "../../../utils/text";
 
 const STATUS_LABELS = {
   expense_candidate: "Expense candidate",
@@ -9,41 +8,48 @@ const STATUS_LABELS = {
   invalid: "Invalid row",
 };
 
-function RowFields({ row, onUpdate }) {
-  const defaultCategory = isDefaultCategory(row.category, DEFAULT_CATEGORIES) || row.category === "uncategorized";
-  const [description, setDescription] = useState(row.editableExpenseDescription ?? "");
-  const [categoryChoice, setCategoryChoice] = useState(defaultCategory ? row.category : "other");
-  const [customCategory, setCustomCategory] = useState(defaultCategory ? "" : row.category ?? "");
-  const [saving, setSaving] = useState(false);
+const CONFIRMATION_CODE_MESSAGES = {
+  possible_duplicate: "New possible duplicate — review this row and explicitly select it again if it should be imported.",
+  row_not_selectable: "This row is not eligible to become an expense.",
+  date_required: "A transaction date is required.",
+  amount_must_be_positive: "The expense amount must be positive.",
+  amount_out_of_range: "The expense amount is outside the supported range.",
+  amount_precision_invalid: "The expense amount must use no more than two decimal places.",
+  description_required: "An expense description is required.",
+  description_too_long: "The expense description is too long.",
+  category_required: "An expense category is required.",
+  category_too_long: "The expense category is too long.",
+  category_reserved: "Choose a category other than Other.",
+};
 
-  useEffect(() => {
-    setDescription(row.editableExpenseDescription ?? "");
-    const isDefault = isDefaultCategory(row.category, DEFAULT_CATEGORIES) || row.category === "uncategorized";
-    setCategoryChoice(isDefault ? row.category : "other");
-    setCustomCategory(isDefault ? "" : row.category ?? "");
-  }, [row]);
-
+function RowFields({ row, draft, disabled, onDraftChange, onSave }) {
   if (!row.isEligible) return <span className="muted">Not editable</span>;
 
-  async function save() {
-    setSaving(true);
-    await onUpdate({
-      editableExpenseDescription: description.trim(),
-      category: categoryChoice === "other" ? normalizeText(customCategory) : categoryChoice,
-      selectedForImport: row.selectedForImport,
-    });
-    setSaving(false);
-  }
+  const saveStatus = draft.pending
+    ? "Saving…"
+    : draft.outcome === "error"
+      ? draft.dirty ? "Save failed. Changes remain unsaved." : "The row update failed. Try again."
+      : draft.dirty
+        ? "Unsaved changes"
+        : draft.outcome === "saved" ? "Saved" : "";
 
   return (
     <div className="import-row-fields">
       <label>
         <span>Expense description</span>
-        <input value={description} onChange={(event) => setDescription(event.target.value)} />
+        <input
+          value={draft.description}
+          disabled={disabled || draft.pending}
+          onChange={(event) => onDraftChange({ description: event.target.value })}
+        />
       </label>
       <label>
         <span>Category</span>
-        <select value={categoryChoice} onChange={(event) => setCategoryChoice(event.target.value)}>
+        <select
+          value={draft.categoryChoice}
+          disabled={disabled || draft.pending}
+          onChange={(event) => onDraftChange({ categoryChoice: event.target.value })}
+        >
           {DEFAULT_CATEGORIES.map((category) => (
             <option key={category} value={category.toLowerCase()}>{displayText(category)}</option>
           ))}
@@ -51,20 +57,38 @@ function RowFields({ row, onUpdate }) {
           <option value="other">Other</option>
         </select>
       </label>
-      {categoryChoice === "other" && (
+      {draft.categoryChoice === "other" && (
         <label>
           <span>Custom category</span>
-          <input value={customCategory} onChange={(event) => setCustomCategory(event.target.value)} />
+          <input
+            value={draft.customCategory}
+            disabled={disabled || draft.pending}
+            onChange={(event) => onDraftChange({ customCategory: event.target.value })}
+          />
         </label>
       )}
-      <button type="button" className="button-ghost" disabled={saving} onClick={save}>
-        {saving ? "Saving…" : "Save row"}
+      <button
+        type="button"
+        className="button-ghost"
+        disabled={disabled || draft.pending || !draft.dirty}
+        onClick={onSave}
+      >
+        {draft.pending ? "Saving…" : "Save row"}
       </button>
+      {saveStatus && (
+        <span
+          className={draft.outcome === "error" ? "import-save-status import-save-status--error" : "import-save-status"}
+          role={draft.outcome === "error" ? "alert" : "status"}
+          aria-live="polite"
+        >
+          {saveStatus}
+        </span>
+      )}
     </div>
   );
 }
 
-function RowStatus({ row }) {
+function RowStatus({ row, confirmationCodes }) {
   return (
     <div className="import-row-status">
       <span className={`import-status import-status--${row.classification}`}>
@@ -77,28 +101,37 @@ function RowStatus({ row }) {
       {row.warnings.filter((code) => code !== "possible_duplicate").map((code) => (
         <span className="import-warning" key={code}>Warning: {code.replaceAll("_", " ")}</span>
       ))}
+      {confirmationCodes.map((code) => (
+        <span
+          className={code === "possible_duplicate" ? "import-warning" : "import-error"}
+          key={`confirmation-${code}`}
+        >
+          {CONFIRMATION_CODE_MESSAGES[code]}
+        </span>
+      ))}
     </div>
   );
 }
 
-export default function ImportPreviewRow({ row, onUpdate, presentation = "table" }) {
-  async function updateSelection(selectedForImport) {
-    await onUpdate({
-      editableExpenseDescription: row.editableExpenseDescription,
-      category: row.category,
-      selectedForImport,
-    });
-  }
-
+export default function ImportPreviewRow({
+  row,
+  draft,
+  confirmationCodes = [],
+  disabled = false,
+  onDraftChange,
+  onSave,
+  onSelectionChange,
+  presentation = "table",
+}) {
   const selection = (
     <label className="import-selection">
       <input
         type="checkbox"
         checked={row.selectedForImport}
-        disabled={!row.isEligible}
-        onChange={(event) => updateSelection(event.target.checked)}
+        disabled={!row.isEligible || disabled || draft.pending}
+        onChange={(event) => onSelectionChange(event.target.checked)}
       />
-      <span>{row.isEligible ? "Select for future import" : "Not selectable"}</span>
+      <span>{row.isEligible ? "Select for import" : "Not selectable"}</span>
     </label>
   );
 
@@ -112,13 +145,23 @@ export default function ImportPreviewRow({ row, onUpdate, presentation = "table"
     </>
   );
 
+  const fields = (
+    <RowFields
+      row={row}
+      draft={draft}
+      disabled={disabled}
+      onDraftChange={onDraftChange}
+      onSave={onSave}
+    />
+  );
+
   if (presentation === "card") {
     return (
       <article className="import-preview-card" aria-label={`Statement row ${row.sourceRowOrdinal}`}>
         <div className="import-preview-card__details">{details}</div>
-        <RowStatus row={row} />
+        <RowStatus row={row} confirmationCodes={confirmationCodes} />
         {selection}
-        <RowFields row={row} onUpdate={onUpdate} />
+        {fields}
       </article>
     );
   }
@@ -127,9 +170,9 @@ export default function ImportPreviewRow({ row, onUpdate, presentation = "table"
     <tr>
       <td>{row.sourceRowOrdinal}</td>
       <td>{details}</td>
-      <td><RowStatus row={row} /></td>
+      <td><RowStatus row={row} confirmationCodes={confirmationCodes} /></td>
       <td>{selection}</td>
-      <td><RowFields row={row} onUpdate={onUpdate} /></td>
+      <td>{fields}</td>
     </tr>
   );
 }

--- a/frontend/src/features/importPreview/hooks/useImportPreview.js
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.js
@@ -14,13 +14,73 @@ const SAFE_ERRORS = {
   processing_timed_out: "Statement processing timed out. Try the upload again.",
   processing_cancelled: "Statement processing was cancelled.",
   import_in_progress: "Another statement is already being processed.",
+  already_imported: "This statement was already imported. No duplicate expenses were created.",
   row_not_selectable: "That row cannot be selected for import.",
   row_validation_failed: "Check the description and category, then try again.",
 };
 
+const CONFIRMATION_MESSAGES = {
+  no_rows_selected: "Select at least one eligible row before importing expenses.",
+  duplicate_review_required: "New possible duplicates were found. Review the affected rows and explicitly select any row you still want to import.",
+  confirmation_validation_failed: "One or more selected rows need attention before expenses can be imported.",
+  confirmation_conflict: "The statement could not be confirmed because its import state changed. Review the preview and try again.",
+  confirmation_failed: "The statement could not be confirmed safely. Nothing is being reported as imported; you can try again.",
+  preview_expired: "This preview expired. Re-upload the statement to create a new review.",
+  preview_unavailable: "This import preview is unavailable. Choose the bank and upload the statement again.",
+};
+
+const SAFE_CONFIRMATION_ROW_CODES = new Set([
+  "possible_duplicate",
+  "row_not_selectable",
+  "date_required",
+  "amount_must_be_positive",
+  "amount_out_of_range",
+  "amount_precision_invalid",
+  "description_required",
+  "description_too_long",
+  "category_required",
+  "category_too_long",
+  "category_reserved",
+]);
+
 function safeError(error, fallback) {
   const code = error?.response?.data?.code;
   return SAFE_ERRORS[code] ?? fallback;
+}
+
+function safeConfirmationRows(rows) {
+  if (!Array.isArray(rows)) return [];
+  return rows.flatMap((row) => {
+    if (typeof row?.rowId !== "string" || !Array.isArray(row.codes)) return [];
+    const codes = row.codes.filter((code) => SAFE_CONFIRMATION_ROW_CODES.has(code));
+    return codes.length > 0 ? [{ rowId: row.rowId, codes }] : [];
+  });
+}
+
+function safeConfirmationIssue(error) {
+  const status = error?.response?.status;
+  const responseData = error?.response?.data;
+  const responseCode = typeof responseData?.code === "string" ? responseData.code : "";
+  const code = status === 404
+    ? "preview_unavailable"
+    : Object.hasOwn(CONFIRMATION_MESSAGES, responseCode)
+      ? responseCode
+      : "confirmation_failed";
+  return {
+    code,
+    message: CONFIRMATION_MESSAGES[code],
+    rows: safeConfirmationRows(responseData?.rows),
+    requiresPreviewRefresh: false,
+  };
+}
+
+function isConfirmationResponse(value, batchId) {
+  return value
+    && value.batchId === batchId
+    && (value.status === "confirmed" || value.status === "already_confirmed")
+    && typeof value.confirmedAt === "string"
+    && Number.isInteger(value.importedExpenseCount)
+    && value.importedExpenseCount >= 0;
 }
 
 function batchIdFromLocation() {
@@ -45,7 +105,11 @@ export function useImportPreview() {
   const [loading, setLoading] = useState(true);
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [confirmation, setConfirmation] = useState(null);
+  const [confirmationIssue, setConfirmationIssue] = useState(null);
   const processingController = useRef(null);
+  const confirmationInFlight = useRef(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -61,7 +125,12 @@ export function useImportPreview() {
         }
       } catch (requestError) {
         if (!axios.isCancel(requestError)) {
-          setError(safeError(requestError, "The saved import preview could not be loaded."));
+          if (requestError?.response?.status === 404) {
+            forgetBatch();
+            setError(CONFIRMATION_MESSAGES.preview_unavailable);
+          } else {
+            setError(safeError(requestError, "The saved import preview could not be loaded."));
+          }
         }
       } finally {
         if (!controller.signal.aborted) setLoading(false);
@@ -79,6 +148,8 @@ export function useImportPreview() {
     setSourceType(nextSourceType);
     setPreview(null);
     setError("");
+    setConfirmation(null);
+    setConfirmationIssue(null);
     if (!nextSourceType) {
       setLoading(false);
       return null;
@@ -112,6 +183,8 @@ export function useImportPreview() {
     processingController.current = controller;
     setProcessing(true);
     setError("");
+    setConfirmation(null);
+    setConfirmationIssue(null);
     try {
       const response = await importPreviewApi.upload(sourceType, file, controller.signal);
       setPreview(response.data);
@@ -141,6 +214,15 @@ export function useImportPreview() {
         ...current,
         rows: current.rows.map((row) => row.rowId === rowId ? response.data : row),
       }));
+      setConfirmationIssue((current) => {
+        if (!current) return null;
+        if (current.code === "no_rows_selected" && payload.selectedForImport) return null;
+        if (!current.rows.some((row) => row.rowId === rowId)) return current;
+        return {
+          ...current,
+          rows: current.rows.filter((row) => row.rowId !== rowId),
+        };
+      });
       return response.data;
     } catch (requestError) {
       setError(safeError(requestError, "The preview row could not be updated."));
@@ -148,11 +230,61 @@ export function useImportPreview() {
     }
   }, [preview]);
 
+  const confirm = useCallback(async () => {
+    if (!preview || confirmationInFlight.current) return null;
+    const batchId = preview.batchId;
+    confirmationInFlight.current = true;
+    setConfirming(true);
+    setConfirmationIssue(null);
+    setError("");
+    try {
+      const response = await importPreviewApi.confirm(batchId);
+      if (!isConfirmationResponse(response.data, batchId)) {
+        setConfirmationIssue({
+          code: "confirmation_failed",
+          message: CONFIRMATION_MESSAGES.confirmation_failed,
+          rows: [],
+          requiresPreviewRefresh: false,
+        });
+        return null;
+      }
+
+      setConfirmation(response.data);
+      setPreview(null);
+      forgetBatch();
+      return response.data;
+    } catch (requestError) {
+      const issue = safeConfirmationIssue(requestError);
+      if (issue.code === "duplicate_review_required") {
+        try {
+          const refreshed = await importPreviewApi.getById(batchId);
+          if (!refreshed.data) throw new Error("Preview refresh returned no data.");
+          setPreview(refreshed.data);
+        } catch {
+          issue.requiresPreviewRefresh = true;
+          issue.message = "New duplicate warnings were saved, but the latest preview could not be loaded. Refresh this page before confirming.";
+        }
+      } else if (issue.code === "preview_unavailable" || issue.code === "preview_expired") {
+        setPreview(null);
+        forgetBatch();
+      }
+      setConfirmationIssue(issue);
+      return null;
+    } finally {
+      confirmationInFlight.current = false;
+      setConfirming(false);
+    }
+  }, [preview]);
+
   const clearForReupload = useCallback(() => {
     setPreview(null);
     setError("");
+    setConfirmation(null);
+    setConfirmationIssue(null);
     forgetBatch();
   }, []);
+
+  const selectedCount = preview?.rows.filter((row) => row.isEligible && row.selectedForImport).length ?? 0;
 
   return {
     preview,
@@ -160,10 +292,15 @@ export function useImportPreview() {
     loading,
     processing,
     error,
+    confirming,
+    confirmation,
+    confirmationIssue,
+    selectedCount,
     selectSource,
     upload,
     cancel,
     updateRow,
+    confirm,
     clearForReupload,
   };
 }

--- a/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
@@ -4,14 +4,24 @@ import { importPreviewApi } from '../api/importPreviewApi'
 import { useImportPreview } from './useImportPreview'
 
 vi.mock('../api/importPreviewApi', () => ({ importPreviewApi: {
-  getOpen: vi.fn(), getById: vi.fn(), upload: vi.fn(), updateRow: vi.fn(),
+  getOpen: vi.fn(), getById: vi.fn(), upload: vi.fn(), updateRow: vi.fn(), confirm: vi.fn(),
 } }))
 
 const preview = {
   batchId: '11111111-1111-1111-1111-111111111111',
   sourceType: 'sunflower_pdf',
   expiresAt: '2026-08-21T12:00:00Z',
-  rows: [{ rowId: 'row-1', selectedForImport: false }],
+  rows: [{
+    rowId: 'row-1', isEligible: true, selectedForImport: false,
+    editableExpenseDescription: 'Coffee', category: 'food',
+  }],
+}
+
+const confirmed = {
+  batchId: preview.batchId,
+  status: 'confirmed',
+  confirmedAt: '2026-08-25T21:00:00Z',
+  importedExpenseCount: 1,
 }
 
 describe('useImportPreview', () => {
@@ -47,6 +57,20 @@ describe('useImportPreview', () => {
     expect(importPreviewApi.upload).toHaveBeenCalledWith('sunflower_pdf', expect.any(File), expect.any(AbortSignal))
     expect(result.current.error).toBe('Encrypted or password-protected PDFs are not supported.')
     expect(result.current.error).not.toContain('internal detail')
+  })
+
+  it('maps an exact already-imported upload to friendly static guidance', async () => {
+    importPreviewApi.upload.mockRejectedValue({
+      response: { status: 409, data: { code: 'already_imported', message: 'private server detail' } },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(() => result.current.selectSource('sunflower_pdf'))
+    await act(() => result.current.upload(new File(['pdf'], 'statement.pdf')))
+
+    expect(result.current.error).toBe('This statement was already imported. No duplicate expenses were created.')
+    expect(result.current.error).not.toContain('private server detail')
   })
 
   it('persists a row update into the current preview', async () => {
@@ -87,5 +111,228 @@ describe('useImportPreview', () => {
 
     expect(importPreviewApi.getOpen).toHaveBeenCalledWith('sunflower_pdf', expect.any(AbortSignal))
     expect(result.current.sourceType).toBe('sunflower_pdf')
+  })
+
+  it.each(['confirmed', 'already_confirmed'])('retires the preview and preserves unrelated URL state after %s', async (status) => {
+    window.history.replaceState({}, '', `/transactions?keep=yes&importBatch=${preview.batchId}#expenses`)
+    const selectedPreview = {
+      ...preview,
+      rows: [{ ...preview.rows[0], selectedForImport: true }],
+    }
+    const response = { ...confirmed, status }
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: selectedPreview })
+    importPreviewApi.confirm.mockResolvedValue({ status: 200, data: response })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(selectedPreview))
+
+    let returned
+    await act(async () => { returned = await result.current.confirm() })
+
+    expect(importPreviewApi.confirm).toHaveBeenCalledWith(preview.batchId)
+    expect(returned).toEqual(response)
+    expect(result.current.confirmation).toEqual(response)
+    expect(result.current.preview).toBeNull()
+    expect(window.location.search).toBe('?keep=yes')
+    expect(window.location.hash).toBe('#expenses')
+  })
+
+  it('guards same-tick duplicate confirmation calls', async () => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    const selectedPreview = {
+      ...preview,
+      rows: [{ ...preview.rows[0], selectedForImport: true }],
+    }
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: selectedPreview })
+    let resolveConfirmation
+    importPreviewApi.confirm.mockReturnValue(new Promise((resolve) => { resolveConfirmation = resolve }))
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(selectedPreview))
+
+    let first
+    let second
+    act(() => {
+      first = result.current.confirm()
+      second = result.current.confirm()
+    })
+
+    expect(importPreviewApi.confirm).toHaveBeenCalledOnce()
+    expect(result.current.confirming).toBe(true)
+    await act(async () => {
+      resolveConfirmation({ status: 200, data: confirmed })
+      await first
+      await second
+    })
+    expect(result.current.confirming).toBe(false)
+  })
+
+  it('refetches authoritative duplicate warnings and permits a later explicit reselection', async () => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    const selectedPreview = {
+      ...preview,
+      rows: [{ ...preview.rows[0], selectedForImport: true }],
+    }
+    const refreshedPreview = {
+      ...preview,
+      rows: [{
+        ...preview.rows[0], selectedForImport: false, isPossibleDuplicate: true,
+        warnings: ['possible_duplicate'],
+      }],
+    }
+    importPreviewApi.getById
+      .mockResolvedValueOnce({ status: 200, data: selectedPreview })
+      .mockResolvedValueOnce({ status: 200, data: refreshedPreview })
+    importPreviewApi.confirm
+      .mockRejectedValueOnce({
+        response: {
+          status: 409,
+          data: {
+            code: 'duplicate_review_required', message: 'private detail',
+            rows: [{ rowId: 'row-1', codes: ['possible_duplicate', 'private_code'] }],
+          },
+        },
+      })
+      .mockResolvedValueOnce({ status: 200, data: confirmed })
+    importPreviewApi.updateRow.mockResolvedValue({
+      data: { ...refreshedPreview.rows[0], selectedForImport: true },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(selectedPreview))
+
+    await act(() => result.current.confirm())
+
+    expect(importPreviewApi.getById).toHaveBeenLastCalledWith(preview.batchId)
+    expect(result.current.preview).toEqual(refreshedPreview)
+    expect(result.current.selectedCount).toBe(0)
+    expect(result.current.confirmationIssue).toEqual(expect.objectContaining({
+      code: 'duplicate_review_required',
+      rows: [{ rowId: 'row-1', codes: ['possible_duplicate'] }],
+      requiresPreviewRefresh: false,
+    }))
+    expect(result.current.confirmationIssue.message).not.toContain('private detail')
+
+    await act(() => result.current.updateRow('row-1', {
+      editableExpenseDescription: 'Coffee', category: 'food', selectedForImport: true,
+    }))
+    expect(result.current.selectedCount).toBe(1)
+    expect(result.current.confirmationIssue.rows).toEqual([])
+
+    await act(() => result.current.confirm())
+    expect(result.current.confirmation).toEqual(confirmed)
+    expect(importPreviewApi.confirm).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks stale confirmation state when duplicate-review refetch fails', async () => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    importPreviewApi.getById
+      .mockResolvedValueOnce({ status: 200, data: preview })
+      .mockRejectedValueOnce(new Error('offline'))
+    importPreviewApi.confirm.mockRejectedValue({
+      response: {
+        status: 409,
+        data: {
+          code: 'duplicate_review_required',
+          rows: [{ rowId: 'row-1', codes: ['possible_duplicate'] }],
+        },
+      },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.confirm())
+
+    expect(result.current.preview).toEqual(preview)
+    expect(result.current.confirmationIssue.requiresPreviewRefresh).toBe(true)
+    expect(result.current.confirmationIssue.message).toContain('Refresh this page')
+  })
+
+  it.each([
+    [400, 'no_rows_selected'],
+    [409, 'confirmation_conflict'],
+    [500, 'confirmation_failed'],
+  ])('keeps the preview usable after HTTP %s %s', async (status, code) => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
+    importPreviewApi.confirm.mockRejectedValue({
+      response: { status, data: { code, message: 'private detail', rows: [] } },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.confirm())
+
+    expect(result.current.preview).toEqual(preview)
+    expect(result.current.confirmation).toBeNull()
+    expect(result.current.confirmationIssue.code).toBe(code)
+    expect(result.current.confirmationIssue.message).not.toContain('private detail')
+  })
+
+  it('releases the in-flight guard so a deliberate retry can return stable success', async () => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
+    importPreviewApi.confirm
+      .mockRejectedValueOnce({
+        response: { status: 500, data: { code: 'confirmation_failed', rows: [] } },
+      })
+      .mockResolvedValueOnce({ status: 200, data: confirmed })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.confirm())
+    expect(result.current.confirmationIssue.code).toBe('confirmation_failed')
+
+    await act(() => result.current.confirm())
+    expect(result.current.confirmation).toEqual(confirmed)
+    expect(importPreviewApi.confirm).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the preview and maps only known validation codes to matching rows', async () => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
+    importPreviewApi.confirm.mockRejectedValue({
+      response: {
+        status: 422,
+        data: {
+          code: 'confirmation_validation_failed', message: 'private detail',
+          rows: [{ rowId: 'row-1', codes: ['description_required', 'private_code'] }],
+        },
+      },
+    })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.confirm())
+
+    expect(result.current.preview).toEqual(preview)
+    expect(result.current.confirmationIssue.rows).toEqual([
+      { rowId: 'row-1', codes: ['description_required'] },
+    ])
+  })
+
+  it.each([
+    [404, undefined, 'preview_unavailable'],
+    [410, { code: 'preview_expired', rows: [] }, 'preview_expired'],
+  ])('retires the preview and deep link after HTTP %s', async (status, data, expectedCode) => {
+    window.history.replaceState({}, '', `/transactions?keep=yes&importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: preview })
+    importPreviewApi.confirm.mockRejectedValue({ response: { status, data } })
+    const { result } = renderHook(() => useImportPreview())
+    await waitFor(() => expect(result.current.preview).toEqual(preview))
+
+    await act(() => result.current.confirm())
+
+    expect(result.current.preview).toBeNull()
+    expect(result.current.confirmationIssue.code).toBe(expectedCode)
+    expect(window.location.search).toBe('?keep=yes')
+  })
+
+  it('cleans an unavailable resumed deep link without inventing ownership details', async () => {
+    window.history.replaceState({}, '', `/transactions?keep=yes&importBatch=${preview.batchId}`)
+    importPreviewApi.getById.mockRejectedValue({ response: { status: 404 } })
+    const { result } = renderHook(() => useImportPreview())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.error).toBe('This import preview is unavailable. Choose the bank and upload the statement again.')
+    expect(window.location.search).toBe('?keep=yes')
   })
 })

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -17,6 +17,7 @@ export default function TransactionsPage() {
   const {
     expenses,
     loading: expensesLoading,
+    refresh: refreshExpenses,
     addExpense,
     updateExpense,
     deleteExpense,
@@ -141,7 +142,7 @@ export default function TransactionsPage() {
         </div>
       </header>
 
-      <ImportPreviewPanel importState={importState} />
+      <ImportPreviewPanel importState={importState} onImportConfirmed={refreshExpenses} />
   
       <ExpenseForm
         loading={expensesLoading}

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -11,6 +11,7 @@ vi.mock('../../importPreview/hooks/useImportPreview', () => ({ useImportPreview:
 const baseExpensesHook = {
   expenses: [],
   loading: false,
+  refresh: vi.fn(),
   addExpense: vi.fn(),
   updateExpense: vi.fn(),
   deleteExpense: vi.fn(),
@@ -22,11 +23,29 @@ const baseImportHook = {
   loading: false,
   processing: false,
   error: '',
+  confirming: false,
+  confirmation: null,
+  confirmationIssue: null,
+  selectedCount: 0,
   selectSource: vi.fn(),
   upload: vi.fn(),
   cancel: vi.fn(),
   updateRow: vi.fn(),
+  confirm: vi.fn(),
   clearForReupload: vi.fn(),
+}
+
+const selectedImportPreview = {
+  batchId: '11111111-1111-1111-1111-111111111111',
+  sourceType: 'sunflower_pdf',
+  expiresAt: '2026-08-26T12:00:00Z',
+  rows: [{
+    rowId: 'row-1', sourceRowOrdinal: 1, postedDate: '2026-08-12', amount: 8.5,
+    direction: 'debit', sourceDescription: 'SYNTHETIC CAFE', sourceSection: 'electronic_transactions',
+    classification: 'expense_candidate', isEligible: true, errors: [], warnings: [],
+    isPossibleDuplicate: false, editableExpenseDescription: 'Coffee', category: 'food',
+    selectedForImport: true,
+  }],
 }
 
 describe('existing expense workflows', () => {
@@ -173,7 +192,7 @@ describe('existing expense workflows', () => {
     await user.upload(screen.getByLabelText('Sunflower statement PDF'), file)
 
     expect(upload).toHaveBeenCalledWith(file)
-    expect(screen.getByText(/Preview only — no expenses have been created/)).toBeInTheDocument()
+    expect(screen.getByText(/Expenses are created only after confirmation/)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /confirm|import expenses/i })).not.toBeInTheDocument()
   })
 
@@ -204,6 +223,32 @@ describe('existing expense workflows', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Statement processing timed out')
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(cancel).toHaveBeenCalled()
+  })
+
+  it.each(['confirmed', 'already_confirmed'])('refreshes ordinary Expenses after %s import success', async (status) => {
+    const user = userEvent.setup()
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const result = {
+      batchId: selectedImportPreview.batchId,
+      status,
+      confirmedAt: '2026-08-25T21:00:00Z',
+      importedExpenseCount: 1,
+    }
+    const confirm = vi.fn().mockResolvedValue(result)
+    useExpenses.mockReturnValue({ ...baseExpensesHook, refresh })
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      preview: selectedImportPreview,
+      sourceType: 'sunflower_pdf',
+      selectedCount: 1,
+      confirm,
+    })
+    render(<TransactionsPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(refresh).toHaveBeenCalledOnce()
   })
 
   it('renders resumed rows with duplicate and ineligible affordances and persists eligible edits', async () => {
@@ -239,7 +284,7 @@ describe('existing expense workflows', () => {
     expect(within(table).getByText('Possible duplicate — review before selecting')).toBeInTheDocument()
     expect(within(table).getByText('Needs review')).toBeInTheDocument()
     expect(within(table).getByLabelText('Not selectable')).toBeDisabled()
-    await user.click(within(table).getByLabelText('Select for future import'))
+    await user.click(within(table).getByLabelText('Select for import'))
     expect(updateRow).toHaveBeenCalledWith('row-1', expect.objectContaining({ selectedForImport: true }))
 
     const description = within(table).getByLabelText('Expense description')
@@ -252,6 +297,6 @@ describe('existing expense workflows', () => {
       category: 'food',
       selectedForImport: false,
     })
-    expect(screen.queryByRole('button', { name: /confirm|import expenses/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Import selected expenses' })).toBeDisabled()
   })
 })

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -119,7 +119,10 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .import-dropzone--active { border-color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface)); }
 .import-dropzone p { margin: 0; }
 .import-results { display: grid; gap: var(--space-4); }
-.import-results__summary h3, .import-results__summary p { margin-bottom: var(--space-1); }
+.import-results__summary { display: flex; align-items: end; justify-content: space-between; gap: var(--space-4); }
+.import-results__summary h3, .import-results__summary p, .import-completion h3, .import-completion p { margin-bottom: var(--space-1); }
+.import-confirmation-actions { display: grid; justify-items: end; gap: var(--space-2); text-align: right; }
+.import-confirmation-actions p { max-width: 460px; }
 .import-preview-table .data-table { min-width: 1100px; }
 .import-preview-table .data-table td:nth-child(2) { min-width: 190px; }
 .import-preview-table .data-table td:nth-child(5) { min-width: 250px; }
@@ -134,12 +137,15 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .import-status--invalid, .import-error { color: var(--color-danger); background: var(--color-danger-soft); }
 .import-selection { display: flex; align-items: flex-start; gap: var(--space-2); font-size: var(--text-sm); }
 .import-selection input { width: auto; margin-top: .2rem; }
+.import-save-status { color: var(--color-success); font-size: var(--text-xs); font-weight: 800; }
+.import-save-status--error { color: var(--color-danger); }
 .import-preview-cards { display: none; }
 .import-preview-card { display: grid; gap: var(--space-3); padding: var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface); }
 .import-preview-card__details { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2) var(--space-4); }
 
 @media (max-width: 760px) {
-  .import-preview__header, .import-processing { align-items: stretch; flex-direction: column; }
+  .import-preview__header, .import-processing, .import-results__summary { align-items: stretch; flex-direction: column; }
+  .import-confirmation-actions { justify-items: stretch; text-align: left; }
   .import-preview-table { display: none; }
   .import-preview-cards { display: grid; gap: var(--space-3); }
 }


### PR DESCRIPTION
## Summary

- add the bodyless import-preview confirmation call and guarded hook state for all approved success/error outcomes
- share row drafts and save status across desktop/mobile preview presentations so dirty or pending edits block confirmation
- refetch authoritative duplicate warnings, retire stale previews/deep links, and refresh ordinary Expenses after confirmed success
- add focused API, hook, panel, responsive/accessibility, and Transactions integration coverage

Closes #86

## Risk

**MEDIUM** — meaningful frontend workflow and financial API consumption. The implementation follows the owner-approved plan in issue comment 5417288782 and its recorded approval in comment 5417798841.

## Important implementation details

- Confirmation is exactly `POST /api/import-previews/{batchId}/confirm` with no request body.
- A synchronous hook guard and disabled UI prevent concurrent submits.
- Batch/row-keyed controlled drafts preserve edits across table/card layouts; any dirty or pending row blocks confirmation.
- `duplicate_review_required` refetches the authoritative preview before confirmation is available again and maps only known safe row codes.
- `confirmed` and `already_confirmed` retire the preview, remove only `importBatch`, retain safe completion data, and call the existing Expenses `refresh()` callback.
- A post-confirmation Expense-refresh failure remains separate from the durable confirmation success state.

## Verification

- `npm ci` — passed (lockfile unchanged; npm reported the repository's existing audit findings)
- focused import-preview/Transactions tests — passed
- `npm run verify` — passed: 24 test files / 126 tests, ESLint with one pre-existing `useBudgetLimits` exhaustive-deps warning and no errors, production Vite build passed
- `git diff --check` — passed

## Scope boundaries

- Frontend only.
- No backend/API semantic changes, schema/EF migration, dependency or lockfile change, production database operation, deployment, or merge.
- Final private-statement customer acceptance remains after human merge and deployment; no real statement data is included in this PR.