### PR TITLE
Add commitment intelligence backend workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,13 @@ admission, fixed limits, stable errors, timeout/cancellation, process kill/reap,
 and environment scrubbing. This is a narrow containment boundary for untrusted
 PDF parsing, not general subprocess infrastructure.
 
+`backend/Commitments/` contains the pure, versioned recurring-commitment
+detector and the owner-scoped application service for candidate review and
+durable commitment operations. Candidate inference is derived from Expenses;
+only confirmed commitments, occurrence links, and dismissals are persisted.
+The approved V1 semantics and explicit non-goals are defined in
+[`docs/commitment-intelligence.md`](docs/commitment-intelligence.md).
+
 ### Authentication and ownership boundaries
 
 ASP.NET Core Identity manages users, JWT bearer authentication establishes the
@@ -77,10 +84,10 @@ not implemented yet.
 ### Persistence and migrations
 
 PostgreSQL is the application persistence provider. The database stores
-Identity data, expenses, budget limits, and the ASP.NET Core Data Protection key
-ring. Normal application startup does not apply migrations. Production
-migrations remain a separate, deliberate, human-authorized operation described
-in [`README.md`](README.md).
+Identity data, expenses, budget limits, commitment decisions and links, and the
+ASP.NET Core Data Protection key ring. Normal application startup does not
+apply migrations. Production migrations remain a separate, deliberate,
+human-authorized operation described in [`README.md`](README.md).
 
 ### Deployment topology
 

--- a/backend.Tests/Financial/CommitmentDetectorTests.cs
+++ b/backend.Tests/Financial/CommitmentDetectorTests.cs
@@ -82,6 +82,62 @@ public sealed class CommitmentDetectorTests
     }
 
     [Fact]
