### PR TITLE
Add commitment review frontend workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,11 @@ frontend does not connect directly to the database.
 `frontend/src/app/` owns routing, the authenticated application shell, and
 top-level pages. Product behavior is organized under `frontend/src/features/`
 by capability, including authentication, expenses, budget limits, analytics,
-and transactions. Shared HTTP, constants, theme, UI, and utilities live under
+transactions, and commitment review. The protected Commitments experience
+consumes the owner-scoped candidate and commitment APIs and keeps evidence
+review, confirmation, dismissal/reconsideration, expectation edits, and
+lifecycle controls inside `frontend/src/features/commitments/`. Shared HTTP,
+constants, theme, UI, and utilities live under
 `frontend/src/shared/`; chart-specific presentation lives under
 `frontend/src/charts/`.
 

--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -4,6 +4,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import TransactionsPage from "../features/transactions/pages/TransactionsPage";
 import BudgetsPage from "../features/budgetLimits/pages/BudgetsPage";
 import AnalyticsPage from "../features/analytics/pages/AnalyticsPage";
+import CommitmentsPage from "../features/commitments/pages/CommitmentsPage";
 import AuthPage from "../features/auth/components/AuthPage";
 import ConfirmEmailPage from "../features/auth/components/ConfirmEmailPage";
 import ForgotPasswordPage from "../features/auth/components/ForgotPasswordPage";
