### PR TITLE
Fix false empty state while expenses load

### DIFF
--- a/frontend/src/features/expenses/hooks/useExpenses.test.js
+++ b/frontend/src/features/expenses/hooks/useExpenses.test.js
@@ -25,6 +25,20 @@ describe('expense refresh behavior', () => {
     expect(result.current.expenses).toEqual([])
   })
 
+  it('keeps loading true while the initial expense request is pending', async () => {
+    let resolveRequest
+    expensesApi.getAll.mockReturnValue(new Promise((resolve) => { resolveRequest = resolve }))
+    const { result } = renderHook(() => useExpenses())
+
+    await waitFor(() => expect(result.current.loading).toBe(true))
+    expect(result.current.error).toBeNull()
+
+    await act(async () => {
+      resolveRequest({ data: [] })
+    })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+  })
+
   it('exposes a safe refresh error and clears stale expenses', async () => {
     const requestError = new Error('unavailable')
     expensesApi.getAll.mockRejectedValue(requestError)

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -10,6 +10,7 @@ import ExpenseFilters from "../../expenses/components/ExpenseFilters";
 import ExpenseList from "../../expenses/components/ExpenseList";
 import ImportPreviewPanel from "../../importPreview/components/ImportPreviewPanel";
 import { useImportPreview } from "../../importPreview/hooks/useImportPreview";
+import StatusMessage from "../../../shared/ui/StatusMessage";
 const ENTRIES_PER_PAGE = 10;
 
 export default function TransactionsPage() {
@@ -17,6 +18,7 @@ export default function TransactionsPage() {
   const {
     expenses,
     loading: expensesLoading,
+    error: expensesError,
     refresh: refreshExpenses,
     addExpense,
     updateExpense,
@@ -172,20 +174,31 @@ export default function TransactionsPage() {
         setCategoryFilter={setCategoryFilter}
       />
   
-      <ExpenseList
-        expenses={expensesToShow}
-        filteredCount={filteredExpenses.length}
-        entriesPerPage={ENTRIES_PER_PAGE}
-        showAll={showAll}
-        onShowAll={() => setShowAll(true)}
-        editingExpenseId={editingExpenseId}
-        editingExpenseData={editingExpenseData}
-        setEditingExpenseData={setEditingExpenseData}
-        onStartEdit={startEditExpense}
-        onSave={saveExpenseEdit}
-        onCancel={cancelEditExpense}
-        onDelete={deleteExpense}
-      />
+      {expensesLoading && expenses.length === 0 ? (
+        <StatusMessage>Loading expenses...</StatusMessage>
+      ) : expensesError && expenses.length === 0 ? (
+        <div>
+          <StatusMessage tone="danger">We couldn’t load your expenses.</StatusMessage>
+          <button type="button" onClick={() => refreshExpenses().catch(() => {})}>
+            Try again
+          </button>
+        </div>
+      ) : (
+        <ExpenseList
+          expenses={expensesToShow}
+          filteredCount={filteredExpenses.length}
+          entriesPerPage={ENTRIES_PER_PAGE}
+          showAll={showAll}
+          onShowAll={() => setShowAll(true)}
+          editingExpenseId={editingExpenseId}
+          editingExpenseData={editingExpenseData}
+          setEditingExpenseData={setEditingExpenseData}
+          onStartEdit={startEditExpense}
+          onSave={saveExpenseEdit}
+          onCancel={cancelEditExpense}
+          onDelete={deleteExpense}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -11,6 +11,7 @@ vi.mock('../../importPreview/hooks/useImportPreview', () => ({ useImportPreview:
 const baseExpensesHook = {
   expenses: [],
   loading: false,
+  error: null,
   refresh: vi.fn(),
   addExpense: vi.fn(),
   updateExpense: vi.fn(),
@@ -180,6 +181,40 @@ describe('existing expense workflows', () => {
     expect(screen.getByPlaceholderText('Description')).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Spending vs Budget Limits' })).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Chart month')).not.toBeInTheDocument()
+  })
+
+  it('shows loading instead of a false empty state while expenses are pending', () => {
+    useExpenses.mockReturnValue({ ...baseExpensesHook, loading: true })
+
+    render(<TransactionsPage />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading expenses')
+    expect(screen.queryByText('No expenses found.')).not.toBeInTheDocument()
+  })
+
+  it('shows a retryable error instead of an empty state when expense loading fails', async () => {
+    const user = userEvent.setup()
+    const refresh = vi.fn().mockRejectedValue(new Error('offline'))
+    useExpenses.mockReturnValue({
+      ...baseExpensesHook,
+      error: new Error('offline'),
+      refresh,
+    })
+
+    render(<TransactionsPage />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('We couldn’t load your expenses')
+    expect(screen.queryByText('No expenses found.')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(refresh).toHaveBeenCalledOnce()
+  })
+
+  it('shows the empty state only after a successful zero-row response', () => {
+    render(<TransactionsPage />)
+
+    expect(screen.getByText('No expenses found.')).toBeInTheDocument()
+    expect(screen.queryByText('Loading expenses...')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
   })
 
   it('uploads a PDF through the normal Transactions experience', async () => {


### PR DESCRIPTION
## Summary

- distinguish pending, failed, successfully empty, and populated expense states
- show a retry action when the expense fetch fails
- keep the established empty message only for successful zero-row responses
- add focused hook and Transactions-page regression coverage

Closes #96

## Risk

MEDIUM — user-visible frontend state behavior only. The implementation follows the approved plan recorded on #96.

## Verification

- `npm test` — 29 files, 157 tests passed
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check` — passed

## Scope boundaries

No backend API, authentication/authorization, owner scoping, database schema/data, deployment configuration, dependency, or financial-semantic changes. No production deployment or production-data mutation performed.

## Impact

Frontend-only. No migration, API-contract, or dependency impact.