### PR TITLE
Add Monthly Spending Insights V1

### DIFF
--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -42,6 +42,14 @@ export default function AnalyticsPage() {
     [budgetLimits, insights.totalsByCategory]
   );
 
+  async function retryExpenses() {
+    try {
+      await refreshExpenses();
+    } catch {
+      // The hook owns the user-facing error state.
+    }
+  }
+
   return (
     <div className="container analytics-page">
       <header className="page-header analytics-page__header">
@@ -65,7 +73,7 @@ export default function AnalyticsPage() {
       {!expensesLoading && expensesError ? (
         <Card as="section" className="section">
           <StatusMessage tone="danger">We couldn’t load recorded expenses.</StatusMessage>
-          <button type="button" onClick={refreshExpenses}>Try again</button>
+          <button type="button" onClick={retryExpenses}>Try again</button>
         </Card>
       ) : null}
 

--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -1,67 +1,206 @@
 import { useMemo, useState } from "react";
-import SpendingChart from "../../../charts/components/SpendingChart";
+import { Link } from "react-router-dom";
 import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
-import { computeMonthlyTotalsByCategory } from "../../budgetLimits/utils/totalsByCategory";
 import { useExpenses } from "../../expenses/hooks/useExpenses";
+import { formatExpenseDate } from "../../expenses/utils/calendarDate";
 import { getMonthYear } from "../../../shared/utils/monthYear";
+import { displayText } from "../../../utils/text";
 import Card from "../../../shared/ui/Card";
 import FormField from "../../../shared/ui/FormField";
 import StatusMessage from "../../../shared/ui/StatusMessage";
+import {
+  buildBudgetStatuses,
+  buildMonthlySpendingInsights,
+  formatMonthLabel,
+  getAvailableMonths,
+} from "../utils/monthlySpendingInsights";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+
+function formatPercentage(value, { signed = false } = {}) {
+  if (value === null) return "Not applicable";
+  const sign = signed && value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(1)}%`;
+}
 
 export default function AnalyticsPage() {
-  const { expenses, loading: expensesLoading } = useExpenses();
-  const [chartMonthYear, setChartMonthYear] = useState(getMonthYear(new Date()));
-  const { budgetLimits, loading: limitsLoading } = useBudgetLimits(chartMonthYear);
+  const [selectedMonth, setSelectedMonth] = useState(getMonthYear(new Date()));
+  const {
+    expenses, loading: expensesLoading, error: expensesError, refresh: refreshExpenses,
+  } = useExpenses();
+  const {
+    budgetLimits, loading: limitsLoading, error: limitsError, refresh: refreshLimits,
+  } = useBudgetLimits(selectedMonth);
 
-  const totalsByCategory = useMemo(
-    () => computeMonthlyTotalsByCategory(expenses, chartMonthYear),
-    [expenses, chartMonthYear]
+  const availableMonths = useMemo(() => getAvailableMonths(expenses), [expenses]);
+  const insights = useMemo(
+    () => buildMonthlySpendingInsights(expenses, selectedMonth),
+    [expenses, selectedMonth]
+  );
+  const budgetStatuses = useMemo(
+    () => buildBudgetStatuses(budgetLimits, insights.totalsByCategory),
+    [budgetLimits, insights.totalsByCategory]
   );
 
-  const budgetLimitsByCategory = useMemo(() => {
-    const limitsByCategory = {};
-    for (const limit of budgetLimits ?? []) limitsByCategory[limit.category] = limit;
-    return limitsByCategory;
-  }, [budgetLimits]);
-
-  const loading = expensesLoading || limitsLoading;
-  const hasBudgetLimits = (budgetLimits ?? []).length > 0;
-
   return (
-    <div className="container">
-      <header className="page-header">
+    <div className="container analytics-page">
+      <header className="page-header analytics-page__header">
         <div>
           <p className="page-header__eyebrow">Understand your spending</p>
           <h1>Analytics</h1>
-          <p className="muted">Compare recorded spending with category limits for a selected month.</p>
+          <p className="muted">See what happened with your recorded spending, month by month.</p>
         </div>
+        <FormField label="Month">
+          {(id) => (
+            <select id={id} value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value)}>
+              {availableMonths.map((month) => (
+                <option key={month} value={month}>{formatMonthLabel(month)}</option>
+              ))}
+            </select>
+          )}
+        </FormField>
       </header>
 
-      <Card as="section" className="section chart-frame">
-        <div className="section__header">
-          <h2 className="h2">Spending vs Budget Limits</h2>
-          <FormField label="Chart month">{(id) => <input
-            id={id}
-            type="month"
-            value={chartMonthYear}
-            onChange={(event) => setChartMonthYear(event.target.value)}
-          />}</FormField>
-        </div>
+      {expensesLoading ? <StatusMessage>Loading spending insights...</StatusMessage> : null}
+      {!expensesLoading && expensesError ? (
+        <Card as="section" className="section">
+          <StatusMessage tone="danger">We couldn’t load recorded expenses.</StatusMessage>
+          <button type="button" onClick={refreshExpenses}>Try again</button>
+        </Card>
+      ) : null}
 
-        {loading ? (
-          <StatusMessage>Loading spending analytics...</StatusMessage>
-        ) : (
-          <>
-            {!hasBudgetLimits && Object.keys(totalsByCategory).length > 0 ? (
-              <StatusMessage>No budget limits are set for this month. The chart shows recorded spending only.</StatusMessage>
-            ) : null}
-            <SpendingChart
-              totalsByCategory={totalsByCategory}
-              budgetLimitsByCategory={budgetLimitsByCategory}
-            />
-          </>
-        )}
-      </Card>
+      {!expensesLoading && !expensesError ? (
+        <>
+          <Card as="section" className="analytics-total" aria-labelledby="monthly-total-heading">
+            <p className="analytics-kicker">{formatMonthLabel(selectedMonth)}</p>
+            <h2 id="monthly-total-heading" className="h2">Monthly recorded spending</h2>
+            <p className="analytics-total__value">{currencyFormatter.format(insights.total)}</p>
+            <p className="muted">Total of recorded Expenses for the selected calendar month.</p>
+          </Card>
+
+          <div className="analytics-grid">
+            <Card as="section" className="analytics-panel" aria-labelledby="category-breakdown-heading">
+              <div className="analytics-panel__header">
+                <div>
+                  <p className="analytics-kicker">Ranked by amount</p>
+                  <h2 id="category-breakdown-heading" className="h2">Where the money went</h2>
+                </div>
+              </div>
+              {insights.categories.length === 0 ? (
+                <StatusMessage>No recorded spending for this month.</StatusMessage>
+              ) : (
+                <ol className="analytics-list analytics-category-list">
+                  {insights.categories.map((category) => (
+                    <li key={category.category} className="analytics-list__item">
+                      <div className="analytics-row">
+                        <strong>{displayText(category.category)}</strong>
+                        <span>{currencyFormatter.format(category.amount)} · {formatPercentage(category.percentage)}</span>
+                      </div>
+                      <div className="analytics-bar" aria-hidden="true">
+                        <span style={{ width: `${Math.max(0, Math.min(category.percentage ?? 0, 100))}%` }} />
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </Card>
+
+            <Card as="section" className="analytics-panel" aria-labelledby="budget-status-heading">
+              <div className="analytics-panel__header">
+                <div>
+                  <p className="analytics-kicker">Configured limits</p>
+                  <h2 id="budget-status-heading" className="h2">Budget status by category</h2>
+                </div>
+                <Link to="/budgets">Manage budgets</Link>
+              </div>
+              {limitsLoading ? <StatusMessage>Loading budget limits...</StatusMessage> : null}
+              {!limitsLoading && limitsError ? (
+                <>
+                  <StatusMessage tone="danger">Budget limits are unavailable. Other insights are still shown.</StatusMessage>
+                  <button type="button" onClick={refreshLimits}>Try again</button>
+                </>
+              ) : null}
+              {!limitsLoading && !limitsError && budgetStatuses.length === 0 ? (
+                <StatusMessage>No budget limits are set for this month.</StatusMessage>
+              ) : null}
+              {!limitsLoading && !limitsError && budgetStatuses.length > 0 ? (
+                <ul className="analytics-list">
+                  {budgetStatuses.map((budget) => (
+                    <li key={budget.id ?? budget.category} className="analytics-list__item analytics-budget-row">
+                      <div className="analytics-row">
+                        <strong>{displayText(budget.category)}</strong>
+                        <span className={`analytics-status analytics-status--${budget.status.replace(" ", "-")}`}>{displayText(budget.status)}</span>
+                      </div>
+                      <p>{currencyFormatter.format(budget.spent)} spent of {currencyFormatter.format(budget.limitAmount)}</p>
+                      <p>{budget.over !== null
+                        ? `${currencyFormatter.format(budget.over)} over`
+                        : `${currencyFormatter.format(budget.remaining)} remaining`}</p>
+                      <p>{budget.percentage === null
+                        ? "Percentage used: Not applicable for a $0 limit"
+                        : `${formatPercentage(budget.percentage)} used`}</p>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </Card>
+
+            <Card as="section" className="analytics-panel" aria-labelledby="comparison-heading">
+              <p className="analytics-kicker">Compared with {formatMonthLabel(insights.previousMonth)}</p>
+              <h2 id="comparison-heading" className="h2">Month-over-month change</h2>
+              <p className="analytics-comparison__value">
+                {insights.comparison.difference > 0 ? "+" : ""}{currencyFormatter.format(insights.comparison.difference)}
+              </p>
+              {insights.comparison.previousTotal === 0 && insights.total === 0 ? (
+                <p className="muted">Neither month has recorded spending.</p>
+              ) : insights.comparison.percentage === null ? (
+                <p className="muted">Percentage comparison is unavailable because the previous month had $0.00 recorded spending.</p>
+              ) : (
+                <p className="muted">{formatPercentage(insights.comparison.percentage, { signed: true })} from {currencyFormatter.format(insights.comparison.previousTotal)}</p>
+              )}
+              {insights.increases.length === 0 && insights.decreases.length === 0 ? (
+                <StatusMessage>No category changes to show between these months.</StatusMessage>
+              ) : (
+                <div className="analytics-change-grid">
+                  <div>
+                    <h3>Largest increases</h3>
+                    {insights.increases.length === 0 ? <p className="muted">No increases.</p> : (
+                      <ul>{insights.increases.map((change) => <li key={change.category}>{displayText(change.category)} <strong>+{currencyFormatter.format(change.difference)}</strong></li>)}</ul>
+                    )}
+                  </div>
+                  <div>
+                    <h3>Largest decreases</h3>
+                    {insights.decreases.length === 0 ? <p className="muted">No decreases.</p> : (
+                      <ul>{insights.decreases.map((change) => <li key={change.category}>{displayText(change.category)} <strong>{currencyFormatter.format(change.difference)}</strong></li>)}</ul>
+                    )}
+                  </div>
+                </div>
+              )}
+            </Card>
+
+            <Card as="section" className="analytics-panel" aria-labelledby="largest-expenses-heading">
+              <div className="analytics-panel__header">
+                <div>
+                  <p className="analytics-kicker">Top five</p>
+                  <h2 id="largest-expenses-heading" className="h2">Largest expenses</h2>
+                </div>
+                <Link to="/transactions">Review transactions</Link>
+              </div>
+              {insights.largestExpenses.length === 0 ? (
+                <StatusMessage>No expenses to rank for this month.</StatusMessage>
+              ) : (
+                <ol className="analytics-list">
+                  {insights.largestExpenses.map((expense) => (
+                    <li key={expense.id} className="analytics-list__item analytics-row">
+                      <span><strong>{expense.description}</strong><small>{displayText(expense.category)} · {formatExpenseDate(expense.date)}</small></span>
+                      <strong>{currencyFormatter.format(expense.amount)}</strong>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </Card>
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
@@ -1,82 +1,120 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import AnalyticsPage from './AnalyticsPage'
-import { useExpenses } from '../../expenses/hooks/useExpenses'
-import { useBudgetLimits } from '../../budgetLimits/hooks/useBudgetLimits'
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AnalyticsPage from "./AnalyticsPage";
+import { useExpenses } from "../../expenses/hooks/useExpenses";
+import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
 
-vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
-vi.mock('../../budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
-vi.mock('../../../charts/components/SpendingChart', () => ({
-  default: ({ totalsByCategory, budgetLimitsByCategory }) => (
-    <div data-testid="spending-chart">
-      {JSON.stringify({ totalsByCategory, budgetLimitsByCategory })}
-    </div>
-  ),
-}))
+vi.mock("../../expenses/hooks/useExpenses", () => ({ useExpenses: vi.fn() }));
+vi.mock("../../budgetLimits/hooks/useBudgetLimits", () => ({ useBudgetLimits: vi.fn() }));
 
-describe('Analytics page ownership', () => {
+const refreshExpenses = vi.fn();
+const refreshLimits = vi.fn();
+
+function renderPage() {
+  return render(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
+}
+
+describe("monthly spending insights page", () => {
   beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0));
     useExpenses.mockReturnValue({
       expenses: [
-        { category: 'food', amount: 12.34, date: '2026-08-02' },
-        { category: 'bills', amount: 50, date: '2026-07-02' },
+        { id: 1, description: "Groceries", category: "food", amount: 90, date: "2026-08-02" },
+        { id: 2, description: "Train", category: "transport", amount: 10, date: "2026-08-03" },
+        { id: 3, description: "Rent", category: "bills", amount: 75, date: "2026-07-02" },
       ],
       loading: false,
-    })
+      error: null,
+      refresh: refreshExpenses,
+    });
     useBudgetLimits.mockReturnValue({
-      budgetLimits: [{ id: 7, category: 'food', limitAmount: 100 }],
+      budgetLimits: [
+        { id: 1, category: "food", limitAmount: 100 },
+        { id: 2, category: "transport", limitAmount: 0 },
+      ],
       loading: false,
-    })
-  })
+      error: null,
+      refresh: refreshLimits,
+    });
+  });
 
   afterEach(() => {
-    vi.useRealTimers()
-    vi.clearAllMocks()
-  })
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
 
-  it('owns the current chart month and exact chart data mapping', () => {
-    render(<AnalyticsPage />)
+  it("shows the selected total, ranked categories, budgets, comparison, and largest expenses", () => {
+    renderPage();
 
-    expect(screen.getByRole('heading', { name: 'Analytics' })).toBeInTheDocument()
-    expect(screen.getByLabelText('Chart month')).toHaveValue('2026-08')
-    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-08')
-    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{"food":12.34}')
-    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"budgetLimitsByCategory":{"food":{"id":7')
-  })
+    expect(screen.getByLabelText("Month")).toHaveValue("2026-08");
+    expect(useBudgetLimits).toHaveBeenLastCalledWith("2026-08");
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
 
-  it('updates both chart dependencies when the selected month changes', () => {
-    render(<AnalyticsPage />)
+    const breakdown = screen.getByRole("heading", { name: "Where the money went" }).closest("section");
+    const rows = within(breakdown).getAllByRole("listitem");
+    expect(rows[0]).toHaveTextContent("Food");
+    expect(rows[0]).toHaveTextContent("$90.00 · 90.0%");
+    expect(rows[1]).toHaveTextContent("Transport");
 
-    fireEvent.change(screen.getByLabelText('Chart month'), { target: { value: '2026-07' } })
+    const budget = screen.getByRole("heading", { name: "Budget status by category" }).closest("section");
+    expect(budget).toHaveTextContent("Near Limit");
+    expect(budget).toHaveTextContent("Percentage used: Not applicable for a $0 limit");
 
-    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-07')
-    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{"bills":50}')
-  })
+    expect(screen.getByRole("heading", { name: "Month-over-month change" }).closest("section"))
+      .toHaveTextContent("+$25.00");
+    expect(screen.getByRole("heading", { name: "Largest expenses" }).closest("section"))
+      .toHaveTextContent("Groceries");
+    expect(screen.getByRole("link", { name: "Review transactions" })).toHaveAttribute("href", "/transactions");
+  });
 
-  it('shows loading without rendering transient chart data', () => {
-    useExpenses.mockReturnValue({ expenses: [], loading: true })
-    render(<AnalyticsPage />)
+  it("offers current and represented historical months and updates selected-month limits", () => {
+    renderPage();
+    const selector = screen.getByLabelText("Month");
+    expect(within(selector).getAllByRole("option").map(({ value }) => value)).toEqual(["2026-08", "2026-07"]);
 
-    expect(screen.getByText('Loading spending analytics...')).toBeInTheDocument()
-    expect(screen.queryByTestId('spending-chart')).not.toBeInTheDocument()
-  })
+    fireEvent.change(selector, { target: { value: "2026-07" } });
+    expect(useBudgetLimits).toHaveBeenLastCalledWith("2026-07");
+    expect(screen.getByRole("heading", { name: "Monthly recorded spending" }).closest("section"))
+      .toHaveTextContent("$75.00");
+  });
 
-  it('explains spending-only chart data when no limits exist', () => {
-    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
-    render(<AnalyticsPage />)
+  it("renders expense loading and blocking error states without transient insights", () => {
+    useExpenses.mockReturnValue({ expenses: [], loading: true, error: null, refresh: refreshExpenses });
+    const { rerender } = renderPage();
+    expect(screen.getByText("Loading spending insights...")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Monthly recorded spending" })).not.toBeInTheDocument();
 
-    expect(screen.getByText(/No budget limits are set for this month/)).toBeInTheDocument()
-    expect(screen.getByTestId('spending-chart')).toBeInTheDocument()
-  })
+    useExpenses.mockReturnValue({ expenses: [], loading: false, error: new Error("failed"), refresh: refreshExpenses });
+    rerender(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
+    expect(screen.getByRole("alert")).toHaveTextContent("couldn’t load recorded expenses");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refreshExpenses).toHaveBeenCalledOnce();
+  });
 
-  it('preserves the chart empty state when no spending or limits exist', () => {
-    useExpenses.mockReturnValue({ expenses: [], loading: false })
-    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
-    render(<AnalyticsPage />)
+  it("keeps expense insights visible when budget limits fail", () => {
+    useBudgetLimits.mockReturnValue({
+      budgetLimits: [], loading: false, error: new Error("failed"), refresh: refreshLimits,
+    });
+    renderPage();
 
-    expect(screen.getByTestId('spending-chart')).toHaveTextContent('"totalsByCategory":{}')
-    expect(screen.queryByText(/The chart shows recorded spending only/)).not.toBeInTheDocument()
-  })
-})
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Budget limits are unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refreshLimits).toHaveBeenCalledOnce();
+  });
+
+  it("shows honest empty states for a month without expenses or limits", () => {
+    useExpenses.mockReturnValue({ expenses: [], loading: false, error: null, refresh: refreshExpenses });
+    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false, error: null, refresh: refreshLimits });
+    renderPage();
+
+    expect(screen.getAllByText("$0.00")).toHaveLength(2);
+    expect(screen.getByText("No recorded spending for this month.")).toBeInTheDocument();
+    expect(screen.getByText("No budget limits are set for this month.")).toBeInTheDocument();
+    expect(screen.getByText("No category changes to show between these months.")).toBeInTheDocument();
+    expect(screen.getByText("No expenses to rank for this month.")).toBeInTheDocument();
+    expect(screen.getByText("Neither month has recorded spending.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/utils/monthlySpendingInsights.js
+++ b/frontend/src/features/analytics/utils/monthlySpendingInsights.js
@@ -1,0 +1,152 @@
+import { formatLocalCalendarDate } from "../../expenses/utils/calendarDate";
+import { usedPercentage } from "../../../utils/budgets";
+
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MONTH_PATTERN = /^(\d{4})-(\d{2})$/;
+
+function isValidCalendarDate(value) {
+  const match = DATE_PATTERN.exec(String(value));
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1) return false;
+  return day <= new Date(year, month, 0).getDate();
+}
+
+function toCents(value) {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? Math.round(amount * 100) : null;
+}
+
+function compareCategoryNames(left, right) {
+  return left.localeCompare(right, "en", { sensitivity: "base" });
+}
+
+function expensesForMonth(expenses, monthYear, now) {
+  if (!MONTH_PATTERN.test(monthYear)) return [];
+  const currentMonth = formatLocalCalendarDate(now).slice(0, 7);
+  if (monthYear > currentMonth) return [];
+
+  const today = formatLocalCalendarDate(now);
+  return (expenses ?? []).filter((expense) => {
+    if (!isValidCalendarDate(expense.date) || !expense.date.startsWith(`${monthYear}-`)) return false;
+    if (monthYear === currentMonth && expense.date > today) return false;
+    return toCents(expense.amount) !== null;
+  });
+}
+
+function totalsInCents(expenses) {
+  const totals = new Map();
+  for (const expense of expenses) {
+    const category = expense.category || "uncategorized";
+    totals.set(category, (totals.get(category) ?? 0) + toCents(expense.amount));
+  }
+  return totals;
+}
+
+function totalCents(totals) {
+  return Array.from(totals.values()).reduce((sum, amount) => sum + amount, 0);
+}
+
+export function getPreviousMonth(monthYear) {
+  const match = MONTH_PATTERN.exec(String(monthYear));
+  if (!match) return "";
+  const date = new Date(Number(match[1]), Number(match[2]) - 2, 1);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+export function formatMonthLabel(monthYear) {
+  const match = MONTH_PATTERN.exec(String(monthYear));
+  if (!match) return monthYear;
+  return new Intl.DateTimeFormat("en-US", { month: "long", year: "numeric" })
+    .format(new Date(Number(match[1]), Number(match[2]) - 1, 1));
+}
+
+export function getAvailableMonths(expenses, now = new Date()) {
+  const currentMonth = formatLocalCalendarDate(now).slice(0, 7);
+  const months = new Set([currentMonth]);
+  for (const expense of expenses ?? []) {
+    if (!isValidCalendarDate(expense.date)) continue;
+    const month = expense.date.slice(0, 7);
+    if (month <= currentMonth) months.add(month);
+  }
+  return Array.from(months).sort((left, right) => right.localeCompare(left));
+}
+
+export function buildMonthlySpendingInsights(expenses, selectedMonth, now = new Date()) {
+  const selectedExpenses = expensesForMonth(expenses, selectedMonth, now);
+  const previousMonth = getPreviousMonth(selectedMonth);
+  const previousExpenses = expensesForMonth(expenses, previousMonth, now);
+  const selectedTotals = totalsInCents(selectedExpenses);
+  const previousTotals = totalsInCents(previousExpenses);
+  const selectedTotalCents = totalCents(selectedTotals);
+  const previousTotalCents = totalCents(previousTotals);
+  const differenceCents = selectedTotalCents - previousTotalCents;
+
+  const categories = Array.from(selectedTotals, ([category, amountCents]) => ({
+    category,
+    amount: amountCents / 100,
+    percentage: selectedTotalCents > 0 ? (amountCents / selectedTotalCents) * 100 : null,
+  })).sort((left, right) => right.amount - left.amount || compareCategoryNames(left.category, right.category));
+
+  const categoryChanges = Array.from(new Set([...selectedTotals.keys(), ...previousTotals.keys()]), (category) => ({
+    category,
+    difference: ((selectedTotals.get(category) ?? 0) - (previousTotals.get(category) ?? 0)) / 100,
+  }));
+  const increases = categoryChanges
+    .filter(({ difference }) => difference > 0)
+    .sort((left, right) => right.difference - left.difference || compareCategoryNames(left.category, right.category))
+    .slice(0, 3);
+  const decreases = categoryChanges
+    .filter(({ difference }) => difference < 0)
+    .sort((left, right) => left.difference - right.difference || compareCategoryNames(left.category, right.category))
+    .slice(0, 3);
+
+  const largestExpenses = [...selectedExpenses]
+    .sort((left, right) => {
+      const amountDifference = toCents(right.amount) - toCents(left.amount);
+      if (amountDifference) return amountDifference;
+      const dateDifference = right.date.localeCompare(left.date);
+      if (dateDifference) return dateDifference;
+      return Number(left.id ?? 0) - Number(right.id ?? 0);
+    })
+    .slice(0, 5);
+
+  return {
+    previousMonth,
+    total: selectedTotalCents / 100,
+    categories,
+    totalsByCategory: Object.fromEntries(Array.from(selectedTotals, ([category, cents]) => [category, cents / 100])),
+    comparison: {
+      previousTotal: previousTotalCents / 100,
+      difference: differenceCents / 100,
+      percentage: previousTotalCents > 0 ? (differenceCents / previousTotalCents) * 100 : null,
+    },
+    increases,
+    decreases,
+    largestExpenses,
+  };
+}
+
+export function buildBudgetStatuses(budgetLimits, totalsByCategory) {
+  return (budgetLimits ?? []).map((limit) => {
+    const spent = Number(totalsByCategory?.[limit.category] ?? 0);
+    const limitAmount = Number(limit.limitAmount ?? 0);
+    const difference = Math.round(Math.abs(limitAmount - spent) * 100) / 100;
+    const isOver = spent > limitAmount;
+    const percentage = limitAmount === 0 ? null : usedPercentage(spent, limitAmount);
+    const status = isOver ? "over budget" : percentage >= 90 ? "near limit" : "on track";
+    return {
+      ...limit,
+      spent,
+      percentage: limitAmount === 0 && spent === 0 ? 0 : percentage,
+      status,
+      remaining: isOver ? null : difference,
+      over: isOver ? difference : null,
+    };
+  }).sort((left, right) => {
+    const priority = { "over budget": 0, "near limit": 1, "on track": 2 };
+    return priority[left.status] - priority[right.status] || compareCategoryNames(left.category, right.category);
+  });
+}

--- a/frontend/src/features/analytics/utils/monthlySpendingInsights.test.js
+++ b/frontend/src/features/analytics/utils/monthlySpendingInsights.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBudgetStatuses,
+  buildMonthlySpendingInsights,
+  getAvailableMonths,
+  getPreviousMonth,
+} from "./monthlySpendingInsights";
+
+const now = new Date(2026, 7, 14, 12, 0, 0);
+
+describe("monthly spending insights", () => {
+  it("derives represented historical months and preserves January rollover", () => {
+    const expenses = [
+      { date: "2026-07-02" },
+      { date: "2025-12-31" },
+      { date: "2026-09-01" },
+      { date: "not-a-date" },
+    ];
+    expect(getAvailableMonths(expenses, now)).toEqual(["2026-08", "2026-07", "2025-12"]);
+    expect(getPreviousMonth("2026-01")).toBe("2025-12");
+  });
+
+  it("ranks categories, compares the previous month, and excludes future current-month days", () => {
+    const expenses = [
+      { id: 1, description: "Groceries", category: "food", amount: 60, date: "2026-08-02" },
+      { id: 2, description: "Bus", category: "transport", amount: 40, date: "2026-08-03" },
+      { id: 3, description: "Future", category: "food", amount: 500, date: "2026-08-15" },
+      { id: 4, description: "July food", category: "food", amount: 25, date: "2026-07-03" },
+      { id: 5, description: "July bills", category: "bills", amount: 75, date: "2026-07-04" },
+    ];
+    const result = buildMonthlySpendingInsights(expenses, "2026-08", now);
+
+    expect(result.total).toBe(100);
+    expect(result.categories).toEqual([
+      { category: "food", amount: 60, percentage: 60 },
+      { category: "transport", amount: 40, percentage: 40 },
+    ]);
+    expect(result.comparison).toEqual({ previousTotal: 100, difference: 0, percentage: 0 });
+    expect(result.increases).toEqual([
+      { category: "transport", difference: 40 },
+      { category: "food", difference: 35 },
+    ]);
+    expect(result.decreases).toEqual([{ category: "bills", difference: -75 }]);
+  });
+
+  it("does not invent a percentage when the previous month is zero and caps largest expenses at five", () => {
+    const expenses = Array.from({ length: 7 }, (_, index) => ({
+      id: index + 1,
+      description: `Expense ${index + 1}`,
+      category: "food",
+      amount: index + 1,
+      date: "2026-08-01",
+    }));
+    const result = buildMonthlySpendingInsights(expenses, "2026-08", now);
+
+    expect(result.comparison.percentage).toBeNull();
+    expect(result.largestExpenses.map(({ amount }) => amount)).toEqual([7, 6, 5, 4, 3]);
+  });
+
+  it("uses deterministic amount, date, and id ordering for largest expenses", () => {
+    const result = buildMonthlySpendingInsights([
+      { id: 3, description: "Third", category: "food", amount: 10, date: "2026-08-03" },
+      { id: 2, description: "Second", category: "food", amount: 10, date: "2026-08-03" },
+      { id: 1, description: "First", category: "food", amount: 10, date: "2026-08-02" },
+    ], "2026-08", now);
+    expect(result.largestExpenses.map(({ id }) => id)).toEqual([2, 3, 1]);
+  });
+});
+
+describe("budget status", () => {
+  it("uses the approved status threshold and uncapped percentage", () => {
+    const statuses = buildBudgetStatuses([
+      { id: 1, category: "over", limitAmount: 100 },
+      { id: 2, category: "near", limitAmount: 100 },
+      { id: 3, category: "track", limitAmount: 100 },
+    ], { over: 125, near: 90, track: 20 });
+    expect(statuses.map(({ category, status }) => ({ category, status }))).toEqual([
+      { category: "over", status: "over budget" },
+      { category: "near", status: "near limit" },
+      { category: "track", status: "on track" },
+    ]);
+    expect(statuses[0]).toMatchObject({ percentage: 125, over: 25, remaining: null });
+  });
+
+  it("implements the approved zero-dollar limit presentation", () => {
+    const statuses = buildBudgetStatuses([
+      { id: 1, category: "spent", limitAmount: 0 },
+      { id: 2, category: "empty", limitAmount: 0 },
+    ], { spent: 12 });
+    expect(statuses[0]).toMatchObject({ category: "spent", status: "over budget", percentage: null, over: 12 });
+    expect(statuses[1]).toMatchObject({ category: "empty", status: "on track", percentage: 0, remaining: 0 });
+  });
+});

--- a/frontend/src/features/budgetLimits/hooks/useBudgetLimits.js
+++ b/frontend/src/features/budgetLimits/hooks/useBudgetLimits.js
@@ -1,32 +1,45 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { budgetLimitsApi } from "../api/budgetLimitsApi";
 
 export function useBudgetLimits(monthYear) {
   const [budgetLimits, setBudgetLimits] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const requestId = useRef(0);
 
-  async function refresh() {
+  const refresh = useCallback(async function refresh({ rethrow = false } = {}) {
     if (!monthYear) return;
+    const currentRequestId = ++requestId.current;
     setLoading(true);
+    setError(null);
+    setBudgetLimits([]);
     try {
       const res = await budgetLimitsApi.getByMonth(monthYear);
-      setBudgetLimits(res.data ?? []);
+      if (currentRequestId === requestId.current) setBudgetLimits(res.data ?? []);
+    } catch (requestError) {
+      if (currentRequestId === requestId.current) {
+        setError(requestError);
+        if (rethrow) throw requestError;
+      }
     } finally {
-      setLoading(false);
+      if (currentRequestId === requestId.current) setLoading(false);
     }
-  }
+  }, [monthYear]);
 
-  useEffect(() => { refresh(); }, [monthYear]);
+  useEffect(() => {
+    refresh();
+    return () => { requestId.current += 1; };
+  }, [refresh]);
 
   async function upsertLimit(payload) {
     await budgetLimitsApi.upsert(payload);
-    await refresh();
+    await refresh({ rethrow: true });
   }
 
   async function deleteLimit(id) {
     await budgetLimitsApi.remove(id);
-    await refresh();
+    await refresh({ rethrow: true });
   }
 
-  return { budgetLimits, loading, refresh, upsertLimit, deleteLimit };
+  return { budgetLimits, loading, error, refresh, upsertLimit, deleteLimit };
 }

--- a/frontend/src/features/budgetLimits/hooks/useBudgetLimits.test.js
+++ b/frontend/src/features/budgetLimits/hooks/useBudgetLimits.test.js
@@ -17,6 +17,38 @@ describe('budget-limit refresh behavior', () => {
     budgetLimitsApi.getByMonth.mockResolvedValue({ data: [] })
   })
 
+  it('exposes a selected-month fetch error without stale limits', async () => {
+    const requestError = new Error('unavailable')
+    budgetLimitsApi.getByMonth.mockRejectedValue(requestError)
+    const { result } = renderHook(() => useBudgetLimits('2026-08'))
+
+    await waitFor(() => expect(result.current.error).toBe(requestError))
+    expect(result.current.budgetLimits).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('ignores an older month response after the selection changes', async () => {
+    let resolveJuly
+    let resolveAugust
+    budgetLimitsApi.getByMonth.mockImplementation((month) => new Promise((resolve) => {
+      if (month === '2026-07') resolveJuly = resolve
+      if (month === '2026-08') resolveAugust = resolve
+    }))
+    const { result, rerender } = renderHook(
+      ({ month }) => useBudgetLimits(month),
+      { initialProps: { month: '2026-07' } }
+    )
+    await waitFor(() => expect(resolveJuly).toBeTypeOf('function'))
+
+    rerender({ month: '2026-08' })
+    await waitFor(() => expect(resolveAugust).toBeTypeOf('function'))
+    await act(() => resolveJuly({ data: [{ id: 7, category: 'old' }] }))
+    expect(result.current.budgetLimits).toEqual([])
+
+    await act(() => resolveAugust({ data: [{ id: 8, category: 'current' }] }))
+    expect(result.current.budgetLimits).toEqual([{ id: 8, category: 'current' }])
+  })
+
   it('upserts and refreshes the currently selected month', async () => {
     const payload = { category: 'food', limitAmount: 100, monthYear: '2026-08-01T05:00:00.000Z' }
     const { result } = renderHook(() => useBudgetLimits('2026-08'))

--- a/frontend/src/features/expenses/hooks/useExpenses.js
+++ b/frontend/src/features/expenses/hooks/useExpenses.js
@@ -8,7 +8,7 @@ export function useExpenses() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const refresh = useCallback(async function refresh({ rethrow = false } = {}) {
+  const refresh = useCallback(async function refresh() {
     setLoading(true);
     setError(null);
     try {
@@ -17,27 +17,27 @@ export function useExpenses() {
     } catch (requestError) {
       setExpenses([]);
       setError(requestError);
-      if (rethrow) throw requestError;
+      throw requestError;
     } finally {
       setLoading(false);
     }
   }, []);
 
-  useEffect(() => { refresh(); }, [refresh]);
+  useEffect(() => { refresh().catch(() => {}); }, [refresh]);
 
   async function addExpense(payload) {
     await expensesApi.create(payload);
-    await refresh({ rethrow: true });
+    await refresh();
   }
 
   async function updateExpense(id, payload) {
     await expensesApi.update(id, payload);
-    await refresh({ rethrow: true });
+    await refresh();
   }
 
   async function deleteExpense(id) {
     await expensesApi.remove(id);
-    await refresh({ rethrow: true });
+    await refresh();
   }
 
   return { expenses, loading, error, refresh, addExpense, updateExpense, deleteExpense };

--- a/frontend/src/features/expenses/hooks/useExpenses.js
+++ b/frontend/src/features/expenses/hooks/useExpenses.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { expensesApi } from "../api/expensesApi";
 
 //fetch/state
@@ -6,33 +6,39 @@ import { expensesApi } from "../api/expensesApi";
 export function useExpenses() {
   const [expenses, setExpenses] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  async function refresh() {
+  const refresh = useCallback(async function refresh({ rethrow = false } = {}) {
     setLoading(true);
+    setError(null);
     try {
       const res = await expensesApi.getAll();
       setExpenses(res.data ?? []);
+    } catch (requestError) {
+      setExpenses([]);
+      setError(requestError);
+      if (rethrow) throw requestError;
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
-  useEffect(() => { refresh(); }, []);
+  useEffect(() => { refresh(); }, [refresh]);
 
   async function addExpense(payload) {
     await expensesApi.create(payload);
-    await refresh();
+    await refresh({ rethrow: true });
   }
 
   async function updateExpense(id, payload) {
     await expensesApi.update(id, payload);
-    await refresh();
+    await refresh({ rethrow: true });
   }
 
   async function deleteExpense(id) {
     await expensesApi.remove(id);
-    await refresh();
+    await refresh({ rethrow: true });
   }
 
-  return { expenses, loading, refresh, addExpense, updateExpense, deleteExpense };
+  return { expenses, loading, error, refresh, addExpense, updateExpense, deleteExpense };
 }

--- a/frontend/src/features/expenses/hooks/useExpenses.test.js
+++ b/frontend/src/features/expenses/hooks/useExpenses.test.js
@@ -25,6 +25,16 @@ describe('expense refresh behavior', () => {
     expect(result.current.expenses).toEqual([])
   })
 
+  it('exposes a safe refresh error and clears stale expenses', async () => {
+    const requestError = new Error('unavailable')
+    expensesApi.getAll.mockRejectedValue(requestError)
+    const { result } = renderHook(() => useExpenses())
+
+    await waitFor(() => expect(result.current.error).toBe(requestError))
+    expect(result.current.expenses).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
   it('creates through the existing API and refreshes expenses', async () => {
     const payload = { description: 'coffee', amount: 4, date: '2026-08-14', category: 'food' }
     expensesApi.getAll

--- a/frontend/src/features/expenses/hooks/useExpenses.test.js
+++ b/frontend/src/features/expenses/hooks/useExpenses.test.js
@@ -35,6 +35,20 @@ describe('expense refresh behavior', () => {
     expect(result.current.loading).toBe(false)
   })
 
+  it('keeps refresh rejection observable to post-confirmation callers', async () => {
+    const requestError = new Error('offline')
+    const { result } = renderHook(() => useExpenses())
+    await waitFor(() => expect(expensesApi.getAll).toHaveBeenCalledOnce())
+    expensesApi.getAll.mockRejectedValueOnce(requestError)
+
+    await act(async () => {
+      await expect(result.current.refresh()).rejects.toBe(requestError)
+    })
+
+    expect(result.current.error).toBe(requestError)
+    expect(result.current.expenses).toEqual([])
+  })
+
   it('creates through the existing API and refreshes expenses', async () => {
     const payload = { description: 'coffee', amount: 4, date: '2026-08-14', category: 'food' }
     expensesApi.getAll

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -251,6 +251,33 @@ describe('existing expense workflows', () => {
     expect(refresh).toHaveBeenCalledOnce()
   })
 
+  it('surfaces the established warning when post-confirmation Expense refresh fails', async () => {
+    const user = userEvent.setup()
+    const refresh = vi.fn().mockRejectedValue(new Error('offline'))
+    const confirm = vi.fn().mockResolvedValue({
+      batchId: selectedImportPreview.batchId,
+      status: 'confirmed',
+      confirmedAt: '2026-08-25T21:00:00Z',
+      importedExpenseCount: 1,
+    })
+    useExpenses.mockReturnValue({ ...baseExpensesHook, refresh })
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      preview: selectedImportPreview,
+      sourceType: 'sunflower_pdf',
+      selectedCount: 1,
+      confirm,
+    })
+    render(<TransactionsPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Expenses were imported, but Transactions could not be refreshed'
+    )
+  })
+
   it('renders resumed rows with duplicate and ineligible affordances and persists eligible edits', async () => {
     const user = userEvent.setup()
     const updateRow = vi.fn().mockResolvedValue(undefined)

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -103,8 +103,35 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .chart-summary h3 { margin-bottom: var(--space-3); font-size: var(--text-lg); }
 .chart-summary__list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 190px), 1fr)); gap: var(--space-3); margin: 0; padding: 0; list-style: none; }
 .chart-summary__item { display: flex; min-width: 0; padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-md); flex-direction: column; gap: var(--space-1); background: var(--color-surface-subtle); font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
+.analytics-page__header .field { width: min(100%, 240px); }
+.analytics-total { margin-bottom: var(--space-4); border-color: color-mix(in srgb, var(--color-primary) 32%, var(--color-border)); background: var(--color-bg-accent); box-shadow: none; }
+.analytics-kicker { margin: 0 0 var(--space-1); color: var(--color-primary); font-size: var(--text-xs); font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.analytics-total h2, .analytics-panel h2 { margin: 0; }
+.analytics-total__value, .analytics-comparison__value { margin: var(--space-2) 0; font-size: clamp(2rem, 6vw, 3.5rem); font-weight: 900; font-variant-numeric: tabular-nums; }
+.analytics-total > .muted { margin: 0; }
+.analytics-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+.analytics-panel { min-width: 0; box-shadow: none; }
+.analytics-panel__header, .analytics-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+.analytics-panel__header { align-items: start; margin-bottom: var(--space-4); }
+.analytics-panel__header a { flex: 0 0 auto; color: var(--color-primary); font-weight: 800; }
+.analytics-list { display: grid; gap: var(--space-3); margin: 0; padding: 0; list-style: none; }
+.analytics-list__item { min-width: 0; padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-subtle); font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
+.analytics-list__item p { margin: var(--space-1) 0 0; color: var(--color-text-muted); font-size: var(--text-sm); }
+.analytics-list__item small { display: block; margin-top: var(--space-1); color: var(--color-text-muted); }
+.analytics-row > :last-child { flex: 0 0 auto; text-align: right; }
+.analytics-bar { height: .45rem; margin-top: var(--space-2); overflow: hidden; border-radius: 999px; background: var(--color-divider); }
+.analytics-bar span { display: block; height: 100%; border-radius: inherit; background: var(--color-primary); }
+.analytics-status { padding: .25rem .5rem; border-radius: 999px; font-size: var(--text-xs); font-weight: 800; }
+.analytics-status--on-track { color: var(--color-success); background: var(--color-success-soft); }
+.analytics-status--near-limit { color: var(--color-warning); background: var(--color-warning-soft); }
+.analytics-status--over-budget { color: var(--color-danger); background: var(--color-danger-soft); }
+.analytics-change-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); margin-top: var(--space-4); }
+.analytics-change-grid h3 { margin-bottom: var(--space-2); font-size: var(--text-base); }
+.analytics-change-grid ul { display: grid; gap: var(--space-2); margin: 0; padding-left: 1.25rem; }
+.analytics-panel > button { margin-top: var(--space-3); }
 .mt-2 { margin-top: var(--space-4); }
-@media (max-width: 820px) { .overview-grid, .overview-metrics, .settings-grid, .investing-capabilities__grid { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
+@media (max-width: 820px) { .overview-grid, .overview-metrics, .settings-grid, .investing-capabilities__grid, .analytics-grid { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--transactions, .overview-module--budgets, .overview-module--analytics, .overview-module--investing { grid-column: auto; } .overview-hero, .overview-module--transactions { min-height: 220px; } }
+@media (max-width: 600px) { .analytics-panel__header { align-items: stretch; flex-direction: column; } .analytics-change-grid { grid-template-columns: 1fr; } }
 @media (max-width: 520px) { .card { padding: var(--space-4); } button:not(.icon-button):not(.password-toggle) { width: 100%; } }
 @media (max-width: 380px) { .mobile-nav .app-nav__link { min-height: 56px; } }
 


### PR DESCRIPTION
## Summary

- replace the generic Analytics chart-first view with monthly recorded-spending insights
- add historical month selection, ranked category shares, budget statuses, month-over-month changes, and the five largest Expenses
- derive all insight data in the frontend from existing authenticated Expense and Budget Limit payloads
- expose independent Expense/Budget Limit fetch errors and prevent stale month-limit responses

Closes #90

## Risk

**MEDIUM** — meaningful frontend state and financial-data presentation. Implementation follows the approved plan and owner-confirmed zero-dollar budget rule recorded on issue #90.

## Important implementation details

- Category/date matching preserves exact canonical keys and calendar-date string semantics.
- Previous-month percentages are omitted when the previous total is zero.
- Budget status reuses the existing 90% threshold: on track, near limit, or over budget.
- A zero-dollar limit with zero spent shows 0%/on track; positive spend against zero is over budget with percentage marked not applicable.
- The Transactions path is a stable `/transactions` link; no unsupported query/filter contract was added.
- No visualization dependency was added.

## Verification

- **Passed locally:** `cd frontend && npm ci`
- **Passed locally:** focused Analytics and hook suite (20 tests)
- **Passed locally:** `cd frontend && npm run verify`
  - 25 test files / 135 tests passed
  - ESLint passed
  - Vite production build passed
- **Passed locally:** `git diff --check`
- **Required by CI:** Frontend test, lint, and build
- **Required by normal PR checks:** Vercel, if triggered

## Scope boundaries and impact

- Frontend-only; no backend or API changes.
- No database, migration, persistence, authentication, authorization, or user-isolation changes.
- No dependency or lockfile changes.
- Overview and Transactions management/filter behavior are unchanged.
- No backend or PostgreSQL verification is required for this scope.