@@ -48,6 +49,7 @@ export default function App() {
           <Route path="/transactions" element={<TransactionsPage />} />
           <Route path="/budgets" element={<BudgetsPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="/commitments" element={<CommitmentsPage />} />
           <Route path="/investing" element={<InvestingPage />} />
           <Route path="/settings" element={<SettingsPage email={localStorage.getItem("email")} />} />
         </Route>

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -17,6 +17,10 @@ vi.mock('../features/analytics/pages/AnalyticsPage', () => ({
   default: () => <h1>Analytics workspace</h1>,
 }))
 
+vi.mock('../features/commitments/pages/CommitmentsPage', () => ({
+  default: () => <h1>Commitments workspace</h1>,
+}))
+
 vi.mock('./pages/OverviewPage', () => ({
   default: () => <h1>Welcome back</h1>,
 }))
@@ -86,6 +90,7 @@ describe('application routes and shell', () => {
     ['/transactions', 'Transactions workspace'],
     ['/budgets', 'Budgets workspace'],
     ['/analytics', 'Analytics workspace'],
+    ['/commitments', 'Commitments workspace'],
     ['/investing', 'Investing'],
     ['/settings', 'Settings'],
   ])('supports direct authenticated navigation to %s', async (path, heading) => {
@@ -112,12 +117,12 @@ describe('application routes and shell', () => {
     expect(document.getElementById('main-content')).toHaveAttribute('id', 'main-content')
   })
 
-  it('exposes five primary destinations in mobile navigation and keeps Settings directly reachable', () => {
+  it('exposes six primary destinations in mobile navigation and keeps Settings directly reachable', () => {
     localStorage.setItem('token', 'jwt-value')
     renderAt('/overview')
     const navigation = screen.getByRole('navigation', { name: 'Mobile navigation' })
     expect(navigation).toBeInTheDocument()
-    expect(navigation.querySelectorAll('a')).toHaveLength(5)
+    expect(navigation.querySelectorAll('a')).toHaveLength(6)
     expect(screen.getAllByRole('link', { name: /Settings/ })).toHaveLength(2)
   })
 

--- a/frontend/src/app/navigation.js
+++ b/frontend/src/app/navigation.js
@@ -4,6 +4,7 @@ import {
   Landmark,
   LayoutDashboard,
   ReceiptText,
+  Repeat2,
   Settings,
 } from "lucide-react";
 
@@ -12,6 +13,7 @@ export const APP_DESTINATIONS = [
   { to: "/transactions", label: "Transactions", icon: ReceiptText },
   { to: "/budgets", label: "Budgets", icon: BarChart3 },
   { to: "/analytics", label: "Analytics", icon: ChartNoAxesCombined },
+  { to: "/commitments", label: "Commitments", icon: Repeat2 },
   { to: "/investing", label: "Investing", icon: Landmark },
   { to: "/settings", label: "Settings", icon: Settings },
 ];

--- a/frontend/src/features/commitments/api/commitmentsApi.js
+++ b/frontend/src/features/commitments/api/commitmentsApi.js
@@ -1,0 +1,11 @@
+import client from "../../../shared/api/client";
+
+export const commitmentsApi = {
+  getCandidates: () => client.get("/api/commitment-candidates"),
+  dismissCandidate: (fingerprint) => client.post("/api/commitment-candidates/dismiss", { fingerprint }),
+  reconsiderCandidate: (fingerprint) => client.post("/api/commitment-candidates/reconsider", { fingerprint }),
+  confirmCandidate: (payload) => client.post("/api/commitment-candidates/confirm", payload),
+  getCommitments: () => client.get("/api/commitments"),
+  updateCommitment: (id, payload) => client.put(`/api/commitments/${id}`, payload),
+  updateLifecycle: (id, lifecycle) => client.patch(`/api/commitments/${id}/lifecycle`, { lifecycle }),
+};

--- a/frontend/src/features/commitments/api/commitmentsApi.test.js
+++ b/frontend/src/features/commitments/api/commitmentsApi.test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import client from "../../../shared/api/client";
+import { commitmentsApi } from "./commitmentsApi";
+
+vi.mock("../../../shared/api/client", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("commitment API contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.get.mockResolvedValue({ data: [] });
+    client.post.mockResolvedValue({ data: {} });
+    client.put.mockResolvedValue({ data: {} });
+    client.patch.mockResolvedValue({ data: {} });
+  });
+
+  it("uses the candidate review endpoints with opaque fingerprints", async () => {
+    await commitmentsApi.getCandidates();
+    await commitmentsApi.dismissCandidate("abc");
+    await commitmentsApi.reconsiderCandidate("def");
+    await commitmentsApi.confirmCandidate({ fingerprint: "ghi", name: "Rent" });
+
+    expect(client.get).toHaveBeenCalledWith("/api/commitment-candidates");
+    expect(client.post).toHaveBeenNthCalledWith(1, "/api/commitment-candidates/dismiss", { fingerprint: "abc" });
+    expect(client.post).toHaveBeenNthCalledWith(2, "/api/commitment-candidates/reconsider", { fingerprint: "def" });
+    expect(client.post).toHaveBeenNthCalledWith(3, "/api/commitment-candidates/confirm", { fingerprint: "ghi", name: "Rent" });
+  });
+
+  it("uses the confirmed commitment and lifecycle endpoints", async () => {
+    const payload = { name: "Updated rent" };
+    await commitmentsApi.getCommitments();
+    await commitmentsApi.updateCommitment("commitment-1", payload);
+    await commitmentsApi.updateLifecycle("commitment-1", "paused");
+
+    expect(client.get).toHaveBeenCalledWith("/api/commitments");
+    expect(client.put).toHaveBeenCalledWith("/api/commitments/commitment-1", payload);
+    expect(client.patch).toHaveBeenCalledWith("/api/commitments/commitment-1/lifecycle", { lifecycle: "paused" });
+  });
+});

--- a/frontend/src/features/commitments/components/CommitmentEvidence.jsx
+++ b/frontend/src/features/commitments/components/CommitmentEvidence.jsx
@@ -1,0 +1,25 @@
+import { formatDate, formatMoney } from "../utils/formatCommitments";
+
+function sourceLabel(source) {
+  return source === "sunflower_pdf" ? "Sunflower statement" : "Manual entry";
+}
+
+export default function CommitmentEvidence({ evidence }) {
+  return (
+    <div className="commitment-evidence">
+      <h4>Supporting expenses</h4>
+      <ul className="commitment-evidence__list">
+        {evidence.map((expense) => (
+          <li key={expense.expenseId} className="commitment-evidence__item">
+            <div>
+              <strong>{expense.description}</strong>
+              <span>{formatDate(expense.date)} · {expense.category}</span>
+              <span>{sourceLabel(expense.source)}</span>
+            </div>
+            <strong>{formatMoney(expense.amount)}</strong>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/features/commitments/components/CommitmentForm.jsx
+++ b/frontend/src/features/commitments/components/CommitmentForm.jsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import FormField from "../../../shared/ui/FormField";
+
+const WEEKDAYS = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+
+function initialForm(model) {
+  return {
+    name: model.name ?? model.description ?? "",
+    category: model.category ?? "",
+    cadence: model.cadence ?? "monthly",
+    timingKind: model.timingKind ?? "dayofmonth",
+    expectedDayOfWeek: model.expectedDayOfWeek ?? "monday",
+    expectedDay: model.expectedDay?.toString() ?? "",
+    expectedMonth: model.expectedMonth?.toString() ?? "",
+    windowBeforeDays: model.windowBeforeDays?.toString() ?? "0",
+    windowAfterDays: model.windowAfterDays?.toString() ?? "0",
+    amountMode: model.amountMode ?? (model.observedAmountMode === "fixed" ? "fixed" : "range"),
+    expectedAmount: (model.expectedAmount ?? (model.observedAmountMode === "fixed" ? model.observedMedianAmount : null))?.toString() ?? "",
+    expectedMinimumAmount: (model.expectedMinimumAmount ?? model.observedMinimumAmount)?.toString() ?? "",
+    expectedMaximumAmount: (model.expectedMaximumAmount ?? model.observedMaximumAmount)?.toString() ?? "",
+  };
+}
+
+function numberOrNull(value) {
+  return value === "" ? null : Number(value);
+}
+
+export default function CommitmentForm({ model, fingerprint, submitLabel, busy, onSubmit, onCancel }) {
+  const [form, setForm] = useState(() => initialForm(model));
+
+  function update(name, value) {
+    setForm((current) => ({ ...current, [name]: value }));
+  }
+
+  function updateCadence(cadence) {
+    setForm((current) => ({
+      ...current,
+      cadence,
+      timingKind: cadence === "weekly" ? "weekday" : cadence === "yearly" ? "monthandday" : "dayofmonth",
+      expectedDayOfWeek: cadence === "weekly" ? (current.expectedDayOfWeek || "monday") : "",
+      expectedDay: cadence === "weekly" ? "" : (current.expectedDay || "1"),
+      expectedMonth: cadence === "yearly" ? (current.expectedMonth || "1") : "",
+    }));
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const isWeekly = form.cadence === "weekly";
+    const isMonthly = form.cadence === "monthly";
+    const isMonthEnd = isMonthly && form.timingKind === "monthend";
+    const payload = {
+      ...(fingerprint ? { fingerprint } : {}),
+      name: form.name.trim(),
+      category: form.category.trim(),
+      cadence: form.cadence,
+      timingKind: form.timingKind,
+      expectedDayOfWeek: isWeekly ? form.expectedDayOfWeek : null,
+      expectedDay: isWeekly || isMonthEnd ? null : numberOrNull(form.expectedDay),
+      expectedMonth: form.cadence === "yearly" ? numberOrNull(form.expectedMonth) : null,
+      windowBeforeDays: Number(form.windowBeforeDays),
+      windowAfterDays: Number(form.windowAfterDays),
+      amountMode: form.amountMode,
+      expectedAmount: form.amountMode === "fixed" ? numberOrNull(form.expectedAmount) : null,
+      expectedMinimumAmount: form.amountMode === "range" ? numberOrNull(form.expectedMinimumAmount) : null,
+      expectedMaximumAmount: form.amountMode === "range" ? numberOrNull(form.expectedMaximumAmount) : null,
+    };
+    onSubmit(payload);
+  }
+
+  return (
+    <form className="commitment-form" onSubmit={handleSubmit}>
+      <div className="form-grid">
+        <FormField label="Name">{(id) => <input id={id} required maxLength="500" value={form.name} onChange={(event) => update("name", event.target.value)} />}</FormField>
+        <FormField label="Category">{(id) => <input id={id} required maxLength="100" value={form.category} onChange={(event) => update("category", event.target.value)} />}</FormField>
+        <FormField label="Cadence">{(id) => <select id={id} value={form.cadence} onChange={(event) => updateCadence(event.target.value)}>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+          <option value="yearly">Yearly</option>
+        </select>}</FormField>
+
+        {form.cadence === "weekly" && (
+          <FormField label="Expected weekday">{(id) => <select id={id} value={form.expectedDayOfWeek} onChange={(event) => update("expectedDayOfWeek", event.target.value)}>
+            {WEEKDAYS.map((weekday) => <option key={weekday} value={weekday}>{weekday[0].toUpperCase() + weekday.slice(1)}</option>)}
+          </select>}</FormField>
+        )}
+
+        {form.cadence === "monthly" && (
+          <FormField label="Monthly timing">{(id) => <select id={id} value={form.timingKind} onChange={(event) => update("timingKind", event.target.value)}>
+            <option value="dayofmonth">Day of month</option>
+            <option value="monthend">Month end</option>
+          </select>}</FormField>
+        )}
+
+        {form.cadence === "yearly" && (
+          <FormField label="Expected month">{(id) => <input id={id} type="number" required min="1" max="12" value={form.expectedMonth} onChange={(event) => update("expectedMonth", event.target.value)} />}</FormField>
+        )}
+
+        {form.cadence !== "weekly" && !(form.cadence === "monthly" && form.timingKind === "monthend") && (
+          <FormField label="Expected day">{(id) => <input id={id} type="number" required min="1" max="31" value={form.expectedDay} onChange={(event) => update("expectedDay", event.target.value)} />}</FormField>
+        )}
+
+        <FormField label="Days before">{(id) => <input id={id} type="number" required min="0" step="1" value={form.windowBeforeDays} onChange={(event) => update("windowBeforeDays", event.target.value)} />}</FormField>
+        <FormField label="Days after">{(id) => <input id={id} type="number" required min="0" step="1" value={form.windowAfterDays} onChange={(event) => update("windowAfterDays", event.target.value)} />}</FormField>
+        <FormField label="Amount model">{(id) => <select id={id} value={form.amountMode} onChange={(event) => update("amountMode", event.target.value)}>
+          <option value="fixed">Fixed amount</option>
+          <option value="range">Amount range</option>
+        </select>}</FormField>
+
+        {form.amountMode === "fixed" ? (
+          <FormField label="Expected amount">{(id) => <input id={id} type="number" required min="0.01" step="0.01" value={form.expectedAmount} onChange={(event) => update("expectedAmount", event.target.value)} />}</FormField>
+        ) : (
+          <>
+            <FormField label="Minimum amount">{(id) => <input id={id} type="number" required min="0.01" step="0.01" value={form.expectedMinimumAmount} onChange={(event) => update("expectedMinimumAmount", event.target.value)} />}</FormField>
+            <FormField label="Maximum amount">{(id) => <input id={id} type="number" required min="0.01" step="0.01" value={form.expectedMaximumAmount} onChange={(event) => update("expectedMaximumAmount", event.target.value)} />}</FormField>
+          </>
+        )}
+      </div>
+      <div className="inline-actions commitment-form__actions">
+        <button type="submit" disabled={busy}>{busy ? "Saving..." : submitLabel}</button>
+        <button type="button" className="button-ghost" disabled={busy} onClick={onCancel}>Cancel</button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/commitments/components/CommitmentForm.test.jsx
+++ b/frontend/src/features/commitments/components/CommitmentForm.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import CommitmentForm from "./CommitmentForm";
+
+const model = {
+  description: "Membership",
+  category: "health",
+  cadence: "monthly",
+  timingKind: "dayofmonth",
+  expectedDay: 15,
+  windowBeforeDays: 1,
+  windowAfterDays: 1,
+  observedAmountMode: "fixed",
+  observedMedianAmount: 20,
+  observedMinimumAmount: 20,
+  observedMaximumAmount: 20,
+};
+
+function renderForm(onSubmit = vi.fn()) {
+  render(
+    <CommitmentForm
+      model={model}
+      fingerprint="candidate-1"
+      submitLabel="Confirm commitment"
+      busy={false}
+      onSubmit={onSubmit}
+      onCancel={vi.fn()}
+    />
+  );
+  return onSubmit;
+}
+
+describe("commitment expectation form", () => {
+  it("sends weekly weekday timing and a variable amount range without monthly fields", async () => {
+    const user = userEvent.setup();
+    const onSubmit = renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Cadence"), "weekly");
+    await user.selectOptions(screen.getByLabelText("Expected weekday"), "tuesday");
+    await user.selectOptions(screen.getByLabelText("Amount model"), "range");
+    await user.click(screen.getByRole("button", { name: "Confirm commitment" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      cadence: "weekly",
+      timingKind: "weekday",
+      expectedDayOfWeek: "tuesday",
+      expectedDay: null,
+      expectedMonth: null,
+      amountMode: "range",
+      expectedAmount: null,
+      expectedMinimumAmount: 20,
+      expectedMaximumAmount: 20,
+    }));
+  });
+
+  it("sends month-end timing without an expected calendar day", async () => {
+    const user = userEvent.setup();
+    const onSubmit = renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Monthly timing"), "monthend");
+    await user.click(screen.getByRole("button", { name: "Confirm commitment" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      cadence: "monthly",
+      timingKind: "monthend",
+      expectedDay: null,
+      expectedMonth: null,
+    }));
+  });
+
+  it("sends an explicit month and day for yearly timing", async () => {
+    const user = userEvent.setup();
+    const onSubmit = renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Cadence"), "yearly");
+    await user.clear(screen.getByLabelText("Expected month"));
+    await user.type(screen.getByLabelText("Expected month"), "2");
+    await user.clear(screen.getByLabelText("Expected day"));
+    await user.type(screen.getByLabelText("Expected day"), "28");
+    await user.click(screen.getByRole("button", { name: "Confirm commitment" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      cadence: "yearly",
+      timingKind: "monthandday",
+      expectedDayOfWeek: null,
+      expectedMonth: 2,
+      expectedDay: 28,
+    }));
+  });
+});

--- a/frontend/src/features/commitments/hooks/useCommitments.js
+++ b/frontend/src/features/commitments/hooks/useCommitments.js
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { commitmentsApi } from "../api/commitmentsApi";
+
+const ERROR_MESSAGES = {
+  candidate_changed: "This proposal changed or is no longer available. The latest evidence has been loaded.",
+  candidate_dismissed: "Reconsider this proposal before confirming it.",
+  confirmation_conflict: "This proposal changed while it was being confirmed. The latest state has been loaded.",
+  fingerprint_invalid: "This proposal can no longer be reviewed. Refresh and try again.",
+  name_invalid: "Enter a commitment name of 500 characters or fewer.",
+  category_invalid: "Enter a valid category of 100 characters or fewer.",
+  cadence_invalid: "Choose a valid commitment cadence.",
+  timing_invalid: "Choose timing details that match the cadence.",
+  amount_invalid: "Enter a valid fixed amount or amount range.",
+  lifecycle_invalid: "Choose active, paused, or ended.",
+  commitment_not_found: "That commitment is no longer available.",
+};
+
+const REFRESH_AFTER_ERROR = new Set([
+  "candidate_changed",
+  "candidate_dismissed",
+  "confirmation_conflict",
+  "commitment_not_found",
+]);
+
+export function getCommitmentErrorMessage(error) {
+  const code = error?.response?.data?.code;
+  return ERROR_MESSAGES[code] ?? "Something went wrong. Try again.";
+}
+
+export function useCommitments() {
+  const [candidates, setCandidates] = useState([]);
+  const [dismissedCandidates, setDismissedCandidates] = useState([]);
+  const [commitments, setCommitments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const [busyKey, setBusyKey] = useState(null);
+  const requestId = useRef(0);
+
+  const refresh = useCallback(async ({ rethrow = false } = {}) => {
+    const currentRequestId = ++requestId.current;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const [candidateResponse, commitmentResponse] = await Promise.all([
+        commitmentsApi.getCandidates(),
+        commitmentsApi.getCommitments(),
+      ]);
+      if (currentRequestId === requestId.current) {
+        setCandidates(candidateResponse.data?.candidates ?? []);
+        setDismissedCandidates(candidateResponse.data?.dismissedCandidates ?? []);
+        setCommitments(commitmentResponse.data ?? []);
+      }
+      return true;
+    } catch (error) {
+      if (currentRequestId === requestId.current) setLoadError(getCommitmentErrorMessage(error));
+      if (rethrow) throw error;
+      return false;
+    } finally {
+      if (currentRequestId === requestId.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    return () => { requestId.current += 1; };
+  }, [refresh]);
+
+  const perform = useCallback(async (key, operation, successMessage) => {
+    setBusyKey(key);
+    setActionError(null);
+    setNotice(null);
+    try {
+      const response = await operation();
+      await refresh({ rethrow: true });
+      setNotice(successMessage);
+      return response.data;
+    } catch (error) {
+      if (REFRESH_AFTER_ERROR.has(error?.response?.data?.code)) await refresh();
+      setActionError(getCommitmentErrorMessage(error));
+      return null;
+    } finally {
+      setBusyKey(null);
+    }
+  }, [refresh]);
+
+  return {
+    candidates,
+    dismissedCandidates,
+    commitments,
+    loading,
+    loadError,
+    actionError,
+    notice,
+    busyKey,
+    refresh,
+    clearMessages: () => {
+      setActionError(null);
+      setNotice(null);
+    },
+    dismissCandidate: (fingerprint) => perform(
+      `dismiss:${fingerprint}`,
+      () => commitmentsApi.dismissCandidate(fingerprint),
+      "Proposal dismissed. You can reconsider it below."
+    ),
+    reconsiderCandidate: (fingerprint) => perform(
+      `reconsider:${fingerprint}`,
+      () => commitmentsApi.reconsiderCandidate(fingerprint),
+      "Proposal returned to your review list."
+    ),
+    confirmCandidate: (payload) => perform(
+      `confirm:${payload.fingerprint}`,
+      () => commitmentsApi.confirmCandidate(payload),
+      "Commitment confirmed."
+    ),
+    updateCommitment: (id, payload) => perform(
+      `update:${id}`,
+      () => commitmentsApi.updateCommitment(id, payload),
+      "Commitment updated."
+    ),
+    updateLifecycle: (id, lifecycle) => perform(
+      `lifecycle:${id}`,
+      () => commitmentsApi.updateLifecycle(id, lifecycle),
+      "Commitment status updated."
+    ),
+  };
+}

--- a/frontend/src/features/commitments/hooks/useCommitments.test.js
+++ b/frontend/src/features/commitments/hooks/useCommitments.test.js
@@ -1,0 +1,69 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commitmentsApi } from "../api/commitmentsApi";
+import { getCommitmentErrorMessage, useCommitments } from "./useCommitments";
+
+vi.mock("../api/commitmentsApi", () => ({
+  commitmentsApi: {
+    getCandidates: vi.fn(),
+    dismissCandidate: vi.fn(),
+    reconsiderCandidate: vi.fn(),
+    confirmCandidate: vi.fn(),
+    getCommitments: vi.fn(),
+    updateCommitment: vi.fn(),
+    updateLifecycle: vi.fn(),
+  },
+}));
+
+describe("commitment state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    commitmentsApi.getCandidates.mockResolvedValue({
+      data: { candidates: [{ fingerprint: "candidate-1" }], dismissedCandidates: [{ fingerprint: "dismissed-1" }] },
+    });
+    commitmentsApi.getCommitments.mockResolvedValue({ data: [{ id: "commitment-1" }] });
+    commitmentsApi.confirmCandidate.mockResolvedValue({ data: { alreadyConfirmed: false } });
+    commitmentsApi.dismissCandidate.mockResolvedValue({ data: null });
+  });
+
+  it("loads active proposals, dismissed proposals, and confirmed commitments together", async () => {
+    const { result } = renderHook(() => useCommitments());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.candidates).toEqual([{ fingerprint: "candidate-1" }]);
+    expect(result.current.dismissedCandidates).toEqual([{ fingerprint: "dismissed-1" }]);
+    expect(result.current.commitments).toEqual([{ id: "commitment-1" }]);
+  });
+
+  it("confirms through the server and refreshes both collections", async () => {
+    const payload = { fingerprint: "candidate-1", name: "Rent" };
+    const { result } = renderHook(() => useCommitments());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let response;
+    await act(async () => { response = await result.current.confirmCandidate(payload); });
+
+    expect(commitmentsApi.confirmCandidate).toHaveBeenCalledWith(payload);
+    expect(commitmentsApi.getCandidates).toHaveBeenCalledTimes(2);
+    expect(commitmentsApi.getCommitments).toHaveBeenCalledTimes(2);
+    expect(response).toEqual({ alreadyConfirmed: false });
+    expect(result.current.notice).toBe("Commitment confirmed.");
+  });
+
+  it("maps stable problem codes without exposing arbitrary server details", async () => {
+    commitmentsApi.dismissCandidate.mockRejectedValue({
+      response: { data: { code: "candidate_changed", detail: "sensitive server detail" } },
+    });
+    const { result } = renderHook(() => useCommitments());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(() => result.current.dismissCandidate("candidate-1"));
+
+    expect(result.current.actionError).toContain("proposal changed");
+    expect(result.current.actionError).not.toContain("sensitive");
+    expect(commitmentsApi.getCandidates).toHaveBeenCalledTimes(2);
+    expect(commitmentsApi.getCommitments).toHaveBeenCalledTimes(2);
+    expect(getCommitmentErrorMessage({ response: { data: { code: "unknown", detail: "private" } } }))
+      .toBe("Something went wrong. Try again.");
+  });
+});

--- a/frontend/src/features/commitments/pages/CommitmentsPage.jsx
+++ b/frontend/src/features/commitments/pages/CommitmentsPage.jsx
@@ -1,0 +1,227 @@
+import { useState } from "react";
+import Card from "../../../shared/ui/Card";
+import StatusMessage from "../../../shared/ui/StatusMessage";
+import CommitmentEvidence from "../components/CommitmentEvidence";
+import CommitmentForm from "../components/CommitmentForm";
+import { useCommitments } from "../hooks/useCommitments";
+import { formatDate, formatMoney } from "../utils/formatCommitments";
+
+const EVIDENCE_RULES = {
+  consecutive_calendar_months: "Consecutive calendar months",
+  weekly_six_to_eight_day_gaps: "Weekly, with 6–8 days between expenses",
+  consecutive_years_same_month: "Consecutive years in the same month",
+};
+
+function words(value) {
+  return value?.replaceAll("_", " ").replace(/([a-z])([A-Z])/g, "$1 $2") ?? "";
+}
+
+function title(value) {
+  const text = words(value);
+  return text ? text[0].toUpperCase() + text.slice(1) : "";
+}
+
+function timingSummary(model) {
+  if (model.cadence === "weekly") return `${title(model.expectedDayOfWeek)} with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
+  if (model.cadence === "monthly" && model.timingKind === "monthend") return `Month end, up to ${model.windowBeforeDays} day(s) before`;
+  if (model.cadence === "yearly") return `Month ${model.expectedMonth}, day ${model.expectedDay}, with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
+  return `Day ${model.expectedDay}, with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
+}
+
+function amountSummary(model) {
+  const mode = model.amountMode ?? model.observedAmountMode;
+  if (mode === "fixed") return formatMoney(model.expectedAmount ?? model.observedMedianAmount);
+  return `${formatMoney(model.expectedMinimumAmount ?? model.observedMinimumAmount)}–${formatMoney(model.expectedMaximumAmount ?? model.observedMaximumAmount)}`;
+}
+
+function CandidateCard({ candidate, dismissed, state }) {
+  const [reviewing, setReviewing] = useState(false);
+  const busy = state.busyKey?.endsWith(candidate.fingerprint);
+
+  async function confirm(payload) {
+    const result = await state.confirmCandidate(payload);
+    if (result) setReviewing(false);
+  }
+
+  return (
+    <Card as="article" className="commitment-card">
+      <div className="commitment-card__header">
+        <div>
+          <p className="commitment-card__eyebrow">{dismissed ? "Dismissed proposal" : "Needs your review"}</p>
+          <h3>{candidate.description}</h3>
+          <p className="muted">{candidate.category} · {title(candidate.cadence)}</p>
+        </div>
+        <strong className="commitment-card__amount">{amountSummary(candidate)}</strong>
+      </div>
+
+      <dl className="commitment-facts">
+        <div><dt>Evidence</dt><dd>{candidate.occurrenceCount} expenses · {EVIDENCE_RULES[candidate.evidenceRule] ?? title(candidate.evidenceRule)}</dd></div>
+        <div><dt>Covered period</dt><dd>{formatDate(candidate.coveredFrom)}–{formatDate(candidate.coveredTo)}</dd></div>
+        <div><dt>Observed timing</dt><dd>{timingSummary(candidate)}</dd></div>
+        <div><dt>Observed amount</dt><dd>{candidate.observedAmountMode === "fixed" ? "Identical each time" : `Median ${formatMoney(candidate.observedMedianAmount)}`}</dd></div>
+        <div><dt>Rule version</dt><dd>{candidate.algorithmVersion}</dd></div>
+      </dl>
+
+      <CommitmentEvidence evidence={candidate.evidence} />
+
+      {reviewing ? (
+        <CommitmentForm
+          model={candidate}
+          fingerprint={candidate.fingerprint}
+          submitLabel="Confirm commitment"
+          busy={busy}
+          onSubmit={confirm}
+          onCancel={() => setReviewing(false)}
+        />
+      ) : (
+        <div className="inline-actions commitment-card__actions">
+          {dismissed ? (
+            <button type="button" disabled={busy} onClick={() => state.reconsiderCandidate(candidate.fingerprint)}>
+              {busy ? "Updating..." : "Reconsider"}
+            </button>
+          ) : (
+            <>
+              <button type="button" onClick={() => { state.clearMessages(); setReviewing(true); }}>Review and confirm</button>
+              <button type="button" className="button-ghost" disabled={busy} onClick={() => state.dismissCandidate(candidate.fingerprint)}>
+                {busy ? "Dismissing..." : "Dismiss"}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ConfirmedCommitmentCard({ commitment, state }) {
+  const [editing, setEditing] = useState(false);
+  const [lifecycle, setLifecycle] = useState(commitment.lifecycle);
+  const busy = state.busyKey?.endsWith(commitment.id);
+
+  async function save(payload) {
+    const result = await state.updateCommitment(commitment.id, payload);
+    if (result) setEditing(false);
+  }
+
+  async function saveLifecycle() {
+    await state.updateLifecycle(commitment.id, lifecycle);
+  }
+
+  return (
+    <Card as="article" className="commitment-card commitment-card--confirmed">
+      <div className="commitment-card__header">
+        <div>
+          <p className="commitment-card__eyebrow">Confirmed · {title(commitment.lifecycle)}</p>
+          <h3>{commitment.name}</h3>
+          <p className="muted">{commitment.category} · {title(commitment.cadence)}</p>
+        </div>
+        <strong className="commitment-card__amount">{amountSummary(commitment)}</strong>
+      </div>
+
+      <dl className="commitment-facts">
+        <div><dt>Expected timing</dt><dd>{timingSummary(commitment)}</dd></div>
+        <div><dt>Confirmation evidence</dt><dd>{commitment.evidence.length} linked expense(s)</dd></div>
+      </dl>
+
+      <CommitmentEvidence evidence={commitment.evidence} />
+
+      {editing ? (
+        <CommitmentForm model={commitment} submitLabel="Save changes" busy={busy} onSubmit={save} onCancel={() => setEditing(false)} />
+      ) : (
+        <div className="commitment-controls">
+          <button type="button" className="button-ghost" onClick={() => { state.clearMessages(); setEditing(true); }}>Edit expectation</button>
+          <label className="field commitment-lifecycle">
+            <span className="field__label">Lifecycle</span>
+            <select value={lifecycle} onChange={(event) => setLifecycle(event.target.value)}>
+              <option value="active">Active</option>
+              <option value="paused">Paused</option>
+              <option value="ended">Ended</option>
+            </select>
+          </label>
+          <button type="button" disabled={busy || lifecycle === commitment.lifecycle} onClick={saveLifecycle}>
+            {busy ? "Updating..." : "Update status"}
+          </button>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default function CommitmentsPage() {
+  const state = useCommitments();
+
+  return (
+    <div className="container commitments-page">
+      <header className="page-header">
+        <div>
+          <p className="page-header__eyebrow">Promises your money keeps</p>
+          <h1>Commitments</h1>
+          <p className="muted">Review patterns from your expenses. Nothing becomes a commitment until you confirm it.</p>
+        </div>
+      </header>
+
+      {state.loadError && <StatusMessage tone="danger">{state.loadError}</StatusMessage>}
+      {state.actionError && <StatusMessage tone="danger">{state.actionError}</StatusMessage>}
+      {state.notice && <StatusMessage tone="success">{state.notice}</StatusMessage>}
+
+      {state.loading ? (
+        <StatusMessage>Loading commitments...</StatusMessage>
+      ) : state.loadError ? (
+        <button type="button" onClick={() => state.refresh()}>Try again</button>
+      ) : (
+        <>
+          <section className="commitment-section" aria-labelledby="candidate-heading">
+            <div className="commitment-section__header">
+              <div>
+                <h2 id="candidate-heading">Proposals to review</h2>
+                <p className="muted">Each proposal passed a deterministic evidence rule. Check the expenses and correct the expectation before confirming.</p>
+              </div>
+              <span className="commitment-count">{state.candidates.length}</span>
+            </div>
+            {state.candidates.length === 0 ? (
+              <p className="empty-state">No commitment proposals need your review.</p>
+            ) : (
+              <div className="commitment-list">
+                {state.candidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} state={state} />)}
+              </div>
+            )}
+          </section>
+
+          <section className="commitment-section" aria-labelledby="confirmed-heading">
+            <div className="commitment-section__header">
+              <div>
+                <h2 id="confirmed-heading">Confirmed commitments</h2>
+                <p className="muted">These are your saved expectations. Edit their details or set them active, paused, or ended.</p>
+              </div>
+              <span className="commitment-count">{state.commitments.length}</span>
+            </div>
+            {state.commitments.length === 0 ? (
+              <p className="empty-state">No commitments confirmed yet.</p>
+            ) : (
+              <div className="commitment-list">
+                {state.commitments.map((commitment) => <ConfirmedCommitmentCard key={commitment.id} commitment={commitment} state={state} />)}
+              </div>
+            )}
+          </section>
+
+          <section className="commitment-section" aria-labelledby="dismissed-heading">
+            <div className="commitment-section__header">
+              <div>
+                <h2 id="dismissed-heading">Dismissed proposals</h2>
+                <p className="muted">Dismissals apply only to the exact evidence you reviewed. Reconsider one to return it to your review list.</p>
+              </div>
+              <span className="commitment-count">{state.dismissedCandidates.length}</span>
+            </div>
+            {state.dismissedCandidates.length === 0 ? (
+              <p className="empty-state">No dismissed proposals.</p>
+            ) : (
+              <div className="commitment-list">
+                {state.dismissedCandidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} dismissed state={state} />)}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/commitments/pages/CommitmentsPage.jsx
+++ b/frontend/src/features/commitments/pages/CommitmentsPage.jsx
@@ -23,7 +23,7 @@ function title(value) {
 
 function timingSummary(model) {
   if (model.cadence === "weekly") return `${title(model.expectedDayOfWeek)} with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
-  if (model.cadence === "monthly" && model.timingKind === "monthend") return `Month end, up to ${model.windowBeforeDays} day(s) before`;
+  if (model.cadence === "monthly" && model.timingKind === "monthend") return `Month end, with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
   if (model.cadence === "yearly") return `Month ${model.expectedMonth}, day ${model.expectedDay}, with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
   return `Day ${model.expectedDay}, with a ${model.windowBeforeDays}-day before / ${model.windowAfterDays}-day after window`;
 }

--- a/frontend/src/features/commitments/pages/CommitmentsPage.test.jsx
+++ b/frontend/src/features/commitments/pages/CommitmentsPage.test.jsx
@@ -1,0 +1,202 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCommitments } from "../hooks/useCommitments";
+import CommitmentsPage from "./CommitmentsPage";
+
+vi.mock("../hooks/useCommitments", () => ({ useCommitments: vi.fn() }));
+
+const evidence = [
+  { expenseId: 1, date: "2026-05-15", amount: 20, description: "Gym membership", category: "health", source: "manual" },
+  { expenseId: 2, date: "2026-06-15", amount: 20, description: "Gym membership", category: "health", source: "sunflower_pdf" },
+  { expenseId: 3, date: "2026-07-15", amount: 20, description: "Gym membership", category: "health", source: "manual" },
+];
+
+const candidate = {
+  fingerprint: "fingerprint-1",
+  algorithmVersion: "commitment-v1",
+  description: "Gym membership",
+  category: "health",
+  cadence: "monthly",
+  timingKind: "dayofmonth",
+  expectedDayOfWeek: null,
+  expectedDay: 15,
+  expectedMonth: null,
+  windowBeforeDays: 0,
+  windowAfterDays: 0,
+  observedAmountMode: "fixed",
+  observedMedianAmount: 20,
+  observedMinimumAmount: 20,
+  observedMaximumAmount: 20,
+  coveredFrom: "2026-05-15",
+  coveredTo: "2026-07-15",
+  occurrenceCount: 3,
+  evidenceRule: "consecutive_calendar_months",
+  evidence,
+};
+
+const dismissedCandidate = {
+  ...candidate,
+  fingerprint: "fingerprint-2",
+  description: "Streaming service",
+  evidence: evidence.map((item) => ({ ...item, description: "Streaming service" })),
+};
+
+const commitment = {
+  id: "commitment-1",
+  name: "Rent",
+  category: "housing",
+  lifecycle: "active",
+  cadence: "monthly",
+  timingKind: "dayofmonth",
+  expectedDayOfWeek: null,
+  expectedDay: 1,
+  expectedMonth: null,
+  windowBeforeDays: 1,
+  windowAfterDays: 1,
+  amountMode: "fixed",
+  expectedAmount: 1200,
+  expectedMinimumAmount: null,
+  expectedMaximumAmount: null,
+  evidence: evidence.map((item) => ({ ...item, description: "Rent", amount: 1200, category: "housing" })),
+};
+
+function state(overrides = {}) {
+  return {
+    candidates: [candidate],
+    dismissedCandidates: [dismissedCandidate],
+    commitments: [commitment],
+    loading: false,
+    loadError: null,
+    actionError: null,
+    notice: null,
+    busyKey: null,
+    refresh: vi.fn(),
+    clearMessages: vi.fn(),
+    dismissCandidate: vi.fn().mockResolvedValue({}),
+    reconsiderCandidate: vi.fn().mockResolvedValue({}),
+    confirmCandidate: vi.fn().mockResolvedValue({}),
+    updateCommitment: vi.fn().mockResolvedValue({}),
+    updateLifecycle: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe("Commitments workspace", () => {
+  beforeEach(() => useCommitments.mockReturnValue(state()));
+
+  it("shows explainable proposals, provenance, confirmed state, and reversible dismissals", () => {
+    render(<CommitmentsPage />);
+
+    expect(screen.getByRole("heading", { name: "Commitments", level: 1 })).toBeInTheDocument();
+    const activeCard = screen.getByRole("heading", { name: "Gym membership" }).closest("article");
+    expect(within(activeCard).getByText("3 expenses · Consecutive calendar months")).toBeInTheDocument();
+    expect(within(activeCard).getByText("Identical each time")).toBeInTheDocument();
+    expect(within(activeCard).getByText("commitment-v1")).toBeInTheDocument();
+    expect(screen.getAllByText("Sunflower statement")).toHaveLength(3);
+    expect(screen.getAllByText("Manual entry")).toHaveLength(6);
+    expect(screen.getByRole("heading", { name: "Rent" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Streaming service" })).toBeInTheDocument();
+    expect(screen.queryByText(/revision/i)).not.toBeInTheDocument();
+  });
+
+  it("prefills an editable review form and confirms only the reviewed fingerprint", async () => {
+    const user = userEvent.setup();
+    const current = state();
+    useCommitments.mockReturnValue(current);
+    render(<CommitmentsPage />);
+    const card = screen.getByRole("heading", { name: "Gym membership" }).closest("article");
+
+    await user.click(within(card).getByRole("button", { name: "Review and confirm" }));
+    const name = within(card).getByLabelText("Name");
+    expect(name).toHaveValue("Gym membership");
+    expect(within(card).getByLabelText("Expected day")).toHaveValue(15);
+    await user.clear(name);
+    await user.type(name, "Gym plan");
+    await user.click(within(card).getByRole("button", { name: "Confirm commitment" }));
+
+    expect(current.confirmCandidate).toHaveBeenCalledWith({
+      fingerprint: "fingerprint-1",
+      name: "Gym plan",
+      category: "health",
+      cadence: "monthly",
+      timingKind: "dayofmonth",
+      expectedDayOfWeek: null,
+      expectedDay: 15,
+      expectedMonth: null,
+      windowBeforeDays: 0,
+      windowAfterDays: 0,
+      amountMode: "fixed",
+      expectedAmount: 20,
+      expectedMinimumAmount: null,
+      expectedMaximumAmount: null,
+    });
+  });
+
+  it("dismisses active proposals and reconsiders dismissed proposals", async () => {
+    const user = userEvent.setup();
+    const current = state();
+    useCommitments.mockReturnValue(current);
+    render(<CommitmentsPage />);
+
+    const activeCard = screen.getByRole("heading", { name: "Gym membership" }).closest("article");
+    const dismissedCard = screen.getByRole("heading", { name: "Streaming service" }).closest("article");
+    await user.click(within(activeCard).getByRole("button", { name: "Dismiss" }));
+    await user.click(within(dismissedCard).getByRole("button", { name: "Reconsider" }));
+
+    expect(current.dismissCandidate).toHaveBeenCalledWith("fingerprint-1");
+    expect(current.reconsiderCandidate).toHaveBeenCalledWith("fingerprint-2");
+  });
+
+  it("edits a confirmed expectation and controls its lifecycle", async () => {
+    const user = userEvent.setup();
+    const current = state();
+    useCommitments.mockReturnValue(current);
+    render(<CommitmentsPage />);
+    const card = screen.getByRole("heading", { name: "Rent" }).closest("article");
+
+    await user.click(within(card).getByRole("button", { name: "Edit expectation" }));
+    const name = within(card).getByLabelText("Name");
+    await user.clear(name);
+    await user.type(name, "Apartment rent");
+    await user.click(within(card).getByRole("button", { name: "Save changes" }));
+    expect(current.updateCommitment).toHaveBeenCalledWith(
+      "commitment-1",
+      expect.objectContaining({ name: "Apartment rent", expectedAmount: 1200 })
+    );
+
+    await user.selectOptions(within(card).getByLabelText("Lifecycle"), "paused");
+    await user.click(within(card).getByRole("button", { name: "Update status" }));
+    expect(current.updateLifecycle).toHaveBeenCalledWith("commitment-1", "paused");
+  });
+
+  it("shows honest empty states when there is no derived or confirmed state", () => {
+    useCommitments.mockReturnValue(state({
+      candidates: [],
+      dismissedCandidates: [],
+      commitments: [],
+    }));
+    render(<CommitmentsPage />);
+
+    expect(screen.getByText("No commitment proposals need your review.")).toBeInTheDocument();
+    expect(screen.getByText("No commitments confirmed yet.")).toBeInTheDocument();
+    expect(screen.getByText("No dismissed proposals.")).toBeInTheDocument();
+  });
+
+  it("shows safe load errors and a retry control", async () => {
+    const user = userEvent.setup();
+    const refresh = vi.fn();
+    useCommitments.mockReturnValue(state({
+      candidates: [],
+      dismissedCandidates: [],
+      commitments: [],
+      loadError: "Something went wrong. Try again.",
+      refresh,
+    }));
+    render(<CommitmentsPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong");
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/commitments/pages/CommitmentsPage.test.jsx
+++ b/frontend/src/features/commitments/pages/CommitmentsPage.test.jsx
@@ -100,6 +100,32 @@ describe("Commitments workspace", () => {
     expect(screen.queryByText(/revision/i)).not.toBeInTheDocument();
   });
 
+  it("displays both saved timing windows for month-end proposals and commitments", () => {
+    const monthEndCandidate = {
+      ...candidate,
+      timingKind: "monthend",
+      expectedDay: null,
+      windowBeforeDays: 2,
+      windowAfterDays: 1,
+    };
+    const monthEndCommitment = {
+      ...commitment,
+      timingKind: "monthend",
+      expectedDay: null,
+      windowBeforeDays: 2,
+      windowAfterDays: 1,
+    };
+    useCommitments.mockReturnValue(state({
+      candidates: [monthEndCandidate],
+      commitments: [monthEndCommitment],
+      dismissedCandidates: [],
+    }));
+
+    render(<CommitmentsPage />);
+
+    expect(screen.getAllByText("Month end, with a 2-day before / 1-day after window")).toHaveLength(2);
+  });
+
   it("prefills an editable review form and confirms only the reviewed fingerprint", async () => {
     const user = userEvent.setup();
     const current = state();

--- a/frontend/src/features/commitments/utils/formatCommitments.js
+++ b/frontend/src/features/commitments/utils/formatCommitments.js
@@ -1,0 +1,12 @@
+export function formatMoney(value) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(Number(value));
+}
+
+export function formatDate(value) {
+  if (!value) return "Unknown date";
+  return new Date(`${value}T00:00:00`).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -180,3 +180,40 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 @media (max-width: 520px) {
   .import-preview-card__details { grid-template-columns: 1fr; }
 }
+
+.commitments-page { display: grid; gap: var(--space-7); }
+.commitments-page > .page-header { margin-bottom: 0; }
+.commitment-section { display: grid; gap: var(--space-4); }
+.commitment-section__header { display: flex; align-items: start; justify-content: space-between; gap: var(--space-4); }
+.commitment-section__header h2 { margin-bottom: var(--space-1); }
+.commitment-section__header p { max-width: 760px; margin: 0; }
+.commitment-count { display: inline-grid; place-items: center; min-width: 34px; height: 34px; padding-inline: var(--space-2); border-radius: 999px; color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 12%, var(--color-surface)); font-weight: 800; }
+.commitment-list { display: grid; gap: var(--space-4); }
+.commitment-card { display: grid; gap: var(--space-4); box-shadow: var(--shadow-sm); }
+.commitment-card--confirmed { border-color: color-mix(in srgb, var(--color-success) 32%, var(--color-border)); }
+.commitment-card__header { display: flex; align-items: start; justify-content: space-between; gap: var(--space-4); }
+.commitment-card__header h3 { margin-bottom: var(--space-1); }
+.commitment-card__header p { margin: 0; }
+.commitment-card__eyebrow { margin: 0 0 var(--space-1); color: var(--color-primary); font-size: var(--text-xs); font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.commitment-card__amount { color: var(--color-text); font-size: var(--text-xl); white-space: nowrap; }
+.commitment-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); margin: 0; }
+.commitment-facts > div { padding: var(--space-3); border-radius: var(--radius-md); background: var(--color-surface-subtle); }
+.commitment-facts dt { margin-bottom: var(--space-1); color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+.commitment-facts dd { margin: 0; }
+.commitment-evidence { display: grid; gap: var(--space-2); }
+.commitment-evidence h4 { margin: 0; font-size: var(--text-base); }
+.commitment-evidence__list { display: grid; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
+.commitment-evidence__item { display: flex; align-items: start; justify-content: space-between; gap: var(--space-4); padding: var(--space-3); border: 1px solid var(--color-divider); border-radius: var(--radius-md); }
+.commitment-evidence__item > div { display: grid; gap: .15rem; }
+.commitment-evidence__item span { color: var(--color-text-muted); font-size: var(--text-sm); }
+.commitment-form { display: grid; gap: var(--space-4); padding-top: var(--space-4); border-top: 1px solid var(--color-divider); }
+.commitment-form__actions { justify-content: end; }
+.commitment-card__actions { padding-top: var(--space-2); }
+.commitment-controls { display: flex; flex-wrap: wrap; align-items: end; gap: var(--space-3); padding-top: var(--space-2); }
+.commitment-lifecycle { min-width: 170px; }
+
+@media (max-width: 720px) {
+  .commitment-card__header, .commitment-section__header, .commitment-evidence__item { align-items: stretch; flex-direction: column; }
+  .commitment-card__amount { white-space: normal; }
+  .commitment-facts { grid-template-columns: 1fr; }
+}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -36,7 +36,7 @@
 .app-content { min-width: 0; padding: var(--space-4); padding-bottom: 6.75rem; }
 .app-content > .container { width: 100%; max-width: none; margin: 0; padding: 0; }
 .shell-page { width: 100%; padding-block: var(--space-2) var(--space-6); animation: page-enter var(--duration-normal) var(--ease-standard); }
-.mobile-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); overflow: hidden; padding: var(--space-1); border-top: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 -6px 18px rgb(24 23 22 / 8%); }
+.mobile-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); overflow: hidden; padding: var(--space-1); border-top: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 -6px 18px rgb(24 23 22 / 8%); }
 @keyframes page-enter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 @media (min-width: 900px) {
   .app-shell { display: grid; grid-template-columns: 200px minmax(0, 1fr); }


### PR DESCRIPTION
## Summary

- add a protected Commitments workspace and bounded desktop/mobile navigation entry
- show deterministic candidate evidence, cadence rule, covered period, timing, fixed/range amount observations, detector version, and manual/import provenance
- let users review and correct expectations before confirming, or dismiss and later reconsider exact-evidence proposals
- show confirmed commitments with editable cadence/timing/amount expectations and active/paused/ended lifecycle controls
- refresh current server state after mutations and stale-state conflicts while mapping stable problem codes to safe user messages
- document the current frontend commitment-review boundary

This is the final separately reviewed repository implementation stage for #92, following merged schema PR #93 and backend PR #94.

## Risk classification

HIGH — this exposes the approved financial commitment model to users. Implementation follows the durable HIGH-risk approval and frontend-stage checkpoint on issue #92.

## Verification

- `npm ci` — passed using the existing lockfile
- focused commitment and route suite — 37 passed during iteration
- `npm run verify` — passed on the final staged code:
  - Vitest: 29 files, 152 tests passed
  - ESLint: passed with no warnings
  - Vite production build: passed
- `git diff --check` — passed

`npm ci` reported 10 vulnerabilities already represented by the unchanged lockfile (1 low, 9 high). This PR adds or upgrades no dependencies and does not modify `package-lock.json`; remediation is intentionally outside this issue scope.

## Scope boundaries

- no backend, schema, migration, persistence, or API contract changes
- no automatic transaction matching or duplicate Expense creation
- no confidence scores, late/missing/upcoming claims, forecasting, cash/income, resilience, notifications, or document intelligence
- no production database migration, deployment, production access, or data operation is authorized or performed

## API and UX notes

The client sends only the opaque candidate fingerprint plus the user-reviewed expectation; current evidence and ownership remain authoritative on the backend. Evidence revision IDs are never displayed. The page makes confirmation explicit, keeps dismissal reversible, includes honest loading/error/empty states, and uses labeled responsive controls for weekly, monthly day/month-end, yearly month/day, fixed/range, and lifecycle shapes.