+    public void Yearly_candidate_represents_february_month_end_across_leap_and_non_leap_years()
+    {
+        var candidate = Assert.Single(_detector.Detect(
+        [
+            Expense(1, new DateOnly(2024, 2, 29), 100m),
+            Expense(2, new DateOnly(2025, 2, 28), 100m),
+            Expense(3, new DateOnly(2026, 2, 28), 100m)
+        ], Today));
+
+        Assert.Equal(CommitmentCadence.Yearly, candidate.Cadence);
+        Assert.Equal(CommitmentTimingKind.MonthAndDay, candidate.TimingKind);
+        Assert.Equal(2, candidate.ExpectedMonth);
+        Assert.Equal(28, candidate.ExpectedDay);
+        Assert.Equal(0, candidate.WindowBeforeDays);
+        Assert.Equal(1, candidate.WindowAfterDays);
+    }
+
+    [Fact]
+    public void Yearly_candidate_timing_window_contains_every_supporting_evidence_date()
+    {
+        var candidate = Assert.Single(_detector.Detect(
+        [
+            Expense(1, new DateOnly(2024, 3, 28), 100m),
+            Expense(2, new DateOnly(2025, 3, 30), 100m),
+            Expense(3, new DateOnly(2026, 3, 29), 100m)
+        ], Today));
+
+        Assert.Equal(29, candidate.ExpectedDay);
+        Assert.Equal(1, candidate.WindowBeforeDays);
+        Assert.Equal(1, candidate.WindowAfterDays);
+        Assert.All(candidate.Evidence, expense =>
+        {
+            var anchor = new DateOnly(expense.Date.Year, candidate.ExpectedMonth!.Value, candidate.ExpectedDay!.Value);
+            var offset = expense.Date.DayNumber - anchor.DayNumber;
+            Assert.InRange(offset, -candidate.WindowBeforeDays, candidate.WindowAfterDays);
+        });
+    }
+
+    [Fact]
+    public void Weekly_candidate_handles_an_iso_week_calendar_year_boundary()
+    {
+        var candidate = Assert.Single(_detector.Detect(
+        [
+            Expense(1, new DateOnly(2025, 12, 22), 10m),
+            Expense(2, new DateOnly(2025, 12, 29), 10m),
+            Expense(3, new DateOnly(2026, 1, 5), 10m),
+            Expense(4, new DateOnly(2026, 1, 12), 10m)
+        ], Today));
+
+        Assert.Equal(CommitmentCadence.Weekly, candidate.Cadence);
+        Assert.Equal(DayOfWeek.Monday, candidate.ExpectedDayOfWeek);
+        Assert.Equal(0, candidate.WindowBeforeDays);
+        Assert.Equal(0, candidate.WindowAfterDays);
+    }
+
+    [Fact]
     public void Ambiguous_or_gapped_groups_are_withheld()
     {
         var expenses = new[]

--- a/backend.Tests/Financial/CommitmentDetectorTests.cs
+++ b/backend.Tests/Financial/CommitmentDetectorTests.cs
@@ -1,0 +1,174 @@
+using BudgetPlanner.Commitments;
+using BudgetPlanner.Models;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+public sealed class CommitmentDetectorTests
+{
+    private static readonly DateOnly Today = new(2026, 8, 26);
+    private readonly CommitmentDetector _detector = new();
+
+    [Fact]
+    public void Monthly_candidate_uses_normalized_identity_and_fixed_amount_evidence()
+    {
+        var expenses = new[]
+        {
+            Expense(1, new DateOnly(2026, 5, 14), 20m, "  Gym   Club ", " Health "),
+            Expense(2, new DateOnly(2026, 6, 15), 20m, "gym club", "health"),
+            Expense(3, new DateOnly(2026, 7, 16), 20m, "GYM CLUB", "health")
+        };
+
+        var candidate = Assert.Single(_detector.Detect(expenses, Today));
+
+        Assert.Equal(CommitmentCadence.Monthly, candidate.Cadence);
+        Assert.Equal(CommitmentTimingKind.DayOfMonth, candidate.TimingKind);
+        Assert.Equal(15, candidate.ExpectedDay);
+        Assert.Equal(1, candidate.WindowBeforeDays);
+        Assert.Equal(1, candidate.WindowAfterDays);
+        Assert.True(candidate.HasFixedObservedAmount);
+        Assert.Equal(20m, candidate.ObservedMedianAmount);
+        Assert.Equal(32, candidate.EvidenceFingerprint.Length);
+    }
+
+    [Fact]
+    public void Monthly_candidate_uses_month_end_anchor_and_variable_median_range()
+    {
+        var candidate = Assert.Single(_detector.Detect(
+        [
+            Expense(1, new DateOnly(2026, 4, 28), 10m),
+            Expense(2, new DateOnly(2026, 5, 30), 30m),
+            Expense(3, new DateOnly(2026, 6, 29), 20m)
+        ], Today));
+
+        Assert.Equal(CommitmentTimingKind.MonthEnd, candidate.TimingKind);
+        Assert.Equal(2, candidate.WindowBeforeDays);
+        Assert.False(candidate.HasFixedObservedAmount);
+        Assert.Equal(20m, candidate.ObservedMedianAmount);
+        Assert.Equal(10m, candidate.ObservedMinimumAmount);
+        Assert.Equal(30m, candidate.ObservedMaximumAmount);
+    }
+
+    [Fact]
+    public void Weekly_candidate_requires_four_distinct_weeks_and_six_to_eight_day_gaps()
+    {
+        var candidate = Assert.Single(_detector.Detect(
+        [
+            Expense(1, new DateOnly(2026, 7, 6), 10m),
+            Expense(2, new DateOnly(2026, 7, 13), 10m),
+            Expense(3, new DateOnly(2026, 7, 21), 10m),
+            Expense(4, new DateOnly(2026, 7, 27), 10m)
+        ], Today));
+
+        Assert.Equal(CommitmentCadence.Weekly, candidate.Cadence);
+        Assert.Equal(CommitmentTimingKind.Weekday, candidate.TimingKind);
+        Assert.Equal(DayOfWeek.Monday, candidate.ExpectedDayOfWeek);
+        Assert.Equal(1, candidate.WindowAfterDays);
+    }
+
+    [Fact]
+    public void Yearly_candidate_requires_three_consecutive_years_and_same_month()
+    {
+        var candidate = Assert.Single(_detector.Detect(
+        [
+            Expense(1, new DateOnly(2024, 2, 28), 100m),
+            Expense(2, new DateOnly(2025, 2, 28), 100m),
+            Expense(3, new DateOnly(2026, 2, 28), 100m)
+        ], Today));
+
+        Assert.Equal(CommitmentCadence.Yearly, candidate.Cadence);
+        Assert.Equal(2, candidate.ExpectedMonth);
+        Assert.Equal(28, candidate.ExpectedDay);
+    }
+
+    [Fact]
+    public void Ambiguous_or_gapped_groups_are_withheld()
+    {
+        var expenses = new[]
+        {
+            Expense(1, new DateOnly(2026, 4, 10), 10m, "ambiguous"),
+            Expense(2, new DateOnly(2026, 4, 20), 10m, "ambiguous"),
+            Expense(3, new DateOnly(2026, 5, 10), 10m, "ambiguous"),
+            Expense(4, new DateOnly(2026, 6, 10), 10m, "ambiguous"),
+            Expense(5, new DateOnly(2026, 3, 10), 10m, "gapped"),
+            Expense(6, new DateOnly(2026, 5, 10), 10m, "gapped"),
+            Expense(7, new DateOnly(2026, 6, 10), 10m, "gapped")
+        };
+
+        Assert.Empty(_detector.Detect(expenses, Today));
+    }
+
+    [Fact]
+    public void Lookback_excludes_evidence_before_the_latest_thirty_six_calendar_months()
+    {
+        var expenses = new[]
+        {
+            Expense(1, new DateOnly(2023, 8, 31), 10m),
+            Expense(2, new DateOnly(2023, 9, 15), 10m),
+            Expense(3, new DateOnly(2023, 10, 15), 10m),
+            Expense(4, new DateOnly(2023, 11, 15), 10m)
+        };
+
+        var candidate = Assert.Single(_detector.Detect(expenses, Today));
+        Assert.Equal(new[] { 2, 3, 4 }, candidate.Evidence.Select(expense => expense.Id));
+    }
+
+    [Fact]
+    public void Fingerprint_is_stable_for_ordering_but_changes_with_evidence_revision()
+    {
+        var expenses = new[]
+        {
+            Expense(3, new DateOnly(2026, 7, 15), 10m),
+            Expense(1, new DateOnly(2026, 5, 15), 10m),
+            Expense(2, new DateOnly(2026, 6, 15), 10m)
+        };
+        var first = Assert.Single(_detector.Detect(expenses, Today));
+        var reordered = Assert.Single(_detector.Detect(expenses.Reverse(), Today));
+        Assert.Equal(first.EvidenceFingerprint, reordered.EvidenceFingerprint);
+
+        expenses[1].CommitmentEvidenceRevision = Guid.NewGuid();
+        var changed = Assert.Single(_detector.Detect(expenses, Today));
+        Assert.NotEqual(first.EvidenceFingerprint, changed.EvidenceFingerprint);
+    }
+
+    [Fact]
+    public void Same_amount_different_description_or_category_never_groups()
+    {
+        var expenses = new[]
+        {
+            Expense(1, new DateOnly(2026, 5, 15), 10m, "one", "bills"),
+            Expense(2, new DateOnly(2026, 6, 15), 10m, "two", "bills"),
+            Expense(3, new DateOnly(2026, 7, 15), 10m, "one", "other bills")
+        };
+
+        Assert.Empty(_detector.Detect(expenses, Today));
+    }
+
+    [Fact]
+    public void Invalid_legacy_expenses_are_not_candidate_evidence()
+    {
+        var expenses = new[]
+        {
+            Expense(1, new DateOnly(2026, 5, 15), 10.001m),
+            Expense(2, new DateOnly(2026, 6, 15), 10.001m),
+            Expense(3, new DateOnly(2026, 7, 15), 10.001m)
+        };
+
+        Assert.Empty(_detector.Detect(expenses, Today));
+    }
+
+    private static Expense Expense(
+        int id,
+        DateOnly date,
+        decimal amount,
+        string description = "membership",
+        string category = "bills") => new()
+    {
+        Id = id,
+        Date = date,
+        Amount = amount,
+        Description = description,
+        Category = category,
+        CommitmentEvidenceRevision = Guid.Parse($"00000000-0000-0000-0000-{id:D12}")
+    };
+}

--- a/backend.Tests/Financial/CommitmentsApiTests.cs
+++ b/backend.Tests/Financial/CommitmentsApiTests.cs
@@ -1,0 +1,343 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+public sealed class CommitmentsApiTests
+{
+    [Fact]
+    public async Task Endpoints_require_authentication()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/commitment-candidates")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/commitments")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint = new string('0', 64) })).StatusCode);
+    }
+
+    [Fact]
+    public async Task Candidate_read_is_owner_scoped_explainable_and_deterministic()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("candidate-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("candidate-other@example.com");
+        var dates = RecentMonthlyDates();
+        var ownedExpenses = new List<BudgetPlanner.Models.Expense>();
+        for (var index = 0; index < dates.Length; index++)
+        {
+            ownedExpenses.Add(await app.SeedExpenseAsync(
+                owner.Id, "  Gym   Club ", 20m + index, dates[index], " Health "));
+            await app.SeedExpenseAsync(other.Id, "hidden", 99m, dates[index], "bills");
+        }
+        using (var provenanceScope = app.Services.CreateScope())
+        {
+            var context = provenanceScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var now = DateTime.UtcNow;
+            context.ImportPreviewBatches.Add(new BudgetPlanner.Models.ImportPreviewBatch
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = owner.Id,
+                SourceType = "sunflower_pdf",
+                ParserRuleVersion = "test-v1",
+                DocumentDigest = new byte[32],
+                CreatedAt = now.AddHours(-1),
+                ExpiresAt = now.AddHours(1),
+                Lifecycle = BudgetPlanner.Models.ImportPreviewLifecycle.Confirmed,
+                ConfirmedAt = now,
+                Provenance =
+                [
+                    new BudgetPlanner.Models.ImportExpenseProvenance
+                    {
+                        SourceRowOrdinal = 1,
+                        ExpenseId = ownedExpenses[0].Id
+                    }
+                ]
+            });
+            await context.SaveChangesAsync();
+        }
+
+        var first = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+        var second = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+
+        var candidate = Assert.Single(first.GetProperty("candidates").EnumerateArray());
+        Assert.Empty(first.GetProperty("dismissedCandidates").EnumerateArray());
+        Assert.Equal("monthly", candidate.GetProperty("cadence").GetString());
+        Assert.Equal("health", candidate.GetProperty("category").GetString());
+        Assert.Equal("variable", candidate.GetProperty("observedAmountMode").GetString());
+        Assert.Equal(3, candidate.GetProperty("occurrenceCount").GetInt32());
+        Assert.Equal("consecutive_calendar_months", candidate.GetProperty("evidenceRule").GetString());
+        Assert.Equal(3, candidate.GetProperty("evidence").GetArrayLength());
+        var evidenceRows = candidate.GetProperty("evidence").EnumerateArray().ToArray();
+        Assert.Equal("sunflower_pdf", evidenceRows[0].GetProperty("source").GetString());
+        Assert.All(evidenceRows.Skip(1), evidence =>
+            Assert.Equal("manual", evidence.GetProperty("source").GetString()));
+        Assert.All(evidenceRows, evidence =>
+            Assert.False(evidence.TryGetProperty("commitmentEvidenceRevision", out _)));
+        Assert.Equal(64, candidate.GetProperty("fingerprint").GetString()!.Length);
+        Assert.Equal(
+            candidate.GetProperty("fingerprint").GetString(),
+            Assert.Single(second.GetProperty("candidates").EnumerateArray())
+                .GetProperty("fingerprint").GetString());
+        Assert.DoesNotContain("hidden", first.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Dismiss_and_reconsider_are_reversible_and_idempotent()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("dismiss@example.com");
+        await SeedMonthlyCandidateAsync(app, owner.Id);
+        var fingerprint = await CandidateFingerprintAsync(owner.Client);
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint })).StatusCode);
+        var dismissed = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+        Assert.Empty(dismissed.GetProperty("candidates").EnumerateArray());
+        Assert.Single(dismissed.GetProperty("dismissedCandidates").EnumerateArray());
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync("/api/commitment-candidates/reconsider", new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync("/api/commitment-candidates/reconsider", new { fingerprint })).StatusCode);
+        var reconsidered = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+        Assert.Single(reconsidered.GetProperty("candidates").EnumerateArray());
+        Assert.Empty(reconsidered.GetProperty("dismissedCandidates").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Material_expense_edit_invalidates_stale_candidate_and_dismissal()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("stale@example.com");
+        var expenses = await SeedMonthlyCandidateAsync(app, owner.Id);
+        var oldFingerprint = await CandidateFingerprintAsync(owner.Client);
+        await owner.Client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint = oldFingerprint });
+
+        var edited = expenses[1];
+        var update = await owner.Client.PutAsJsonAsync($"/api/expenses/{edited.Id}", new
+        {
+            id = edited.Id,
+            description = "membership",
+            amount = 12m,
+            date = edited.Date.ToString("yyyy-MM-dd"),
+            category = "bills"
+        });
+        Assert.Equal(HttpStatusCode.NoContent, update.StatusCode);
+
+        var stale = await owner.Client.PostAsJsonAsync(
+            "/api/commitment-candidates/reconsider",
+            new { fingerprint = oldFingerprint });
+        Assert.Equal(HttpStatusCode.Conflict, stale.StatusCode);
+        var current = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+        var newCandidate = Assert.Single(current.GetProperty("candidates").EnumerateArray());
+        Assert.NotEqual(oldFingerprint, newCandidate.GetProperty("fingerprint").GetString());
+        Assert.Empty(current.GetProperty("dismissedCandidates").EnumerateArray());
+        using var scope = app.Services.CreateScope();
+        Assert.Empty(await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .CommitmentCandidateDismissals.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Confirmation_is_server_resolved_persists_links_and_is_retry_safe()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("confirm@example.com");
+        var expenses = await SeedMonthlyCandidateAsync(app, owner.Id);
+        var fingerprint = await CandidateFingerprintAsync(owner.Client);
+        var request = FixedConfirmation(fingerprint);
+
+        var firstResponse = await owner.Client.PostAsJsonAsync("/api/commitment-candidates/confirm", request);
+        var first = await firstResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var retryResponse = await owner.Client.PostAsJsonAsync("/api/commitment-candidates/confirm", request);
+        var retry = await retryResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
+        Assert.False(first.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Equal(HttpStatusCode.OK, retryResponse.StatusCode);
+        Assert.True(retry.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Equal(
+            first.GetProperty("commitment").GetProperty("id").GetGuid(),
+            retry.GetProperty("commitment").GetProperty("id").GetGuid());
+        Assert.Equal(3, first.GetProperty("commitment").GetProperty("evidence").GetArrayLength());
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Single(await context.Commitments.ToListAsync());
+        Assert.Equal(expenses.Count, await context.CommitmentOccurrences.CountAsync());
+        Assert.Empty((await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates"))
+            .GetProperty("candidates").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Dismissed_or_stale_candidate_cannot_be_confirmed()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("confirm-conflict@example.com");
+        var expenses = await SeedMonthlyCandidateAsync(app, owner.Id);
+        var fingerprint = await CandidateFingerprintAsync(owner.Client);
+        await owner.Client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint });
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync("/api/commitment-candidates/confirm", FixedConfirmation(fingerprint))).StatusCode);
+
+        await owner.Client.PostAsJsonAsync("/api/commitment-candidates/reconsider", new { fingerprint });
+        var expense = expenses[0];
+        await owner.Client.PutAsJsonAsync($"/api/expenses/{expense.Id}", new
+        {
+            id = expense.Id,
+            description = expense.Description,
+            amount = 11m,
+            date = expense.Date.ToString("yyyy-MM-dd"),
+            category = expense.Category
+        });
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync("/api/commitment-candidates/confirm", FixedConfirmation(fingerprint))).StatusCode);
+    }
+
+    [Fact]
+    public async Task Commands_reject_invalid_fingerprints_and_expectation_shapes()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("invalid-commitment@example.com");
+        await SeedMonthlyCandidateAsync(app, owner.Id);
+        var fingerprint = await CandidateFingerprintAsync(owner.Client);
+
+        var invalidFingerprint = await owner.Client.PostAsJsonAsync(
+            "/api/commitment-candidates/dismiss",
+            new { fingerprint = "not-a-fingerprint" });
+        Assert.Equal(HttpStatusCode.BadRequest, invalidFingerprint.StatusCode);
+        Assert.Equal("fingerprint_invalid", (await invalidFingerprint.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("code").GetString());
+        Assert.Equal("application/problem+json", invalidFingerprint.Content.Headers.ContentType?.MediaType);
+
+        var invalidExpectation = await owner.Client.PostAsJsonAsync(
+            "/api/commitment-candidates/confirm",
+            new
+            {
+                fingerprint,
+                name = "Membership",
+                category = "bills",
+                cadence = "weekly",
+                timingKind = "dayOfMonth",
+                expectedDayOfWeek = (string?)null,
+                expectedDay = (int?)null,
+                expectedMonth = (int?)null,
+                windowBeforeDays = -1,
+                windowAfterDays = 0,
+                amountMode = "range",
+                expectedAmount = 10m,
+                expectedMinimumAmount = (decimal?)null,
+                expectedMaximumAmount = (decimal?)null
+            });
+        Assert.Equal(HttpStatusCode.BadRequest, invalidExpectation.StatusCode);
+        Assert.Equal("timing_invalid", (await invalidExpectation.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public async Task Commitment_update_and_lifecycle_are_owned_validated_and_do_not_edit_expenses()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("edit-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("edit-other@example.com");
+        var expenses = await SeedMonthlyCandidateAsync(app, owner.Id);
+        var fingerprint = await CandidateFingerprintAsync(owner.Client);
+        var confirmation = await owner.Client.PostAsJsonAsync(
+            "/api/commitment-candidates/confirm",
+            FixedConfirmation(fingerprint));
+        var confirmed = await confirmation.Content.ReadFromJsonAsync<JsonElement>();
+        var id = confirmed.GetProperty("commitment").GetProperty("id").GetGuid();
+
+        var update = await owner.Client.PutAsJsonAsync($"/api/commitments/{id}", new
+        {
+            name = "  Updated membership ",
+            category = " Home   Bills ",
+            cadence = "monthly",
+            timingKind = "monthEnd",
+            expectedDayOfWeek = (string?)null,
+            expectedDay = (int?)null,
+            expectedMonth = (int?)null,
+            windowBeforeDays = 3,
+            windowAfterDays = 0,
+            amountMode = "range",
+            expectedAmount = (decimal?)null,
+            expectedMinimumAmount = 9m,
+            expectedMaximumAmount = 15m
+        });
+        var updated = await update.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.OK, update.StatusCode);
+        Assert.Equal("Updated membership", updated.GetProperty("name").GetString());
+        Assert.Equal("home bills", updated.GetProperty("category").GetString());
+        Assert.Equal("range", updated.GetProperty("amountMode").GetString());
+
+        var lifecycle = await owner.Client.PatchAsJsonAsync(
+            $"/api/commitments/{id}/lifecycle",
+            new { lifecycle = "paused" });
+        Assert.Equal("paused", (await lifecycle.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("lifecycle").GetString());
+        Assert.Equal(HttpStatusCode.NotFound,
+            (await other.Client.PatchAsJsonAsync($"/api/commitments/{id}/lifecycle", new { lifecycle = "ended" })).StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            (await owner.Client.PatchAsJsonAsync($"/api/commitments/{id}/lifecycle", new { lifecycle = "automatic" })).StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            (await owner.Client.PatchAsJsonAsync($"/api/commitments/{id}/lifecycle", new { lifecycle = "1" })).StatusCode);
+        Assert.Empty((await other.Client.GetFromJsonAsync<JsonElement>("/api/commitments")).EnumerateArray());
+        foreach (var expense in expenses)
+        {
+            var persisted = await app.FindExpenseAsync(expense.Id);
+            Assert.Equal(expense.Amount, persisted!.Amount);
+            Assert.Equal(expense.Description, persisted.Description);
+        }
+    }
+
+    private static async Task<List<BudgetPlanner.Models.Expense>> SeedMonthlyCandidateAsync(
+        FinancialApiTestApplication app,
+        string ownerId)
+    {
+        var result = new List<BudgetPlanner.Models.Expense>();
+        foreach (var date in RecentMonthlyDates())
+            result.Add(await app.SeedExpenseAsync(ownerId, "membership", 10m, date, "bills"));
+        return result;
+    }
+
+    private static DateOnly[] RecentMonthlyDates()
+    {
+        var now = DateTime.UtcNow;
+        var current = new DateOnly(now.Year, now.Month, 10);
+        return [current.AddMonths(-2), current.AddMonths(-1), current];
+    }
+
+    private static async Task<string> CandidateFingerprintAsync(HttpClient client)
+    {
+        var response = await client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+        return Assert.Single(response.GetProperty("candidates").EnumerateArray())
+            .GetProperty("fingerprint").GetString()!;
+    }
+
+    private static object FixedConfirmation(string fingerprint) => new
+    {
+        fingerprint,
+        name = "Membership",
+        category = "bills",
+        cadence = "monthly",
+        timingKind = "dayOfMonth",
+        expectedDayOfWeek = (string?)null,
+        expectedDay = 10,
+        expectedMonth = (int?)null,
+        windowBeforeDays = 0,
+        windowAfterDays = 0,
+        amountMode = "fixed",
+        expectedAmount = 10m,
+        expectedMinimumAmount = (decimal?)null,
+        expectedMaximumAmount = (decimal?)null
+    };
+}

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -435,6 +435,77 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Commitment_candidate_and_confirmation_flow_executes_relational_queries()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-commitment@example.com");
+        foreach (var date in RecentCommitmentDates())
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, date, "bills");
+        var fingerprint = await ReadCandidateFingerprintAsync(owner.Client);
+
+        using var response = await owner.Client.PostAsJsonAsync(
+            "/api/commitment-candidates/confirm",
+            FixedCommitmentConfirmation(fingerprint));
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.False(body.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Equal(3, body.GetProperty("commitment").GetProperty("evidence").GetArrayLength());
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Single(await context.Commitments.Where(value => value.OwnerId == owner.Id).ToListAsync());
+        Assert.Equal(3, await context.CommitmentOccurrences.CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Concurrent_candidate_confirmations_create_one_commitment_and_return_one_retry()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-commitment-race@example.com");
+        foreach (var date in RecentCommitmentDates())
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, date, "bills");
+        var fingerprint = await ReadCandidateFingerprintAsync(owner.Client);
+        var request = FixedCommitmentConfirmation(fingerprint);
+
+        var responses = await Task.WhenAll(
+            owner.Client.PostAsJsonAsync("/api/commitment-candidates/confirm", request),
+            owner.Client.PostAsJsonAsync("/api/commitment-candidates/confirm", request));
+        var bodies = await Task.WhenAll(responses.Select(response =>
+            response.Content.ReadFromJsonAsync<JsonElement>()));
+
+        Assert.All(responses, response => Assert.Contains(response.StatusCode,
+            new[] { HttpStatusCode.Created, HttpStatusCode.OK }));
+        Assert.Single(bodies, body => !body.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Single(bodies, body => body.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Single(bodies.Select(body =>
+            body.GetProperty("commitment").GetProperty("id").GetGuid()).Distinct());
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(1, await context.Commitments.CountAsync(value => value.OwnerId == owner.Id));
+        Assert.Equal(3, await context.CommitmentOccurrences.CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Concurrent_candidate_dismissals_are_idempotent()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-dismiss-race@example.com");
+        foreach (var date in RecentCommitmentDates())
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, date, "bills");
+        var fingerprint = await ReadCandidateFingerprintAsync(owner.Client);
+
+        var responses = await Task.WhenAll(
+            owner.Client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint }),
+            owner.Client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint }));
+
+        Assert.All(responses, response => Assert.Equal(HttpStatusCode.NoContent, response.StatusCode));
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(1, await context.CommitmentCandidateDismissals.CountAsync(
+            value => value.OwnerId == owner.Id));
+    }
+
+    [PostgreSqlFact]
     public async Task Expense_date_migration_preserves_the_utc_calendar_component()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
@@ -1237,6 +1308,38 @@ public sealed class PostgreSqlFinancialApiTests
             $"Expected preview creation, received {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         return body;
     }
+
+    private static DateOnly[] RecentCommitmentDates()
+    {
+        var now = DateTime.UtcNow;
+        var current = new DateOnly(now.Year, now.Month, 10);
+        return [current.AddMonths(-2), current.AddMonths(-1), current];
+    }
+
+    private static async Task<string> ReadCandidateFingerprintAsync(HttpClient client)
+    {
+        var response = await client.GetFromJsonAsync<JsonElement>("/api/commitment-candidates");
+        return Assert.Single(response.GetProperty("candidates").EnumerateArray())
+            .GetProperty("fingerprint").GetString()!;
+    }
+
+    private static object FixedCommitmentConfirmation(string fingerprint) => new
+    {
+        fingerprint,
+        name = "Membership",
+        category = "bills",
+        cadence = "monthly",
+        timingKind = "dayOfMonth",
+        expectedDayOfWeek = (string?)null,
+        expectedDay = 10,
+        expectedMonth = (int?)null,
+        windowBeforeDays = 0,
+        windowAfterDays = 0,
+        amountMode = "fixed",
+        expectedAmount = 10m,
+        expectedMinimumAmount = (decimal?)null,
+        expectedMaximumAmount = (decimal?)null
+    };
 
     private static MultipartFormDataContent CreatePdfUpload(byte[] pdf)
     {

--- a/backend/Commitments/CommitmentDetector.cs
+++ b/backend/Commitments/CommitmentDetector.cs
@@ -128,15 +128,27 @@ public sealed class CommitmentDetector : ICommitmentDetector
         var monthEndOffsets = dates.Select(date => DateTime.DaysInMonth(date.Year, date.Month) - date.Day).ToArray();
         if (monthEndOffsets.All(offset => offset <= 3) && monthEndOffsets.Max() - monthEndOffsets.Min() <= 2)
         {
+            if (yearly)
+            {
+                var yearlyDays = dates.Select(date => date.Day).Order().ToArray();
+                var yearlyExpectedDay = yearlyDays[(yearlyDays.Length - 1) / 2];
+                timing = new CandidateTiming(
+                    CommitmentTimingKind.MonthAndDay,
+                    null,
+                    yearlyExpectedDay,
+                    dates[0].Month,
+                    yearlyExpectedDay - yearlyDays[0],
+                    yearlyDays[^1] - yearlyExpectedDay);
+                return true;
+            }
+
             timing = new CandidateTiming(
                 CommitmentTimingKind.MonthEnd,
                 null,
                 null,
-                yearly ? dates[0].Month : null,
+                null,
                 monthEndOffsets.Max(),
                 0);
-            if (yearly)
-                timing = timing with { Kind = CommitmentTimingKind.MonthAndDay, Day = dates.Max(date => date.Day) };
             return true;
         }
 

--- a/backend/Commitments/CommitmentDetector.cs
+++ b/backend/Commitments/CommitmentDetector.cs
@@ -1,0 +1,222 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using BudgetPlanner.Import;
+using BudgetPlanner.Models;
+
+namespace BudgetPlanner.Commitments;
+
+public sealed record CommitmentCandidate(
+    string AlgorithmVersion,
+    CommitmentCadence Cadence,
+    string Description,
+    string Category,
+    CommitmentTimingKind TimingKind,
+    DayOfWeek? ExpectedDayOfWeek,
+    int? ExpectedDay,
+    int? ExpectedMonth,
+    int WindowBeforeDays,
+    int WindowAfterDays,
+    bool HasFixedObservedAmount,
+    decimal ObservedMedianAmount,
+    decimal ObservedMinimumAmount,
+    decimal ObservedMaximumAmount,
+    byte[] EvidenceFingerprint,
+    IReadOnlyList<Expense> Evidence);
+
+public interface ICommitmentDetector
+{
+    IReadOnlyList<CommitmentCandidate> Detect(IEnumerable<Expense> expenses, DateOnly today);
+}
+
+public sealed class CommitmentDetector : ICommitmentDetector
+{
+    public const string AlgorithmVersion = "commitment-v1";
+    private static readonly byte[] FingerprintDomain = "ordo.commitment-candidate.v1\0"u8.ToArray();
+
+    public IReadOnlyList<CommitmentCandidate> Detect(IEnumerable<Expense> expenses, DateOnly today)
+    {
+        var currentMonth = new DateOnly(today.Year, today.Month, 1);
+        var cutoff = currentMonth.AddMonths(-35);
+        var groups = expenses
+            .Where(expense => expense.Date >= cutoff && expense.Date <= today)
+            .Where(expense => ExpenseInputRules.Validate(
+                expense.Amount,
+                expense.Date,
+                expense.Description,
+                expense.Category).Count == 0)
+            .GroupBy(expense => new CandidateGroupKey(
+                ExpenseInputRules.NormalizeDescriptionForComparison(expense.Description),
+                ExpenseInputRules.NormalizeCategory(expense.Category)))
+            .OrderBy(group => group.Key.Description, StringComparer.Ordinal)
+            .ThenBy(group => group.Key.Category, StringComparer.Ordinal);
+
+        var candidates = new List<CommitmentCandidate>();
+        foreach (var group in groups)
+        {
+            var evidence = group.OrderBy(expense => expense.Date).ThenBy(expense => expense.Id).ToArray();
+            if (TryMonthly(evidence, out var monthlyTiming))
+                candidates.Add(Create(group.Key, evidence, CommitmentCadence.Monthly, monthlyTiming));
+            if (TryWeekly(evidence, out var weeklyTiming))
+                candidates.Add(Create(group.Key, evidence, CommitmentCadence.Weekly, weeklyTiming));
+            if (TryYearly(evidence, out var yearlyTiming))
+                candidates.Add(Create(group.Key, evidence, CommitmentCadence.Yearly, yearlyTiming));
+        }
+
+        return candidates
+            .OrderBy(candidate => candidate.Description, StringComparer.Ordinal)
+            .ThenBy(candidate => candidate.Category, StringComparer.Ordinal)
+            .ThenBy(candidate => candidate.Cadence)
+            .ToArray();
+    }
+
+    private static bool TryMonthly(IReadOnlyList<Expense> evidence, out CandidateTiming timing)
+    {
+        timing = default;
+        if (evidence.Count < 3) return false;
+        var periods = evidence.Select(expense => expense.Date.Year * 12 + expense.Date.Month).ToArray();
+        if (periods.Distinct().Count() != evidence.Count) return false;
+        if (periods.Zip(periods.Skip(1)).Any(pair => pair.Second - pair.First != 1)) return false;
+        return TryCalendarDayTiming(evidence.Select(expense => expense.Date).ToArray(), false, out timing);
+    }
+
+    private static bool TryWeekly(IReadOnlyList<Expense> evidence, out CandidateTiming timing)
+    {
+        timing = default;
+        if (evidence.Count < 4 || evidence[^1].Date.DayNumber - evidence[0].Date.DayNumber < 21) return false;
+        var weeks = evidence.Select(expense =>
+            (ISOWeek.GetYear(expense.Date.ToDateTime(TimeOnly.MinValue)),
+             ISOWeek.GetWeekOfYear(expense.Date.ToDateTime(TimeOnly.MinValue)))).ToArray();
+        if (weeks.Distinct().Count() != evidence.Count) return false;
+        var gaps = evidence.Zip(evidence.Skip(1), (left, right) => right.Date.DayNumber - left.Date.DayNumber).ToArray();
+        if (gaps.Any(gap => gap is < 6 or > 8)) return false;
+
+        var weekday = evidence
+            .GroupBy(expense => expense.Date.DayOfWeek)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => (int)group.Key)
+            .First().Key;
+        var offsets = evidence.Select(expense => SignedWeekdayOffset(weekday, expense.Date.DayOfWeek)).ToArray();
+        timing = new CandidateTiming(
+            CommitmentTimingKind.Weekday,
+            weekday,
+            null,
+            null,
+            Math.Max(0, -offsets.Min()),
+            Math.Max(0, offsets.Max()));
+        return true;
+    }
+
+    private static bool TryYearly(IReadOnlyList<Expense> evidence, out CandidateTiming timing)
+    {
+        timing = default;
+        if (evidence.Count < 3) return false;
+        var years = evidence.Select(expense => expense.Date.Year).ToArray();
+        if (years.Distinct().Count() != evidence.Count) return false;
+        if (years.Zip(years.Skip(1)).Any(pair => pair.Second - pair.First != 1)) return false;
+        if (evidence.Select(expense => expense.Date.Month).Distinct().Count() != 1) return false;
+        return TryCalendarDayTiming(evidence.Select(expense => expense.Date).ToArray(), true, out timing);
+    }
+
+    private static bool TryCalendarDayTiming(
+        IReadOnlyList<DateOnly> dates,
+        bool yearly,
+        out CandidateTiming timing)
+    {
+        timing = default;
+        var monthEndOffsets = dates.Select(date => DateTime.DaysInMonth(date.Year, date.Month) - date.Day).ToArray();
+        if (monthEndOffsets.All(offset => offset <= 3) && monthEndOffsets.Max() - monthEndOffsets.Min() <= 2)
+        {
+            timing = new CandidateTiming(
+                CommitmentTimingKind.MonthEnd,
+                null,
+                null,
+                yearly ? dates[0].Month : null,
+                monthEndOffsets.Max(),
+                0);
+            if (yearly)
+                timing = timing with { Kind = CommitmentTimingKind.MonthAndDay, Day = dates.Max(date => date.Day) };
+            return true;
+        }
+
+        var days = dates.Select(date => date.Day).Order().ToArray();
+        if (days[^1] - days[0] > 6) return false;
+        var expectedDay = days[(days.Length - 1) / 2];
+        timing = new CandidateTiming(
+            yearly ? CommitmentTimingKind.MonthAndDay : CommitmentTimingKind.DayOfMonth,
+            null,
+            expectedDay,
+            yearly ? dates[0].Month : null,
+            expectedDay - days[0],
+            days[^1] - expectedDay);
+        return true;
+    }
+
+    private static CommitmentCandidate Create(
+        CandidateGroupKey key,
+        IReadOnlyList<Expense> evidence,
+        CommitmentCadence cadence,
+        CandidateTiming timing)
+    {
+        var amounts = evidence.Select(expense => expense.Amount).Order().ToArray();
+        var median = amounts.Length % 2 == 1
+            ? amounts[amounts.Length / 2]
+            : (amounts[amounts.Length / 2 - 1] + amounts[amounts.Length / 2]) / 2m;
+        return new CommitmentCandidate(
+            AlgorithmVersion,
+            cadence,
+            evidence[^1].Description,
+            key.Category,
+            timing.Kind,
+            timing.DayOfWeek,
+            timing.Day,
+            timing.Month,
+            timing.WindowBeforeDays,
+            timing.WindowAfterDays,
+            amounts[0] == amounts[^1],
+            median,
+            amounts[0],
+            amounts[^1],
+            ComputeFingerprint(cadence, evidence),
+            evidence);
+    }
+
+    private static byte[] ComputeFingerprint(CommitmentCadence cadence, IReadOnlyList<Expense> evidence)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(FingerprintDomain);
+        var version = Encoding.UTF8.GetBytes(AlgorithmVersion);
+        WriteInt32(stream, version.Length);
+        stream.Write(version);
+        stream.WriteByte((byte)cadence);
+        WriteInt32(stream, evidence.Count);
+        Span<byte> revision = stackalloc byte[16];
+        foreach (var expense in evidence)
+        {
+            WriteInt32(stream, expense.Id);
+            expense.CommitmentEvidenceRevision.TryWriteBytes(revision, bigEndian: true, out _);
+            stream.Write(revision);
+        }
+        return SHA256.HashData(stream.ToArray());
+    }
+
+    private static void WriteInt32(Stream stream, int value)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+        stream.Write(bytes);
+    }
+
+    private static int SignedWeekdayOffset(DayOfWeek expected, DayOfWeek actual) =>
+        ((int)actual - (int)expected + 10) % 7 - 3;
+
+    private sealed record CandidateGroupKey(string Description, string Category);
+    private readonly record struct CandidateTiming(
+        CommitmentTimingKind Kind,
+        DayOfWeek? DayOfWeek,
+        int? Day,
+        int? Month,
+        int WindowBeforeDays,
+        int WindowAfterDays);
+}

--- a/backend/Commitments/CommitmentService.cs
+++ b/backend/Commitments/CommitmentService.cs
@@ -1,0 +1,598 @@
+using System.Data;
+using System.Security.Cryptography;
+using BudgetPlanner.Contracts.Commitments;
+using BudgetPlanner.Data;
+using BudgetPlanner.Import;
+using BudgetPlanner.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+
+namespace BudgetPlanner.Commitments;
+
+public sealed record CommitmentOperation<T>(T? Value, CommitmentError? Error)
+{
+    public bool IsSuccess => Error is null;
+    public static CommitmentOperation<T> Success(T value) => new(value, null);
+    public static CommitmentOperation<T> Failure(string code, string message) =>
+        new(default, new CommitmentError(code, message));
+}
+
+public interface ICommitmentService
+{
+    Task<CommitmentCandidatesResponse> GetCandidatesAsync(string ownerId, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> DismissAsync(string ownerId, CandidateDecisionRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> ReconsiderAsync(string ownerId, CandidateDecisionRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<ConfirmCommitmentResponse>> ConfirmAsync(string ownerId, ConfirmCommitmentRequest request, CancellationToken cancellationToken);
+    Task<IReadOnlyList<CommitmentResponse>> GetCommitmentsAsync(string ownerId, CancellationToken cancellationToken);
+    Task<CommitmentOperation<CommitmentResponse>> UpdateAsync(string ownerId, Guid id, UpdateCommitmentRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<CommitmentResponse>> UpdateLifecycleAsync(string ownerId, Guid id, UpdateCommitmentLifecycleRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class CommitmentService(
+    BudgetContext context,
+    ICommitmentDetector detector,
+    TimeProvider clock) : ICommitmentService
+{
+    public async Task<CommitmentCandidatesResponse> GetCandidatesAsync(
+        string ownerId,
+        CancellationToken cancellationToken)
+    {
+        var state = await LoadCandidateStateAsync(ownerId, cancellationToken);
+        var available = state.Detected
+            .Where(candidate => candidate.Evidence.All(expense => !state.LinkedExpenseIds.Contains(expense.Id)))
+            .ToArray();
+        var currentFingerprints = available
+            .Select(candidate => FingerprintKey(candidate.EvidenceFingerprint)).ToHashSet();
+        var obsolete = state.Dismissals
+            .Where(dismissal => !currentFingerprints.Contains(FingerprintKey(dismissal.EvidenceFingerprint)))
+            .ToArray();
+        if (obsolete.Length > 0)
+        {
+            context.CommitmentCandidateDismissals.RemoveRange(obsolete);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        var dismissedKeys = state.Dismissals.Except(obsolete)
+            .Select(dismissal => FingerprintKey(dismissal.EvidenceFingerprint)).ToHashSet();
+        return new CommitmentCandidatesResponse(
+            available.Where(candidate => !dismissedKeys.Contains(FingerprintKey(candidate.EvidenceFingerprint)))
+                .Select(candidate => ToCandidateResponse(candidate, state.ImportedExpenseIds)).ToArray(),
+            available.Where(candidate => dismissedKeys.Contains(FingerprintKey(candidate.EvidenceFingerprint)))
+                .Select(candidate => ToCandidateResponse(candidate, state.ImportedExpenseIds)).ToArray());
+    }
+
+    public async Task<CommitmentOperation<bool>> DismissAsync(
+        string ownerId,
+        CandidateDecisionRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseFingerprint(request.Fingerprint, out var fingerprint)) return InvalidFingerprint<bool>();
+        await using var transaction = await BeginSerializableTransactionAsync(cancellationToken);
+        try
+        {
+            var state = await LoadCandidateStateAsync(ownerId, cancellationToken);
+            var candidate = FindAvailableCandidate(state, fingerprint);
+            if (candidate is null)
+            {
+                await RollbackAsync(transaction);
+                return CandidateChanged<bool>();
+            }
+            if (state.Dismissals.Any(value => FingerprintsEqual(value.EvidenceFingerprint, fingerprint)))
+            {
+                await CommitAsync(transaction, cancellationToken);
+                return CommitmentOperation<bool>.Success(true);
+            }
+            context.CommitmentCandidateDismissals.Add(new CommitmentCandidateDismissal
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = ownerId,
+                AlgorithmVersion = candidate.AlgorithmVersion,
+                Cadence = candidate.Cadence,
+                EvidenceFingerprint = candidate.EvidenceFingerprint,
+                DismissedAt = clock.GetUtcNow().UtcDateTime
+            });
+            await context.SaveChangesAsync(cancellationToken);
+            await CommitAsync(transaction, cancellationToken);
+            return CommitmentOperation<bool>.Success(true);
+        }
+        catch (Exception exception) when (IsConcurrencyConflict(exception))
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            var persisted = await context.CommitmentCandidateDismissals.AsNoTracking().AnyAsync(value =>
+                value.OwnerId == ownerId
+                && value.EvidenceFingerprint.SequenceEqual(fingerprint),
+                cancellationToken);
+            return persisted
+                ? CommitmentOperation<bool>.Success(true)
+                : CandidateChanged<bool>();
+        }
+    }
+
+    public async Task<CommitmentOperation<bool>> ReconsiderAsync(
+        string ownerId,
+        CandidateDecisionRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseFingerprint(request.Fingerprint, out var fingerprint)) return InvalidFingerprint<bool>();
+        await using var transaction = await BeginSerializableTransactionAsync(cancellationToken);
+        try
+        {
+            var state = await LoadCandidateStateAsync(ownerId, cancellationToken);
+            if (FindAvailableCandidate(state, fingerprint) is null)
+            {
+                await RollbackAsync(transaction);
+                return CandidateChanged<bool>();
+            }
+            var dismissal = state.Dismissals.SingleOrDefault(value =>
+                FingerprintsEqual(value.EvidenceFingerprint, fingerprint));
+            if (dismissal is not null)
+            {
+                context.CommitmentCandidateDismissals.Remove(dismissal);
+                await context.SaveChangesAsync(cancellationToken);
+            }
+            await CommitAsync(transaction, cancellationToken);
+            return CommitmentOperation<bool>.Success(true);
+        }
+        catch (Exception exception) when (IsConcurrencyConflict(exception))
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            var state = await LoadCandidateStateAsync(ownerId, cancellationToken);
+            return FindAvailableCandidate(state, fingerprint) is not null
+                && state.Dismissals.All(value => !FingerprintsEqual(value.EvidenceFingerprint, fingerprint))
+                ? CommitmentOperation<bool>.Success(true)
+                : CandidateChanged<bool>();
+        }
+    }
+
+    public async Task<CommitmentOperation<ConfirmCommitmentResponse>> ConfirmAsync(
+        string ownerId,
+        ConfirmCommitmentRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseFingerprint(request.Fingerprint, out var fingerprint))
+            return InvalidFingerprint<ConfirmCommitmentResponse>();
+        var expectation = ValidateExpectation(request);
+        if (!expectation.IsSuccess)
+            return CommitmentOperation<ConfirmCommitmentResponse>.Failure(
+                expectation.Error!.Code,
+                expectation.Error.Message);
+
+        await using var transaction = await BeginSerializableTransactionAsync(cancellationToken);
+        try
+        {
+            var existing = await FindByOriginAsync(ownerId, fingerprint, cancellationToken);
+            if (existing is not null)
+            {
+                await CommitAsync(transaction, cancellationToken);
+                return CommitmentOperation<ConfirmCommitmentResponse>.Success(
+                    new ConfirmCommitmentResponse(await ToCommitmentResponseAsync(existing, cancellationToken), true));
+            }
+
+            var state = await LoadCandidateStateAsync(ownerId, cancellationToken);
+            var candidate = FindAvailableCandidate(state, fingerprint);
+            if (candidate is null)
+            {
+                await RollbackAsync(transaction);
+                return CandidateChanged<ConfirmCommitmentResponse>();
+            }
+            if (state.Dismissals.Any(value => FingerprintsEqual(value.EvidenceFingerprint, fingerprint)))
+            {
+                await RollbackAsync(transaction);
+                return CommitmentOperation<ConfirmCommitmentResponse>.Failure(
+                    "candidate_dismissed",
+                    "Reconsider this candidate before confirming it.");
+            }
+
+            var values = expectation.Value!;
+            var now = clock.GetUtcNow().UtcDateTime;
+            var commitment = new Commitment
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = ownerId,
+                Name = values.Name,
+                Category = values.Category,
+                Lifecycle = CommitmentLifecycle.Active,
+                Cadence = values.Cadence,
+                TimingKind = values.TimingKind,
+                ExpectedDayOfWeek = values.ExpectedDayOfWeek,
+                ExpectedDay = values.ExpectedDay,
+                ExpectedMonth = values.ExpectedMonth,
+                WindowBeforeDays = values.WindowBeforeDays,
+                WindowAfterDays = values.WindowAfterDays,
+                AmountMode = values.AmountMode,
+                ExpectedAmount = values.ExpectedAmount,
+                ExpectedMinimumAmount = values.ExpectedMinimumAmount,
+                ExpectedMaximumAmount = values.ExpectedMaximumAmount,
+                OriginAlgorithmVersion = candidate.AlgorithmVersion,
+                OriginEvidenceFingerprint = candidate.EvidenceFingerprint,
+                CreatedAt = now,
+                UpdatedAt = now,
+                Occurrences = candidate.Evidence.Select(expense => new CommitmentOccurrence
+                {
+                    ExpenseId = expense.Id,
+                    Kind = CommitmentOccurrenceKind.ConfirmationEvidence,
+                    LinkedAt = now
+                }).ToList()
+            };
+            context.Commitments.Add(commitment);
+            await context.SaveChangesAsync(cancellationToken);
+            await CommitAsync(transaction, cancellationToken);
+            return CommitmentOperation<ConfirmCommitmentResponse>.Success(
+                new ConfirmCommitmentResponse(await ToCommitmentResponseAsync(commitment, cancellationToken), false));
+        }
+        catch (Exception exception) when (IsConcurrencyConflict(exception))
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            var existing = await FindByOriginAsync(ownerId, fingerprint, cancellationToken);
+            return existing is null
+                ? CommitmentOperation<ConfirmCommitmentResponse>.Failure(
+                    "confirmation_conflict",
+                    "The candidate was changed or confirmed by another request.")
+                : CommitmentOperation<ConfirmCommitmentResponse>.Success(
+                    new ConfirmCommitmentResponse(await ToCommitmentResponseAsync(existing, cancellationToken), true));
+        }
+    }
+
+    public async Task<IReadOnlyList<CommitmentResponse>> GetCommitmentsAsync(
+        string ownerId,
+        CancellationToken cancellationToken)
+    {
+        var commitments = await context.Commitments.AsNoTracking()
+            .Where(value => value.OwnerId == ownerId)
+            .Include(value => value.Occurrences).ThenInclude(value => value.Expense)
+            .OrderBy(value => value.Name).ThenBy(value => value.Id)
+            .ToListAsync(cancellationToken);
+        var importedIds = await LoadImportedExpenseIdsAsync(ownerId, cancellationToken);
+        return commitments.Select(value => ToCommitmentResponse(value, importedIds)).ToArray();
+    }
+
+    public async Task<CommitmentOperation<CommitmentResponse>> UpdateAsync(
+        string ownerId,
+        Guid id,
+        UpdateCommitmentRequest request,
+        CancellationToken cancellationToken)
+    {
+        var commitment = await context.Commitments
+            .Include(value => value.Occurrences).ThenInclude(value => value.Expense)
+            .SingleOrDefaultAsync(value => value.Id == id && value.OwnerId == ownerId, cancellationToken);
+        if (commitment is null) return NotFound<CommitmentResponse>();
+        var expectation = ValidateExpectation(request);
+        if (!expectation.IsSuccess)
+            return CommitmentOperation<CommitmentResponse>.Failure(expectation.Error!.Code, expectation.Error.Message);
+        var values = expectation.Value!;
+        ApplyExpectation(commitment, values);
+        commitment.UpdatedAt = clock.GetUtcNow().UtcDateTime;
+        await context.SaveChangesAsync(cancellationToken);
+        return CommitmentOperation<CommitmentResponse>.Success(
+            ToCommitmentResponse(commitment, await LoadImportedExpenseIdsAsync(ownerId, cancellationToken)));
+    }
+
+    public async Task<CommitmentOperation<CommitmentResponse>> UpdateLifecycleAsync(
+        string ownerId,
+        Guid id,
+        UpdateCommitmentLifecycleRequest request,
+        CancellationToken cancellationToken)
+    {
+        var commitment = await context.Commitments
+            .Include(value => value.Occurrences).ThenInclude(value => value.Expense)
+            .SingleOrDefaultAsync(value => value.Id == id && value.OwnerId == ownerId, cancellationToken);
+        if (commitment is null) return NotFound<CommitmentResponse>();
+        if (!TryParseEnumName(request.Lifecycle, out CommitmentLifecycle lifecycle))
+            return CommitmentOperation<CommitmentResponse>.Failure(
+                "lifecycle_invalid",
+                "Lifecycle must be active, paused, or ended.");
+        commitment.Lifecycle = lifecycle;
+        commitment.UpdatedAt = clock.GetUtcNow().UtcDateTime;
+        await context.SaveChangesAsync(cancellationToken);
+        return CommitmentOperation<CommitmentResponse>.Success(
+            ToCommitmentResponse(commitment, await LoadImportedExpenseIdsAsync(ownerId, cancellationToken)));
+    }
+
+    private async Task<CandidateState> LoadCandidateStateAsync(string ownerId, CancellationToken cancellationToken)
+    {
+        var expenses = await context.Expenses.AsNoTracking()
+            .Where(expense => expense.UserId == ownerId)
+            .ToListAsync(cancellationToken);
+        var detected = detector.Detect(expenses, DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime));
+        var linked = await context.CommitmentOccurrences.AsNoTracking()
+            .Where(value => value.Commitment!.OwnerId == ownerId)
+            .Select(value => value.ExpenseId)
+            .ToHashSetAsync(cancellationToken);
+        var dismissals = await context.CommitmentCandidateDismissals
+            .Where(value => value.OwnerId == ownerId)
+            .ToListAsync(cancellationToken);
+        return new CandidateState(
+            detected,
+            linked,
+            dismissals,
+            await LoadImportedExpenseIdsAsync(ownerId, cancellationToken));
+    }
+
+    private async Task<HashSet<int>> LoadImportedExpenseIdsAsync(string ownerId, CancellationToken cancellationToken) =>
+        await context.ImportExpenseProvenances.AsNoTracking()
+            .Where(value => value.ExpenseId != null && value.Expense!.UserId == ownerId)
+            .Select(value => value.ExpenseId!.Value)
+            .ToHashSetAsync(cancellationToken);
+
+    private static CommitmentCandidate? FindAvailableCandidate(CandidateState state, byte[] fingerprint) =>
+        state.Detected.SingleOrDefault(candidate =>
+            candidate.Evidence.All(expense => !state.LinkedExpenseIds.Contains(expense.Id))
+            && FingerprintsEqual(candidate.EvidenceFingerprint, fingerprint));
+
+    private async Task<Commitment?> FindByOriginAsync(
+        string ownerId,
+        byte[] fingerprint,
+        CancellationToken cancellationToken) =>
+        await context.Commitments
+            .Include(value => value.Occurrences).ThenInclude(value => value.Expense)
+            .SingleOrDefaultAsync(value =>
+                value.OwnerId == ownerId
+                && value.OriginEvidenceFingerprint != null
+                && value.OriginEvidenceFingerprint.SequenceEqual(fingerprint),
+                cancellationToken);
+
+    private async Task<CommitmentResponse> ToCommitmentResponseAsync(
+        Commitment commitment,
+        CancellationToken cancellationToken)
+    {
+        var loaded = await context.Commitments.AsNoTracking()
+            .Include(value => value.Occurrences).ThenInclude(value => value.Expense)
+            .SingleAsync(value => value.Id == commitment.Id, cancellationToken);
+        return ToCommitmentResponse(
+            loaded,
+            await LoadImportedExpenseIdsAsync(commitment.OwnerId, cancellationToken));
+    }
+
+    private static CommitmentCandidateResponse ToCandidateResponse(
+        CommitmentCandidate candidate,
+        IReadOnlySet<int> importedExpenseIds) => new(
+        FingerprintKey(candidate.EvidenceFingerprint),
+        candidate.AlgorithmVersion,
+        candidate.Description,
+        candidate.Category,
+        candidate.Cadence.ToString().ToLowerInvariant(),
+        candidate.TimingKind.ToString().ToLowerInvariant(),
+        candidate.ExpectedDayOfWeek?.ToString().ToLowerInvariant(),
+        candidate.ExpectedDay,
+        candidate.ExpectedMonth,
+        candidate.WindowBeforeDays,
+        candidate.WindowAfterDays,
+        candidate.HasFixedObservedAmount ? "fixed" : "variable",
+        candidate.ObservedMedianAmount,
+        candidate.ObservedMinimumAmount,
+        candidate.ObservedMaximumAmount,
+        candidate.Evidence[0].Date,
+        candidate.Evidence[^1].Date,
+        candidate.Evidence.Count,
+        candidate.Cadence switch
+        {
+            CommitmentCadence.Monthly => "consecutive_calendar_months",
+            CommitmentCadence.Weekly => "weekly_six_to_eight_day_gaps",
+            CommitmentCadence.Yearly => "consecutive_years_same_month",
+            _ => throw new InvalidOperationException("Unsupported commitment cadence.")
+        },
+        candidate.Evidence.Select(expense => ToEvidenceResponse(expense, importedExpenseIds)).ToArray());
+
+    private static CommitmentResponse ToCommitmentResponse(
+        Commitment commitment,
+        IReadOnlySet<int> importedExpenseIds) => new(
+        commitment.Id,
+        commitment.Name,
+        commitment.Category,
+        commitment.Lifecycle.ToString().ToLowerInvariant(),
+        commitment.Cadence.ToString().ToLowerInvariant(),
+        commitment.TimingKind.ToString().ToLowerInvariant(),
+        commitment.ExpectedDayOfWeek?.ToString().ToLowerInvariant(),
+        commitment.ExpectedDay,
+        commitment.ExpectedMonth,
+        commitment.WindowBeforeDays,
+        commitment.WindowAfterDays,
+        commitment.AmountMode.ToString().ToLowerInvariant(),
+        commitment.ExpectedAmount,
+        commitment.ExpectedMinimumAmount,
+        commitment.ExpectedMaximumAmount,
+        commitment.CreatedAt,
+        commitment.UpdatedAt,
+        commitment.Occurrences
+            .Where(value => value.Expense is not null)
+            .OrderBy(value => value.Expense!.Date).ThenBy(value => value.ExpenseId)
+            .Select(value => ToEvidenceResponse(value.Expense!, importedExpenseIds)).ToArray());
+
+    private static CommitmentEvidenceResponse ToEvidenceResponse(Expense expense, IReadOnlySet<int> importedExpenseIds) =>
+        new(expense.Id, expense.Date, expense.Amount, expense.Description, expense.Category,
+            importedExpenseIds.Contains(expense.Id) ? "sunflower_pdf" : "manual");
+
+    private static CommitmentOperation<Expectation> ValidateExpectation(ConfirmCommitmentRequest request) =>
+        ValidateExpectation(
+            request.Name, request.Category, request.Cadence, request.TimingKind,
+            request.ExpectedDayOfWeek, request.ExpectedDay, request.ExpectedMonth,
+            request.WindowBeforeDays, request.WindowAfterDays, request.AmountMode,
+            request.ExpectedAmount, request.ExpectedMinimumAmount, request.ExpectedMaximumAmount);
+
+    private static CommitmentOperation<Expectation> ValidateExpectation(UpdateCommitmentRequest request) =>
+        ValidateExpectation(
+            request.Name, request.Category, request.Cadence, request.TimingKind,
+            request.ExpectedDayOfWeek, request.ExpectedDay, request.ExpectedMonth,
+            request.WindowBeforeDays, request.WindowAfterDays, request.AmountMode,
+            request.ExpectedAmount, request.ExpectedMinimumAmount, request.ExpectedMaximumAmount);
+
+    private static CommitmentOperation<Expectation> ValidateExpectation(
+        string? name,
+        string? category,
+        string? cadenceText,
+        string? timingText,
+        string? weekdayText,
+        int? day,
+        int? month,
+        int windowBefore,
+        int windowAfter,
+        string? amountModeText,
+        decimal? expectedAmount,
+        decimal? minimumAmount,
+        decimal? maximumAmount)
+    {
+        var normalizedName = ExpenseInputRules.NormalizeDescription(name);
+        var normalizedCategory = ExpenseInputRules.NormalizeCategory(category);
+        if (normalizedName.Length is 0 or > 500)
+            return InvalidExpectation("name_invalid", "Name is required and must be 500 characters or fewer.");
+        if (normalizedCategory.Length is 0 or > 100 || normalizedCategory == "other")
+            return InvalidExpectation("category_invalid", "Category is invalid.");
+        if (!TryParseEnumName(cadenceText, out CommitmentCadence cadence))
+            return InvalidExpectation("cadence_invalid", "Cadence must be weekly, monthly, or yearly.");
+        if (!TryParseEnumName(timingText, out CommitmentTimingKind timingKind))
+            return InvalidExpectation("timing_invalid", "Timing kind is invalid.");
+        DayOfWeek? weekday = null;
+        if (weekdayText is not null)
+        {
+            if (!TryParseEnumName(weekdayText, out DayOfWeek parsedWeekday))
+                return InvalidExpectation("timing_invalid", "Expected weekday is invalid.");
+            weekday = parsedWeekday;
+        }
+        if (!IsValidTiming(cadence, timingKind, weekday, day, month) || windowBefore < 0 || windowAfter < 0)
+            return InvalidExpectation("timing_invalid", "Timing fields do not match the selected cadence.");
+        if (!TryParseEnumName(amountModeText, out CommitmentAmountMode amountMode)
+            || !IsValidAmount(amountMode, expectedAmount, minimumAmount, maximumAmount))
+            return InvalidExpectation("amount_invalid", "Amount fields do not match the selected amount mode.");
+        return CommitmentOperation<Expectation>.Success(new Expectation(
+            normalizedName, normalizedCategory, cadence, timingKind, weekday, day, month,
+            windowBefore, windowAfter, amountMode, expectedAmount, minimumAmount, maximumAmount));
+    }
+
+    private static bool IsValidTiming(
+        CommitmentCadence cadence,
+        CommitmentTimingKind timing,
+        DayOfWeek? weekday,
+        int? day,
+        int? month) =>
+        cadence switch
+        {
+            CommitmentCadence.Weekly => timing == CommitmentTimingKind.Weekday
+                && weekday is not null && day is null && month is null,
+            CommitmentCadence.Monthly when timing == CommitmentTimingKind.DayOfMonth =>
+                weekday is null && day is >= 1 and <= 31 && month is null,
+            CommitmentCadence.Monthly when timing == CommitmentTimingKind.MonthEnd =>
+                weekday is null && day is null && month is null,
+            CommitmentCadence.Yearly => timing == CommitmentTimingKind.MonthAndDay
+                && weekday is null && month is >= 1 and <= 12 && day is not null
+                && day >= 1 && day <= DateTime.DaysInMonth(2000, month.Value),
+            _ => false
+        };
+
+    private static bool IsValidAmount(
+        CommitmentAmountMode mode,
+        decimal? expected,
+        decimal? minimum,
+        decimal? maximum) => mode switch
+    {
+        CommitmentAmountMode.Fixed => IsValidMoney(expected) && minimum is null && maximum is null,
+        CommitmentAmountMode.Range => expected is null && IsValidMoney(minimum) && IsValidMoney(maximum)
+            && maximum >= minimum,
+        _ => false
+    };
+
+    private static bool IsValidMoney(decimal? amount) =>
+        amount is > 0m and <= ExpenseInputRules.MaximumAmount && decimal.Round(amount.Value, 2) == amount;
+
+    private static void ApplyExpectation(Commitment commitment, Expectation values)
+    {
+        commitment.Name = values.Name;
+        commitment.Category = values.Category;
+        commitment.Cadence = values.Cadence;
+        commitment.TimingKind = values.TimingKind;
+        commitment.ExpectedDayOfWeek = values.ExpectedDayOfWeek;
+        commitment.ExpectedDay = values.ExpectedDay;
+        commitment.ExpectedMonth = values.ExpectedMonth;
+        commitment.WindowBeforeDays = values.WindowBeforeDays;
+        commitment.WindowAfterDays = values.WindowAfterDays;
+        commitment.AmountMode = values.AmountMode;
+        commitment.ExpectedAmount = values.ExpectedAmount;
+        commitment.ExpectedMinimumAmount = values.ExpectedMinimumAmount;
+        commitment.ExpectedMaximumAmount = values.ExpectedMaximumAmount;
+    }
+
+    private async Task<IDbContextTransaction?> BeginSerializableTransactionAsync(CancellationToken cancellationToken) =>
+        context.Database.IsRelational()
+            ? await context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
+            : null;
+
+    private static Task CommitAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken) =>
+        transaction is null ? Task.CompletedTask : transaction.CommitAsync(cancellationToken);
+
+    private static Task RollbackAsync(IDbContextTransaction? transaction) =>
+        transaction is null ? Task.CompletedTask : transaction.RollbackAsync(CancellationToken.None);
+
+    private static bool TryParseFingerprint(string? value, out byte[] fingerprint)
+    {
+        fingerprint = [];
+        if (value is null || value.Length != 64) return false;
+        try
+        {
+            fingerprint = Convert.FromHexString(value);
+            return fingerprint.Length == 32;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryParseEnumName<T>(string? value, out T parsed)
+        where T : struct, Enum
+    {
+        parsed = default;
+        return value is not null
+            && Enum.GetNames<T>().Any(name => name.Equals(value, StringComparison.OrdinalIgnoreCase))
+            && Enum.TryParse(value, true, out parsed);
+    }
+
+    private static string FingerprintKey(byte[] fingerprint) => Convert.ToHexStringLower(fingerprint);
+    private static bool FingerprintsEqual(byte[] left, byte[] right) =>
+        left.Length == right.Length && CryptographicOperations.FixedTimeEquals(left, right);
+    private static bool IsConcurrencyConflict(Exception exception) =>
+        FindPostgresException(exception)?.SqlState is
+            PostgresErrorCodes.UniqueViolation or PostgresErrorCodes.SerializationFailure;
+
+    private static PostgresException? FindPostgresException(Exception? exception)
+    {
+        while (exception is not null)
+        {
+            if (exception is PostgresException postgres) return postgres;
+            exception = exception.InnerException;
+        }
+        return null;
+    }
+
+    private static CommitmentOperation<T> InvalidFingerprint<T>() =>
+        CommitmentOperation<T>.Failure("fingerprint_invalid", "Candidate fingerprint is invalid.");
+    private static CommitmentOperation<T> CandidateChanged<T>() =>
+        CommitmentOperation<T>.Failure("candidate_changed", "The candidate changed or is no longer available.");
+    private static CommitmentOperation<T> NotFound<T>() =>
+        CommitmentOperation<T>.Failure("commitment_not_found", "Commitment was not found.");
+    private static CommitmentOperation<Expectation> InvalidExpectation(string code, string message) =>
+        CommitmentOperation<Expectation>.Failure(code, message);
+
+    private sealed record CandidateState(
+        IReadOnlyList<CommitmentCandidate> Detected,
+        HashSet<int> LinkedExpenseIds,
+        IReadOnlyList<CommitmentCandidateDismissal> Dismissals,
+        HashSet<int> ImportedExpenseIds);
+
+    private sealed record Expectation(
+        string Name,
+        string Category,
+        CommitmentCadence Cadence,
+        CommitmentTimingKind TimingKind,
+        DayOfWeek? ExpectedDayOfWeek,
+        int? ExpectedDay,
+        int? ExpectedMonth,
+        int WindowBeforeDays,
+        int WindowAfterDays,
+        CommitmentAmountMode AmountMode,
+        decimal? ExpectedAmount,
+        decimal? ExpectedMinimumAmount,
+        decimal? ExpectedMaximumAmount);
+}

--- a/backend/Contracts/Commitments/CommitmentContracts.cs
+++ b/backend/Contracts/Commitments/CommitmentContracts.cs
@@ -1,0 +1,96 @@
+namespace BudgetPlanner.Contracts.Commitments;
+
+public sealed record CommitmentError(string Code, string Message);
+
+public sealed record CommitmentEvidenceResponse(
+    int ExpenseId,
+    DateOnly Date,
+    decimal Amount,
+    string Description,
+    string Category,
+    string Source);
+
+public sealed record CommitmentCandidateResponse(
+    string Fingerprint,
+    string AlgorithmVersion,
+    string Description,
+    string Category,
+    string Cadence,
+    string TimingKind,
+    string? ExpectedDayOfWeek,
+    int? ExpectedDay,
+    int? ExpectedMonth,
+    int WindowBeforeDays,
+    int WindowAfterDays,
+    string ObservedAmountMode,
+    decimal ObservedMedianAmount,
+    decimal ObservedMinimumAmount,
+    decimal ObservedMaximumAmount,
+    DateOnly CoveredFrom,
+    DateOnly CoveredTo,
+    int OccurrenceCount,
+    string EvidenceRule,
+    IReadOnlyList<CommitmentEvidenceResponse> Evidence);
+
+public sealed record CommitmentCandidatesResponse(
+    IReadOnlyList<CommitmentCandidateResponse> Candidates,
+    IReadOnlyList<CommitmentCandidateResponse> DismissedCandidates);
+
+public sealed record CandidateDecisionRequest(string? Fingerprint);
+
+public sealed record ConfirmCommitmentRequest(
+    string? Fingerprint,
+    string? Name,
+    string? Category,
+    string? Cadence,
+    string? TimingKind,
+    string? ExpectedDayOfWeek,
+    int? ExpectedDay,
+    int? ExpectedMonth,
+    int WindowBeforeDays,
+    int WindowAfterDays,
+    string? AmountMode,
+    decimal? ExpectedAmount,
+    decimal? ExpectedMinimumAmount,
+    decimal? ExpectedMaximumAmount);
+
+public sealed record UpdateCommitmentRequest(
+    string? Name,
+    string? Category,
+    string? Cadence,
+    string? TimingKind,
+    string? ExpectedDayOfWeek,
+    int? ExpectedDay,
+    int? ExpectedMonth,
+    int WindowBeforeDays,
+    int WindowAfterDays,
+    string? AmountMode,
+    decimal? ExpectedAmount,
+    decimal? ExpectedMinimumAmount,
+    decimal? ExpectedMaximumAmount);
+
+public sealed record UpdateCommitmentLifecycleRequest(string? Lifecycle);
+
+public sealed record CommitmentResponse(
+    Guid Id,
+    string Name,
+    string Category,
+    string Lifecycle,
+    string Cadence,
+    string TimingKind,
+    string? ExpectedDayOfWeek,
+    int? ExpectedDay,
+    int? ExpectedMonth,
+    int WindowBeforeDays,
+    int WindowAfterDays,
+    string AmountMode,
+    decimal? ExpectedAmount,
+    decimal? ExpectedMinimumAmount,
+    decimal? ExpectedMaximumAmount,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    IReadOnlyList<CommitmentEvidenceResponse> Evidence);
+
+public sealed record ConfirmCommitmentResponse(
+    CommitmentResponse Commitment,
+    bool AlreadyConfirmed);

--- a/backend/Controllers/CommitmentsController.cs
+++ b/backend/Controllers/CommitmentsController.cs
@@ -1,0 +1,116 @@
+using System.Security.Claims;
+using BudgetPlanner.Commitments;
+using BudgetPlanner.Contracts.Commitments;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BudgetPlanner.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api")]
+public sealed class CommitmentsController(ICommitmentService commitments) : ControllerBase
+{
+    [HttpGet("commitment-candidates")]
+    public async Task<IActionResult> GetCandidates(CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        return ownerId is null
+            ? Unauthorized()
+            : Ok(await commitments.GetCandidatesAsync(ownerId, cancellationToken));
+    }
+
+    [HttpPost("commitment-candidates/dismiss")]
+    public async Task<IActionResult> Dismiss(
+        CandidateDecisionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await commitments.DismissAsync(ownerId, request, cancellationToken);
+        return result.IsSuccess ? NoContent() : ErrorResult(result.Error!);
+    }
+
+    [HttpPost("commitment-candidates/reconsider")]
+    public async Task<IActionResult> Reconsider(
+        CandidateDecisionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await commitments.ReconsiderAsync(ownerId, request, cancellationToken);
+        return result.IsSuccess ? NoContent() : ErrorResult(result.Error!);
+    }
+
+    [HttpPost("commitment-candidates/confirm")]
+    public async Task<IActionResult> Confirm(
+        ConfirmCommitmentRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await commitments.ConfirmAsync(ownerId, request, cancellationToken);
+        if (!result.IsSuccess) return ErrorResult(result.Error!);
+        return result.Value!.AlreadyConfirmed
+            ? Ok(result.Value)
+            : StatusCode(StatusCodes.Status201Created, result.Value);
+    }
+
+    [HttpGet("commitments")]
+    public async Task<IActionResult> GetCommitments(CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        return ownerId is null
+            ? Unauthorized()
+            : Ok(await commitments.GetCommitmentsAsync(ownerId, cancellationToken));
+    }
+
+    [HttpPut("commitments/{id:guid}")]
+    public async Task<IActionResult> Update(
+        Guid id,
+        UpdateCommitmentRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await commitments.UpdateAsync(ownerId, id, request, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : ErrorResult(result.Error!);
+    }
+
+    [HttpPatch("commitments/{id:guid}/lifecycle")]
+    public async Task<IActionResult> UpdateLifecycle(
+        Guid id,
+        UpdateCommitmentLifecycleRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await commitments.UpdateLifecycleAsync(ownerId, id, request, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : ErrorResult(result.Error!);
+    }
+
+    private string? OwnerId() => User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    private IActionResult ErrorResult(CommitmentError error)
+    {
+        var status = error.Code switch
+        {
+            "commitment_not_found" => StatusCodes.Status404NotFound,
+            "candidate_changed" or "candidate_dismissed" or "confirmation_conflict" =>
+                StatusCodes.Status409Conflict,
+            "fingerprint_invalid" or "name_invalid" or "category_invalid" or "cadence_invalid"
+                or "timing_invalid" or "amount_invalid" or "lifecycle_invalid" =>
+                StatusCodes.Status400BadRequest,
+            _ => StatusCodes.Status422UnprocessableEntity
+        };
+        var problem = new ProblemDetails
+        {
+            Status = status,
+            Title = "Commitment request failed",
+            Detail = error.Message,
+            Type = $"https://ordo.invalid/problems/{error.Code}"
+        };
+        problem.Extensions["code"] = error.Code;
+        return StatusCode(status, problem);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -13,6 +13,7 @@ using BudgetPlanner.Configuration;
 using Microsoft.Extensions.Options;
 using BudgetPlanner.Import;
 using BudgetPlanner.Import.Sunflower;
+using BudgetPlanner.Commitments;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -38,6 +39,8 @@ builder.Services.AddScoped<ImportPreviewAdmissionFilter>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton(new ImportPreviewProcessingOptions());
 builder.Services.AddScoped<IImportPreviewService, ImportPreviewService>();
+builder.Services.AddSingleton<ICommitmentDetector, CommitmentDetector>();
+builder.Services.AddScoped<ICommitmentService, CommitmentService>();
 
 builder.Services
     .AddOptions<EmailSettingsOptions>()


### PR DESCRIPTION
## Summary

- add the versioned pure V1 recurring-commitment detector for monthly, weekly, and yearly candidates
- add authenticated, owner-scoped candidate review and commitment management APIs
- recompute evidence fingerprints server-side and persist confirmations, occurrence links, and reversible dismissals
- use serializable relational transactions and idempotent conflict handling for concurrent confirmation/dismissal requests
- document the current backend module and persistence boundary

Part of #92. This is the second separately reviewed implementation stage after the merged schema foundation in #93.

## Risk classification

HIGH — financial-domain behavior and durable commitment state. The issue plan and staged implementation were explicitly approved in the governing issue before implementation.

## Verification

- `dotnet build backend.Tests/backend.Tests.csproj --configuration Release --no-restore --disable-build-servers -m:1` — passed (existing analyzer warnings and unavailable NuGet vulnerability metadata only)
- non-PostgreSQL backend suite — 244 passed
- PostgreSQL migration-chain test — 1 passed against a disposable local PostgreSQL 16 container
- remaining PostgreSQL integration suite — 23 passed against the disposable local container
- `git diff --check` — passed

## Scope boundaries

- no frontend route, navigation, or user workflow exposure in this stage
- no schema or migration changes in this PR; the schema foundation was reviewed and merged separately in #93
- no dependency changes
- no confidence scores, missing/late detection, projections, or automatic matching
- no production migration, deployment, production access, or data operation is authorized or performed

## API and implementation notes

Candidate evidence stays derived from owner-scoped Expenses and includes explainability/source labels without exposing evidence revision tokens. Confirm, dismiss, and reconsider operations accept a fingerprint only as a lookup token; the server reloads current evidence and recomputes candidates before changing durable state. Confirmation persists the commitment and evidence links atomically, and repeat confirmation of the same owner/origin is idempotent.