### PR TITLE
Add commitment change detector V1

### DIFF
--- a/backend.Tests/Financial/CommitmentChangeDetectorTests.cs
+++ b/backend.Tests/Financial/CommitmentChangeDetectorTests.cs
@@ -107,6 +107,42 @@ public sealed class CommitmentChangeDetectorTests
     }
 
     [Fact]
+    public void Weekly_first_slot_uses_edited_weekday_in_next_week_when_confirmation_is_earlier()
+    {
+        var commitment = WeeklyWithLatestConfirmation(new DateOnly(2026, 3, 2));
+        commitment.ExpectedDayOfWeek = DayOfWeek.Friday;
+
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 3, 13), 10m)], new DateOnly(2026, 3, 14));
+
+        Assert.Equal(new DateOnly(2026, 3, 13), Assert.Single(result.Observations).SlotAnchor);
+    }
+
+    [Fact]
+    public void Weekly_first_slot_uses_edited_weekday_in_next_week_when_confirmation_is_later()
+    {
+        var commitment = WeeklyWithLatestConfirmation(new DateOnly(2026, 3, 6));
+        commitment.ExpectedDayOfWeek = DayOfWeek.Monday;
+
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 3, 9), 10m)], new DateOnly(2026, 3, 10));
+
+        Assert.Equal(new DateOnly(2026, 3, 9), Assert.Single(result.Observations).SlotAnchor);
+    }
+
+    [Fact]
+    public void Weekly_first_slot_preserves_next_iso_week_across_year_boundary()
+    {
+        var commitment = WeeklyWithLatestConfirmation(new DateOnly(2025, 12, 29));
+        commitment.ExpectedDayOfWeek = DayOfWeek.Friday;
+
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 1, 9), 10m)], new DateOnly(2026, 1, 10));
+
+        Assert.Equal(new DateOnly(2026, 1, 9), Assert.Single(result.Observations).SlotAnchor);
+    }
+
+    [Fact]
     public void Explicit_larger_window_expands_plausibility_and_nearest_anchor_wins_overlap()
     {
         var commitment = Monthly();
@@ -401,6 +437,17 @@ public sealed class CommitmentChangeDetectorTests
         commitment.TimingKind = CommitmentTimingKind.Weekday;
         commitment.ExpectedDayOfWeek = DayOfWeek.Monday;
         commitment.Occurrences = Confirmation(commitment, new DateOnly(2026, 2, 23));
+        return commitment;
+    }
+
+    private static Commitment WeeklyWithLatestConfirmation(DateOnly latest)
+    {
+        var commitment = Weekly();
+        commitment.Occurrences =
+        [
+            Link(Expense(1, latest.AddDays(-7), 10m)),
+            Link(Expense(2, latest, 10m))
+        ];
         return commitment;
     }
 

--- a/backend.Tests/Financial/CommitmentChangeDetectorTests.cs
+++ b/backend.Tests/Financial/CommitmentChangeDetectorTests.cs
@@ -1,0 +1,467 @@
+using BudgetPlanner.Commitments;
+using BudgetPlanner.Models;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+public sealed class CommitmentChangeDetectorTests
+{
+    private const string Owner = "owner";
+    private readonly CommitmentChangeDetector _detector = new();
+
+    [Fact]
+    public void Matching_uses_confirmation_identity_normalization_and_owner_scope()
+    {
+        var commitment = Monthly();
+        var expenses = new[]
+        {
+            Expense(10, new DateOnly(2026, 3, 16), 10m, "  GYM   CLUB ", " Health "),
+            Expense(11, new DateOnly(2026, 4, 15), 10m, "gym club", "health", "other"),
+            Expense(12, new DateOnly(2026, 4, 15), 10m, "different", "health")
+        };
+
+        var result = Detect(commitment, expenses, new DateOnly(2026, 4, 20));
+
+        Assert.True(result.IsMatchingAvailable);
+        var observation = Assert.Single(result.Observations);
+        Assert.Equal(10, observation.Expense.Id);
+        Assert.Equal("gym club", result.NormalizedDescription);
+        Assert.Equal("health", result.CanonicalCategory);
+    }
+
+    [Theory]
+    [InlineData(false, CommitmentMatchingUnavailableReason.InsufficientConfirmationEvidence)]
+    [InlineData(true, CommitmentMatchingUnavailableReason.InconsistentConfirmationIdentity)]
+    public void Matching_requires_two_consistent_surviving_confirmation_expenses(
+        bool addInconsistentEvidence,
+        CommitmentMatchingUnavailableReason reason)
+    {
+        var commitment = Monthly();
+        commitment.Occurrences.RemoveAt(0);
+        if (addInconsistentEvidence)
+            commitment.Occurrences.Add(Link(Expense(99, new DateOnly(2026, 2, 15), 10m, "other")));
+
+        var result = Detect(commitment, [], new DateOnly(2026, 4, 20));
+
+        Assert.False(result.IsMatchingAvailable);
+        Assert.Equal(reason, result.UnavailableReason);
+    }
+
+    [Fact]
+    public void Shared_identity_fails_closed_only_for_active_commitments()
+    {
+        var first = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000001"));
+        var second = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000002"));
+
+        var shared = _detector.Detect(Owner, [first, second], [], new DateOnly(2026, 4, 20));
+
+        Assert.All(shared, value =>
+        {
+            Assert.False(value.IsMatchingAvailable);
+            Assert.Equal(CommitmentMatchingUnavailableReason.SharedActiveIdentity, value.UnavailableReason);
+        });
+
+        second.Lifecycle = CommitmentLifecycle.Paused;
+        var withoutPaused = _detector.Detect(Owner, [first, second], [], new DateOnly(2026, 4, 20));
+        Assert.True(Assert.Single(withoutPaused).IsMatchingAvailable);
+    }
+
+    [Fact]
+    public void Monthly_plausibility_is_bounded_to_six_days_and_far_evidence_is_ignored()
+    {
+        var commitment = Monthly();
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 21), 11m),
+            Expense(11, new DateOnly(2026, 4, 22), 11m)
+        ], new DateOnly(2026, 4, 25));
+
+        var observation = Assert.Single(result.Observations);
+        Assert.Equal(10, observation.Expense.Id);
+        Assert.Equal(6, observation.TimingOffsetDays);
+    }
+
+    [Fact]
+    public void Weekly_plausibility_uses_the_nearest_anchor_with_three_day_edges()
+    {
+        var commitment = Weekly();
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 5), 11m),
+            Expense(11, new DateOnly(2026, 3, 13), 11m)
+        ], new DateOnly(2026, 3, 15));
+
+        Assert.Collection(result.Observations,
+            observation =>
+            {
+                Assert.Equal(10, observation.Expense.Id);
+                Assert.Equal(new DateOnly(2026, 3, 2), observation.SlotAnchor);
+                Assert.Equal(3, observation.TimingOffsetDays);
+            },
+            observation =>
+            {
+                Assert.Equal(11, observation.Expense.Id);
+                Assert.Equal(new DateOnly(2026, 3, 16), observation.SlotAnchor);
+                Assert.Equal(-3, observation.TimingOffsetDays);
+            });
+    }
+
+    [Fact]
+    public void Explicit_larger_window_expands_plausibility_and_nearest_anchor_wins_overlap()
+    {
+        var commitment = Monthly();
+        commitment.WindowBeforeDays = 20;
+        commitment.WindowAfterDays = 20;
+
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 3, 29), 10m)], new DateOnly(2026, 4, 2));
+
+        var observation = Assert.Single(result.Observations);
+        Assert.Equal(new DateOnly(2026, 3, 15), observation.SlotAnchor);
+    }
+
+    [Fact]
+    public void Equidistant_overlapping_slot_tie_is_ambiguous_and_not_missing()
+    {
+        var commitment = Monthly();
+        commitment.Occurrences = Confirmation(commitment, new DateOnly(2026, 2, 15));
+        commitment.WindowBeforeDays = 20;
+        commitment.WindowAfterDays = 20;
+
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 4, 30), 10m)], new DateOnly(2026, 6, 1));
+
+        Assert.Empty(result.Observations);
+        Assert.Equal(CommitmentChangeState.WithinExpectation, result.Missing.State);
+    }
+
+    [Fact]
+    public void Multiple_expenses_in_one_slot_are_ambiguous_and_never_count_as_missing()
+    {
+        var commitment = Monthly();
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 14), 10m),
+            Expense(11, new DateOnly(2026, 3, 16), 10m)
+        ], new DateOnly(2026, 4, 1));
+
+        Assert.Empty(result.Observations);
+        Assert.Equal(CommitmentChangeState.WithinExpectation, result.Missing.State);
+    }
+
+    [Theory]
+    [InlineData(1, CommitmentChangeState.IsolatedOutlier)]
+    [InlineData(2, CommitmentChangeState.PossibleChange)]
+    [InlineData(3, CommitmentChangeState.ProposedChange)]
+    public void Fixed_amount_uses_one_two_three_consecutive_deviation_states(
+        int count,
+        CommitmentChangeState state)
+    {
+        var commitment = Monthly();
+        var expenses = Enumerable.Range(1, count)
+            .Select(index => Expense(10 + index, new DateOnly(2026, 2 + index, 15), 12m))
+            .ToArray();
+
+        var result = Detect(commitment, expenses, new DateOnly(2026, 2 + count, 20));
+
+        Assert.Equal(state, result.Amount.State);
+        Assert.Equal(count, result.Amount.Evidence.Count);
+        Assert.NotNull(result.Amount.Fingerprint);
+        if (count == 3)
+        {
+            Assert.Equal(CommitmentAmountMode.Fixed, result.Amount.ProposedMode);
+            Assert.Equal(12m, result.Amount.ProposedAmount);
+        }
+    }
+
+    [Fact]
+    public void Variable_deviation_run_proposes_observed_range_and_lower_median()
+    {
+        var commitment = Monthly();
+        commitment.AmountMode = CommitmentAmountMode.Range;
+        commitment.ExpectedAmount = null;
+        commitment.ExpectedMinimumAmount = 9m;
+        commitment.ExpectedMaximumAmount = 11m;
+
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 15), 13m),
+            Expense(11, new DateOnly(2026, 4, 15), 12m),
+            Expense(12, new DateOnly(2026, 5, 15), 15m)
+        ], new DateOnly(2026, 5, 20));
+
+        Assert.Equal(CommitmentChangeState.ProposedChange, result.Amount.State);
+        Assert.Equal(CommitmentAmountMode.Range, result.Amount.ProposedMode);
+        Assert.Equal(12m, result.Amount.ProposedMinimumAmount);
+        Assert.Equal(15m, result.Amount.ProposedMaximumAmount);
+        Assert.Equal(13m, result.Amount.ObservedMedianAmount);
+    }
+
+    [Fact]
+    public void Baseline_amount_or_closed_gap_breaks_amount_run()
+    {
+        var commitment = Monthly();
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 15), 12m),
+            Expense(11, new DateOnly(2026, 4, 15), 10m),
+            Expense(12, new DateOnly(2026, 6, 15), 12m)
+        ], new DateOnly(2026, 6, 20));
+
+        Assert.Equal(CommitmentChangeState.IsolatedOutlier, result.Amount.State);
+        Assert.Equal(12, Assert.Single(result.Amount.Evidence).Expense.Id);
+    }
+
+    [Fact]
+    public void Ambiguous_current_slot_immediately_breaks_an_amount_run()
+    {
+        var commitment = Monthly();
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 15), 12m),
+            Expense(11, new DateOnly(2026, 4, 14), 12m),
+            Expense(12, new DateOnly(2026, 4, 16), 12m)
+        ], new DateOnly(2026, 4, 16));
+
+        Assert.Equal(CommitmentChangeState.WithinExpectation, result.Amount.State);
+        Assert.Equal(CommitmentChangeState.WithinExpectation, result.Timing.State);
+    }
+
+    [Theory]
+    [InlineData(1, CommitmentChangeState.IsolatedOutlier)]
+    [InlineData(2, CommitmentChangeState.PossibleChange)]
+    [InlineData(3, CommitmentChangeState.ProposedChange)]
+    public void Timing_uses_one_two_three_same_side_deviation_states(
+        int count,
+        CommitmentChangeState state)
+    {
+        var commitment = Monthly();
+        var expenses = Enumerable.Range(1, count)
+            .Select(index => Expense(10 + index, new DateOnly(2026, 2 + index, 18), 10m))
+            .ToArray();
+
+        var result = Detect(commitment, expenses, new DateOnly(2026, 2 + count, 20));
+
+        Assert.Equal(state, result.Timing.State);
+        if (count == 3)
+        {
+            Assert.Equal(CommitmentTimingKind.DayOfMonth, result.Timing.ProposedTimingKind);
+            Assert.Equal(18, result.Timing.ProposedDay);
+            Assert.Equal(0, result.Timing.ProposedWindowBeforeDays);
+            Assert.Equal(0, result.Timing.ProposedWindowAfterDays);
+        }
+    }
+
+    [Fact]
+    public void Timing_direction_change_breaks_the_run()
+    {
+        var commitment = Monthly();
+        var result = Detect(commitment,
+        [
+            Expense(10, new DateOnly(2026, 3, 18), 10m),
+            Expense(11, new DateOnly(2026, 4, 12), 10m)
+        ], new DateOnly(2026, 4, 20));
+
+        Assert.Equal(CommitmentChangeState.IsolatedOutlier, result.Timing.State);
+        Assert.Equal(11, Assert.Single(result.Timing.Evidence).Expense.Id);
+    }
+
+    [Theory]
+    [InlineData(CommitmentCadence.Weekly, 1, CommitmentChangeState.WithinExpectation)]
+    [InlineData(CommitmentCadence.Weekly, 2, CommitmentChangeState.NotSeenRecently)]
+    [InlineData(CommitmentCadence.Weekly, 3, CommitmentChangeState.PossiblyEnded)]
+    [InlineData(CommitmentCadence.Monthly, 1, CommitmentChangeState.WithinExpectation)]
+    [InlineData(CommitmentCadence.Monthly, 2, CommitmentChangeState.NotSeenRecently)]
+    [InlineData(CommitmentCadence.Monthly, 3, CommitmentChangeState.PossiblyEnded)]
+    [InlineData(CommitmentCadence.Yearly, 1, CommitmentChangeState.NotSeenRecently)]
+    [InlineData(CommitmentCadence.Yearly, 2, CommitmentChangeState.PossiblyEnded)]
+    public void Missing_thresholds_are_cadence_aware(
+        CommitmentCadence cadence,
+        int missed,
+        CommitmentChangeState state)
+    {
+        var commitment = cadence switch
+        {
+            CommitmentCadence.Weekly => Weekly(),
+            CommitmentCadence.Monthly => Monthly(),
+            _ => Yearly()
+        };
+        var latest = commitment.Occurrences.Max(value => value.Expense!.Date);
+        var today = cadence switch
+        {
+            CommitmentCadence.Weekly => latest.AddDays(7 * missed + 4),
+            CommitmentCadence.Monthly => latest.AddMonths(missed).AddDays(4),
+            _ => latest.AddYears(missed).AddDays(7)
+        };
+
+        var result = Detect(commitment, [], today);
+
+        Assert.Equal(state, result.Missing.State);
+        Assert.Equal(missed, result.Missing.MissedSlotAnchors.Count);
+        Assert.Equal(state == CommitmentChangeState.WithinExpectation, result.Missing.Fingerprint is null);
+    }
+
+    [Fact]
+    public void Late_but_plausible_observation_is_timing_evidence_not_missing()
+    {
+        var commitment = Monthly();
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 3, 20), 10m)], new DateOnly(2026, 3, 25));
+
+        Assert.Equal(CommitmentChangeState.IsolatedOutlier, result.Timing.State);
+        Assert.Equal(CommitmentChangeState.WithinExpectation, result.Missing.State);
+    }
+
+    [Fact]
+    public void Yearly_february_29_anchor_clamps_in_non_leap_year()
+    {
+        var commitment = Yearly();
+        commitment.ExpectedDay = 29;
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2027, 2, 28), 100m)], new DateOnly(2027, 3, 5));
+
+        Assert.Equal(new DateOnly(2027, 2, 28), Assert.Single(result.Observations).SlotAnchor);
+        Assert.Equal(CommitmentChangeState.WithinExpectation, result.Timing.State);
+    }
+
+    [Fact]
+    public void Far_away_yearly_identity_match_does_not_suppress_missing()
+    {
+        var commitment = Yearly();
+        var result = Detect(commitment,
+        [Expense(10, new DateOnly(2026, 9, 1), 100m)], new DateOnly(2027, 3, 7));
+
+        Assert.Empty(result.Observations);
+        Assert.Equal(CommitmentChangeState.NotSeenRecently, result.Missing.State);
+        Assert.Equal(new DateOnly(2027, 2, 28), Assert.Single(result.Missing.MissedSlotAnchors));
+    }
+
+    [Fact]
+    public void Fingerprint_ignores_presentation_edits_but_tracks_semantics_and_evidence_revision()
+    {
+        var commitment = Monthly();
+        var expenses = new[]
+        {
+            Expense(10, new DateOnly(2026, 3, 15), 12m),
+            Expense(11, new DateOnly(2026, 4, 15), 12m)
+        };
+        var first = Detect(commitment, expenses, new DateOnly(2026, 4, 20)).Amount.Fingerprint;
+
+        commitment.Name = "Presentation only";
+        commitment.Category = "display category";
+        commitment.UpdatedAt = commitment.UpdatedAt.AddDays(1);
+        var presentationEdit = Detect(commitment, expenses, new DateOnly(2026, 4, 20)).Amount.Fingerprint;
+        Assert.Equal(first, presentationEdit);
+
+        commitment.ExpectedAmount = 9m;
+        var baselineEdit = Detect(commitment, expenses, new DateOnly(2026, 4, 20)).Amount.Fingerprint;
+        Assert.NotEqual(first, baselineEdit);
+
+        commitment.ExpectedAmount = 10m;
+        expenses[0].CommitmentEvidenceRevision = Guid.NewGuid();
+        var evidenceEdit = Detect(commitment, expenses, new DateOnly(2026, 4, 20)).Amount.Fingerprint;
+        Assert.NotEqual(first, evidenceEdit);
+
+        expenses[0].CommitmentEvidenceRevision = Guid.Parse("00000000-0000-0000-0000-000000000010");
+        commitment.Occurrences[0].Expense!.CommitmentEvidenceRevision = Guid.NewGuid();
+        var confirmationEdit = Detect(commitment, expenses, new DateOnly(2026, 4, 20)).Amount.Fingerprint;
+        Assert.NotEqual(first, confirmationEdit);
+    }
+
+    [Fact]
+    public void Missing_fingerprint_is_stable_within_the_same_closed_slot()
+    {
+        var commitment = Monthly();
+
+        var first = Detect(commitment, [], new DateOnly(2026, 4, 20)).Missing.Fingerprint;
+        var laterSameSlot = Detect(commitment, [], new DateOnly(2026, 4, 25)).Missing.Fingerprint;
+
+        Assert.Equal(first, laterSameSlot);
+    }
+
+    private CommitmentChangeDetection Detect(
+        Commitment commitment,
+        IEnumerable<Expense> expenses,
+        DateOnly today) => Assert.Single(_detector.Detect(Owner, [commitment], expenses, today));
+
+    private static Commitment Monthly(Guid? id = null)
+    {
+        var commitment = Base(id);
+        commitment.Cadence = CommitmentCadence.Monthly;
+        commitment.TimingKind = CommitmentTimingKind.DayOfMonth;
+        commitment.ExpectedDay = 15;
+        commitment.Occurrences = Confirmation(commitment, new DateOnly(2026, 2, 15));
+        return commitment;
+    }
+
+    private static Commitment Weekly()
+    {
+        var commitment = Base();
+        commitment.Cadence = CommitmentCadence.Weekly;
+        commitment.TimingKind = CommitmentTimingKind.Weekday;
+        commitment.ExpectedDayOfWeek = DayOfWeek.Monday;
+        commitment.Occurrences = Confirmation(commitment, new DateOnly(2026, 2, 23));
+        return commitment;
+    }
+
+    private static Commitment Yearly()
+    {
+        var commitment = Base();
+        commitment.Cadence = CommitmentCadence.Yearly;
+        commitment.TimingKind = CommitmentTimingKind.MonthAndDay;
+        commitment.ExpectedMonth = 2;
+        commitment.ExpectedDay = 28;
+        commitment.ExpectedAmount = 100m;
+        commitment.Occurrences =
+        [
+            Link(Expense(1, new DateOnly(2025, 2, 28), 100m)),
+            Link(Expense(2, new DateOnly(2026, 2, 28), 100m))
+        ];
+        return commitment;
+    }
+
+    private static Commitment Base(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.Parse("10000000-0000-0000-0000-000000000001"),
+        OwnerId = Owner,
+        Name = "Gym club",
+        Category = "health",
+        Lifecycle = CommitmentLifecycle.Active,
+        WindowBeforeDays = 0,
+        WindowAfterDays = 0,
+        AmountMode = CommitmentAmountMode.Fixed,
+        ExpectedAmount = 10m,
+        CreatedAt = new DateTime(2026, 2, 15, 0, 0, 0, DateTimeKind.Utc),
+        UpdatedAt = new DateTime(2026, 2, 15, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static List<CommitmentOccurrence> Confirmation(Commitment commitment, DateOnly latest) =>
+    [
+        Link(Expense(1, latest.AddMonths(-1), commitment.ExpectedAmount ?? 10m)),
+        Link(Expense(2, latest, commitment.ExpectedAmount ?? 10m))
+    ];
+
+    private static CommitmentOccurrence Link(Expense expense) => new()
+    {
+        ExpenseId = expense.Id,
+        Expense = expense,
+        Kind = CommitmentOccurrenceKind.ConfirmationEvidence
+    };
+
+    private static Expense Expense(
+        int id,
+        DateOnly date,
+        decimal amount,
+        string description = "gym club",
+        string category = "health",
+        string owner = Owner) => new()
+        {
+            Id = id,
+            UserId = owner,
+            Date = date,
+            Amount = amount,
+            Description = description,
+            Category = category,
+            CommitmentEvidenceRevision = Guid.Parse($"00000000-0000-0000-0000-{id:D12}")
+        };
+}

--- a/backend.Tests/Financial/CommitmentChangeDetectorTests.cs
+++ b/backend.Tests/Financial/CommitmentChangeDetectorTests.cs
@@ -67,6 +67,72 @@ public sealed class CommitmentChangeDetectorTests
     }
 
     [Fact]
+    public void Confirmation_evidence_for_another_active_commitment_is_never_reused()
+    {
+        var target = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000001"));
+        var other = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000002"));
+        var linkedFutureExpense = Expense(10, new DateOnly(2026, 3, 15), 10m);
+        other.Name = "Different commitment";
+        other.Category = "different category";
+        other.Occurrences = [Link(linkedFutureExpense)];
+
+        var results = _detector.Detect(
+            Owner,
+            [target, other],
+            [linkedFutureExpense],
+            new DateOnly(2026, 3, 20));
+
+        var targetResult = Assert.Single(results, value => value.CommitmentId == target.Id);
+        Assert.Empty(targetResult.Observations);
+        Assert.Equal(
+            CommitmentMatchingUnavailableReason.InsufficientConfirmationEvidence,
+            Assert.Single(results, value => value.CommitmentId == other.Id).UnavailableReason);
+    }
+
+    [Theory]
+    [InlineData(CommitmentLifecycle.Paused)]
+    [InlineData(CommitmentLifecycle.Ended)]
+    public void Paused_or_ended_same_identity_confirmation_evidence_is_never_reused(
+        CommitmentLifecycle lifecycle)
+    {
+        var target = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000001"));
+        var inactive = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000002"));
+        var march = Expense(10, new DateOnly(2026, 3, 15), 10m);
+        var april = Expense(11, new DateOnly(2026, 4, 15), 10m);
+        inactive.Lifecycle = lifecycle;
+        inactive.Occurrences = [Link(march), Link(april)];
+
+        var result = Assert.Single(_detector.Detect(
+            Owner,
+            [target, inactive],
+            [march, april],
+            new DateOnly(2026, 4, 20)));
+
+        Assert.True(result.IsMatchingAvailable);
+        Assert.Empty(result.Observations);
+    }
+
+    [Fact]
+    public void Identical_unlinked_expense_remains_eligible_when_linked_expenses_are_excluded()
+    {
+        var target = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000001"));
+        var paused = Monthly(Guid.Parse("00000000-0000-0000-0000-000000000002"));
+        var linkedMarch = Expense(10, new DateOnly(2026, 3, 15), 10m);
+        var linkedApril = Expense(11, new DateOnly(2026, 4, 15), 10m);
+        var unlinkedMay = Expense(12, new DateOnly(2026, 5, 15), 10m);
+        paused.Lifecycle = CommitmentLifecycle.Paused;
+        paused.Occurrences = [Link(linkedMarch), Link(linkedApril)];
+
+        var result = Assert.Single(_detector.Detect(
+            Owner,
+            [target, paused],
+            [linkedMarch, linkedApril, unlinkedMay],
+            new DateOnly(2026, 5, 20)));
+
+        Assert.Equal(12, Assert.Single(result.Observations).Expense.Id);
+    }
+
+    [Fact]
     public void Monthly_plausibility_is_bounded_to_six_days_and_far_evidence_is_ignored()
     {
         var commitment = Monthly();

--- a/backend/Commitments/CommitmentChangeDetector.cs
+++ b/backend/Commitments/CommitmentChangeDetector.cs
@@ -88,10 +88,18 @@ public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
         IEnumerable<Expense> expenses,
         DateOnly today)
     {
-        var ownedActive = commitments
-            .Where(value => value.OwnerId == ownerId && value.Lifecycle == CommitmentLifecycle.Active)
+        var ownedCommitments = commitments
+            .Where(value => value.OwnerId == ownerId)
+            .ToArray();
+        var ownedActive = ownedCommitments
+            .Where(value => value.Lifecycle == CommitmentLifecycle.Active)
             .OrderBy(value => value.Id)
             .ToArray();
+        var confirmationExpenseIds = ownedCommitments
+            .SelectMany(value => value.Occurrences)
+            .Where(value => value.Kind == CommitmentOccurrenceKind.ConfirmationEvidence)
+            .Select(value => value.ExpenseId)
+            .ToHashSet();
         var ownedExpenses = expenses
             .Where(value => value.UserId == ownerId && value.Date <= today)
             .ToArray();
@@ -110,7 +118,12 @@ public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
                 return Unavailable(commitment, identityResult.Reason!.Value);
             if (shared.Contains(commitment.Id))
                 return Unavailable(commitment, CommitmentMatchingUnavailableReason.SharedActiveIdentity);
-            return DetectOne(commitment, identityResult.Identity, ownedExpenses, today);
+            return DetectOne(
+                commitment,
+                identityResult.Identity,
+                ownedExpenses,
+                confirmationExpenseIds,
+                today);
         }).ToArray();
     }
 
@@ -138,6 +151,7 @@ public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
         Commitment commitment,
         ObservationIdentity identity,
         IReadOnlyList<Expense> ownedExpenses,
+        IReadOnlySet<int> confirmationExpenseIds,
         DateOnly today)
     {
         var confirmation = commitment.Occurrences
@@ -150,6 +164,7 @@ public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
         var slots = BuildSlots(commitment, latestConfirmationDate, today).ToArray();
         var eligible = ownedExpenses
             .Where(value => value.Date > latestConfirmationDate)
+            .Where(value => !confirmationExpenseIds.Contains(value.Id))
             .Where(value => ExpenseInputRules.NormalizeDescriptionForComparison(value.Description) == identity.Description
                 && ExpenseInputRules.NormalizeCategory(value.Category) == identity.Category)
             .OrderBy(value => value.Date).ThenBy(value => value.Id)

--- a/backend/Commitments/CommitmentChangeDetector.cs
+++ b/backend/Commitments/CommitmentChangeDetector.cs
@@ -194,7 +194,9 @@ public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
     {
         return commitment.Cadence switch
         {
-            CommitmentCadence.Weekly => NextWeekday(after, commitment.ExpectedDayOfWeek!.Value),
+            CommitmentCadence.Weekly => WeekdayInNextCalendarWeek(
+                after,
+                commitment.ExpectedDayOfWeek!.Value),
             CommitmentCadence.Monthly => MonthlyAnchor(
                 after.Month == 12 ? after.Year + 1 : after.Year,
                 after.Month == 12 ? 1 : after.Month + 1,
@@ -204,10 +206,12 @@ public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
         };
     }
 
-    private static DateOnly NextWeekday(DateOnly after, DayOfWeek weekday)
+    private static DateOnly WeekdayInNextCalendarWeek(DateOnly after, DayOfWeek weekday)
     {
-        var days = ((int)weekday - (int)after.DayOfWeek + 7) % 7;
-        return after.AddDays(days == 0 ? 7 : days);
+        var daysSinceMonday = ((int)after.DayOfWeek + 6) % 7;
+        var nextMonday = after.AddDays(7 - daysSinceMonday);
+        var daysAfterMonday = ((int)weekday + 6) % 7;
+        return nextMonday.AddDays(daysAfterMonday);
     }
 
     private static DateOnly MonthlyAnchor(int year, int month, Commitment commitment)

--- a/backend/Commitments/CommitmentChangeDetector.cs
+++ b/backend/Commitments/CommitmentChangeDetector.cs
@@ -1,0 +1,608 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using BudgetPlanner.Import;
+using BudgetPlanner.Models;
+
+namespace BudgetPlanner.Commitments;
+
+public enum CommitmentChangeState
+{
+    WithinExpectation,
+    IsolatedOutlier,
+    PossibleChange,
+    ProposedChange,
+    NotSeenRecently,
+    PossiblyEnded,
+    MatchingUnavailable
+}
+
+public enum CommitmentMatchingUnavailableReason
+{
+    InsufficientConfirmationEvidence,
+    InconsistentConfirmationIdentity,
+    SharedActiveIdentity
+}
+
+public sealed record CommitmentChangeObservation(
+    Expense Expense,
+    DateOnly SlotAnchor,
+    int TimingOffsetDays,
+    bool IsWithinTimingWindow);
+
+public sealed record CommitmentAmountChangeAssessment(
+    CommitmentChangeState State,
+    string? Fingerprint,
+    CommitmentAmountMode? ProposedMode,
+    decimal? ProposedAmount,
+    decimal? ProposedMinimumAmount,
+    decimal? ProposedMaximumAmount,
+    decimal? ObservedMedianAmount,
+    IReadOnlyList<CommitmentChangeObservation> Evidence);
+
+public sealed record CommitmentTimingChangeAssessment(
+    CommitmentChangeState State,
+    string? Fingerprint,
+    CommitmentTimingKind? ProposedTimingKind,
+    DayOfWeek? ProposedDayOfWeek,
+    int? ProposedDay,
+    int? ProposedMonth,
+    int? ProposedWindowBeforeDays,
+    int? ProposedWindowAfterDays,
+    IReadOnlyList<CommitmentChangeObservation> Evidence);
+
+public sealed record CommitmentMissingAssessment(
+    CommitmentChangeState State,
+    string? Fingerprint,
+    IReadOnlyList<DateOnly> MissedSlotAnchors);
+
+public sealed record CommitmentChangeDetection(
+    Guid CommitmentId,
+    string AlgorithmVersion,
+    bool IsMatchingAvailable,
+    CommitmentMatchingUnavailableReason? UnavailableReason,
+    string? NormalizedDescription,
+    string? CanonicalCategory,
+    IReadOnlyList<CommitmentChangeObservation> Observations,
+    CommitmentAmountChangeAssessment Amount,
+    CommitmentTimingChangeAssessment Timing,
+    CommitmentMissingAssessment Missing);
+
+public interface ICommitmentChangeDetector
+{
+    IReadOnlyList<CommitmentChangeDetection> Detect(
+        string ownerId,
+        IEnumerable<Commitment> commitments,
+        IEnumerable<Expense> expenses,
+        DateOnly today);
+}
+
+public sealed class CommitmentChangeDetector : ICommitmentChangeDetector
+{
+    public const string AlgorithmVersion = "commitment-change-v1";
+    private static readonly byte[] FingerprintDomain = "ordo.commitment-change.v1\0"u8.ToArray();
+
+    public IReadOnlyList<CommitmentChangeDetection> Detect(
+        string ownerId,
+        IEnumerable<Commitment> commitments,
+        IEnumerable<Expense> expenses,
+        DateOnly today)
+    {
+        var ownedActive = commitments
+            .Where(value => value.OwnerId == ownerId && value.Lifecycle == CommitmentLifecycle.Active)
+            .OrderBy(value => value.Id)
+            .ToArray();
+        var ownedExpenses = expenses
+            .Where(value => value.UserId == ownerId && value.Date <= today)
+            .ToArray();
+        var identities = ownedActive.ToDictionary(value => value.Id, DeriveIdentity);
+        var shared = identities
+            .Where(value => value.Value.Identity is not null)
+            .GroupBy(value => value.Value.Identity!)
+            .Where(group => group.Count() > 1)
+            .SelectMany(group => group.Select(value => value.Key))
+            .ToHashSet();
+
+        return ownedActive.Select(commitment =>
+        {
+            var identityResult = identities[commitment.Id];
+            if (identityResult.Identity is null)
+                return Unavailable(commitment, identityResult.Reason!.Value);
+            if (shared.Contains(commitment.Id))
+                return Unavailable(commitment, CommitmentMatchingUnavailableReason.SharedActiveIdentity);
+            return DetectOne(commitment, identityResult.Identity, ownedExpenses, today);
+        }).ToArray();
+    }
+
+    private static IdentityResult DeriveIdentity(Commitment commitment)
+    {
+        var evidence = commitment.Occurrences
+            .Where(value => value.Kind == CommitmentOccurrenceKind.ConfirmationEvidence && value.Expense is not null)
+            .Select(value => value.Expense!)
+            .Where(value => value.UserId == commitment.OwnerId)
+            .OrderBy(value => value.Date).ThenBy(value => value.Id)
+            .ToArray();
+        if (evidence.Length < 2)
+            return new(null, CommitmentMatchingUnavailableReason.InsufficientConfirmationEvidence);
+        var identities = evidence.Select(value => new ObservationIdentity(
+                ExpenseInputRules.NormalizeDescriptionForComparison(value.Description),
+                ExpenseInputRules.NormalizeCategory(value.Category)))
+            .Distinct()
+            .ToArray();
+        return identities.Length == 1
+            ? new IdentityResult(identities[0], null)
+            : new IdentityResult(null, CommitmentMatchingUnavailableReason.InconsistentConfirmationIdentity);
+    }
+
+    private static CommitmentChangeDetection DetectOne(
+        Commitment commitment,
+        ObservationIdentity identity,
+        IReadOnlyList<Expense> ownedExpenses,
+        DateOnly today)
+    {
+        var confirmation = commitment.Occurrences
+            .Where(value => value.Kind == CommitmentOccurrenceKind.ConfirmationEvidence && value.Expense is not null)
+            .Select(value => value.Expense!)
+            .Where(value => value.UserId == commitment.OwnerId)
+            .OrderBy(value => value.Date).ThenBy(value => value.Id)
+            .ToArray();
+        var latestConfirmationDate = confirmation[^1].Date;
+        var slots = BuildSlots(commitment, latestConfirmationDate, today).ToArray();
+        var eligible = ownedExpenses
+            .Where(value => value.Date > latestConfirmationDate)
+            .Where(value => ExpenseInputRules.NormalizeDescriptionForComparison(value.Description) == identity.Description
+                && ExpenseInputRules.NormalizeCategory(value.Category) == identity.Category)
+            .OrderBy(value => value.Date).ThenBy(value => value.Id)
+            .ToArray();
+
+        AssignExpenses(commitment, slots, eligible);
+        var observations = slots
+            .Where(value => !value.IsAmbiguous && value.Expenses.Count == 1)
+            .Select(value => ToObservation(commitment, value, value.Expenses[0]))
+            .ToArray();
+        var amount = AssessAmount(commitment, identity, confirmation, slots, observations, today);
+        var timing = AssessTiming(commitment, identity, confirmation, slots, observations, today);
+        var missing = AssessMissing(commitment, identity, confirmation, slots, observations, today);
+        return new CommitmentChangeDetection(
+            commitment.Id,
+            AlgorithmVersion,
+            true,
+            null,
+            identity.Description,
+            identity.Category,
+            observations,
+            amount,
+            timing,
+            missing);
+    }
+
+    private static IEnumerable<OccurrenceSlot> BuildSlots(
+        Commitment commitment,
+        DateOnly latestConfirmationDate,
+        DateOnly today)
+    {
+        var anchor = NextAnchor(commitment, latestConfirmationDate);
+        var guard = 0;
+        while (PlausibilityStart(commitment, anchor) <= today && guard++ < 10000)
+        {
+            yield return new OccurrenceSlot(anchor);
+            anchor = NextAnchor(commitment, anchor);
+        }
+    }
+
+    private static DateOnly NextAnchor(Commitment commitment, DateOnly after)
+    {
+        return commitment.Cadence switch
+        {
+            CommitmentCadence.Weekly => NextWeekday(after, commitment.ExpectedDayOfWeek!.Value),
+            CommitmentCadence.Monthly => MonthlyAnchor(
+                after.Month == 12 ? after.Year + 1 : after.Year,
+                after.Month == 12 ? 1 : after.Month + 1,
+                commitment),
+            CommitmentCadence.Yearly => YearlyAnchor(after.Year + 1, commitment),
+            _ => throw new InvalidOperationException("Unsupported commitment cadence.")
+        };
+    }
+
+    private static DateOnly NextWeekday(DateOnly after, DayOfWeek weekday)
+    {
+        var days = ((int)weekday - (int)after.DayOfWeek + 7) % 7;
+        return after.AddDays(days == 0 ? 7 : days);
+    }
+
+    private static DateOnly MonthlyAnchor(int year, int month, Commitment commitment)
+    {
+        var day = commitment.TimingKind == CommitmentTimingKind.MonthEnd
+            ? DateTime.DaysInMonth(year, month)
+            : Math.Min(commitment.ExpectedDay!.Value, DateTime.DaysInMonth(year, month));
+        return new DateOnly(year, month, day);
+    }
+
+    private static DateOnly YearlyAnchor(int year, Commitment commitment)
+    {
+        var month = commitment.ExpectedMonth!.Value;
+        var day = Math.Min(commitment.ExpectedDay!.Value, DateTime.DaysInMonth(year, month));
+        return new DateOnly(year, month, day);
+    }
+
+    private static DateOnly PlausibilityStart(Commitment commitment, DateOnly anchor) =>
+        anchor.AddDays(-Math.Max(commitment.WindowBeforeDays, DefaultPlausibilityDays(commitment.Cadence)));
+
+    private static DateOnly PlausibilityEnd(Commitment commitment, DateOnly anchor) =>
+        anchor.AddDays(Math.Max(commitment.WindowAfterDays, DefaultPlausibilityDays(commitment.Cadence)));
+
+    private static int DefaultPlausibilityDays(CommitmentCadence cadence) =>
+        cadence == CommitmentCadence.Weekly ? 3 : 6;
+
+    private static void AssignExpenses(
+        Commitment commitment,
+        IReadOnlyList<OccurrenceSlot> slots,
+        IReadOnlyList<Expense> expenses)
+    {
+        foreach (var expense in expenses)
+        {
+            var candidates = slots
+                .Where(slot => expense.Date >= PlausibilityStart(commitment, slot.Anchor)
+                    && expense.Date <= PlausibilityEnd(commitment, slot.Anchor))
+                .Select(slot => (Slot: slot, Distance: Math.Abs(expense.Date.DayNumber - slot.Anchor.DayNumber)))
+                .OrderBy(value => value.Distance)
+                .ToArray();
+            if (candidates.Length == 0) continue;
+            if (candidates.Length > 1 && candidates[0].Distance == candidates[1].Distance)
+            {
+                foreach (var candidate in candidates.Where(value => value.Distance == candidates[0].Distance))
+                    candidate.Slot.IsAmbiguous = true;
+                continue;
+            }
+            candidates[0].Slot.Expenses.Add(expense);
+        }
+        foreach (var slot in slots.Where(value => value.Expenses.Count > 1))
+            slot.IsAmbiguous = true;
+    }
+
+    private static CommitmentChangeObservation ToObservation(
+        Commitment commitment,
+        OccurrenceSlot slot,
+        Expense expense)
+    {
+        var offset = expense.Date.DayNumber - slot.Anchor.DayNumber;
+        return new CommitmentChangeObservation(
+            expense,
+            slot.Anchor,
+            offset,
+            offset >= -commitment.WindowBeforeDays && offset <= commitment.WindowAfterDays);
+    }
+
+    private static CommitmentAmountChangeAssessment AssessAmount(
+        Commitment commitment,
+        ObservationIdentity identity,
+        IReadOnlyList<Expense> confirmation,
+        IReadOnlyList<OccurrenceSlot> slots,
+        IReadOnlyList<CommitmentChangeObservation> observations,
+        DateOnly today)
+    {
+        var byAnchor = observations.ToDictionary(value => value.SlotAnchor);
+        var run = new List<CommitmentChangeObservation>();
+        foreach (var slot in slots)
+        {
+            if (slot.IsAmbiguous || !byAnchor.TryGetValue(slot.Anchor, out var observation))
+            {
+                if (slot.IsAmbiguous || AcceptedWindowEnd(commitment, slot.Anchor) < today) run.Clear();
+                continue;
+            }
+            if (AmountWithin(commitment, observation.Expense.Amount)) run.Clear();
+            else run.Add(observation);
+        }
+        var state = RunState(run.Count);
+        if (state == CommitmentChangeState.WithinExpectation)
+            return new(state, null, null, null, null, null, null, []);
+        var evidence = run.TakeLast(6).ToArray();
+        var amounts = evidence.Select(value => value.Expense.Amount).Order().ToArray();
+        var median = LowerMedian(amounts);
+        var proposedMode = amounts[0] == amounts[^1] ? CommitmentAmountMode.Fixed : CommitmentAmountMode.Range;
+        var result = new CommitmentAmountChangeAssessment(
+            state,
+            null,
+            state == CommitmentChangeState.ProposedChange ? proposedMode : null,
+            state == CommitmentChangeState.ProposedChange && proposedMode == CommitmentAmountMode.Fixed ? amounts[0] : null,
+            state == CommitmentChangeState.ProposedChange && proposedMode == CommitmentAmountMode.Range ? amounts[0] : null,
+            state == CommitmentChangeState.ProposedChange && proposedMode == CommitmentAmountMode.Range ? amounts[^1] : null,
+            median,
+            evidence);
+        return result with { Fingerprint = Fingerprint(commitment, identity, confirmation, slots, observations, "amount", result, today) };
+    }
+
+    private static CommitmentTimingChangeAssessment AssessTiming(
+        Commitment commitment,
+        ObservationIdentity identity,
+        IReadOnlyList<Expense> confirmation,
+        IReadOnlyList<OccurrenceSlot> slots,
+        IReadOnlyList<CommitmentChangeObservation> observations,
+        DateOnly today)
+    {
+        var byAnchor = observations.ToDictionary(value => value.SlotAnchor);
+        var run = new List<CommitmentChangeObservation>();
+        var direction = 0;
+        foreach (var slot in slots)
+        {
+            if (slot.IsAmbiguous || !byAnchor.TryGetValue(slot.Anchor, out var observation))
+            {
+                if (slot.IsAmbiguous || AcceptedWindowEnd(commitment, slot.Anchor) < today)
+                {
+                    run.Clear();
+                    direction = 0;
+                }
+                continue;
+            }
+            var currentDirection = observation.TimingOffsetDays < -commitment.WindowBeforeDays ? -1
+                : observation.TimingOffsetDays > commitment.WindowAfterDays ? 1 : 0;
+            if (currentDirection == 0)
+            {
+                run.Clear();
+                direction = 0;
+            }
+            else if (direction == 0 || direction == currentDirection)
+            {
+                direction = currentDirection;
+                run.Add(observation);
+            }
+            else
+            {
+                run.Clear();
+                run.Add(observation);
+                direction = currentDirection;
+            }
+        }
+        var state = RunState(run.Count);
+        if (state == CommitmentChangeState.WithinExpectation)
+            return new(state, null, null, null, null, null, null, null, []);
+        var evidence = run.TakeLast(6).ToArray();
+        var proposal = state == CommitmentChangeState.ProposedChange
+            ? DeriveTimingProposal(commitment, evidence)
+            : default;
+        var result = new CommitmentTimingChangeAssessment(
+            state,
+            null,
+            proposal?.Kind,
+            proposal?.DayOfWeek,
+            proposal?.Day,
+            proposal?.Month,
+            proposal?.WindowBefore,
+            proposal?.WindowAfter,
+            evidence);
+        return result with { Fingerprint = Fingerprint(commitment, identity, confirmation, slots, observations, "timing", result, today) };
+    }
+
+    private static CommitmentMissingAssessment AssessMissing(
+        Commitment commitment,
+        ObservationIdentity identity,
+        IReadOnlyList<Expense> confirmation,
+        IReadOnlyList<OccurrenceSlot> slots,
+        IReadOnlyList<CommitmentChangeObservation> observations,
+        DateOnly today)
+    {
+        var observed = observations.Select(value => value.SlotAnchor).ToHashSet();
+        var missed = new List<DateOnly>();
+        foreach (var slot in slots)
+        {
+            if (AcceptedWindowEnd(commitment, slot.Anchor) >= today) continue;
+            if (slot.IsAmbiguous || observed.Contains(slot.Anchor)) missed.Clear();
+            else missed.Add(slot.Anchor);
+        }
+        var threshold = commitment.Cadence == CommitmentCadence.Yearly ? (NotSeen: 1, Ended: 2) : (NotSeen: 2, Ended: 3);
+        var state = missed.Count >= threshold.Ended ? CommitmentChangeState.PossiblyEnded
+            : missed.Count >= threshold.NotSeen ? CommitmentChangeState.NotSeenRecently
+            : CommitmentChangeState.WithinExpectation;
+        if (state == CommitmentChangeState.WithinExpectation)
+            return new(state, null, missed);
+        var result = new CommitmentMissingAssessment(state, null, missed);
+        return result with { Fingerprint = Fingerprint(commitment, identity, confirmation, slots, observations, "missing", result, today) };
+    }
+
+    private static DateOnly AcceptedWindowEnd(Commitment commitment, DateOnly anchor) =>
+        anchor.AddDays(commitment.WindowAfterDays);
+
+    private static bool AmountWithin(Commitment commitment, decimal amount) =>
+        commitment.AmountMode == CommitmentAmountMode.Fixed
+            ? amount == commitment.ExpectedAmount
+            : amount >= commitment.ExpectedMinimumAmount && amount <= commitment.ExpectedMaximumAmount;
+
+    private static CommitmentChangeState RunState(int count) => count switch
+    {
+        0 => CommitmentChangeState.WithinExpectation,
+        1 => CommitmentChangeState.IsolatedOutlier,
+        2 => CommitmentChangeState.PossibleChange,
+        _ => CommitmentChangeState.ProposedChange
+    };
+
+    private static decimal LowerMedian(IReadOnlyList<decimal> values) => values[(values.Count - 1) / 2];
+
+    private static TimingProposal DeriveTimingProposal(
+        Commitment commitment,
+        IReadOnlyList<CommitmentChangeObservation> evidence)
+    {
+        var offsets = evidence.Select(value => value.TimingOffsetDays).Order().ToArray();
+        var medianOffset = offsets[(offsets.Length - 1) / 2];
+        if (commitment.Cadence == CommitmentCadence.Weekly)
+        {
+            var day = (DayOfWeek)(((int)commitment.ExpectedDayOfWeek!.Value + medianOffset % 7 + 7) % 7);
+            return WithWindows(CommitmentTimingKind.Weekday, day, null, null, evidence,
+                value => SignedWeekdayOffset(day, value.Expense.Date.DayOfWeek));
+        }
+        if (commitment.Cadence == CommitmentCadence.Monthly)
+        {
+            var monthEndOffsets = evidence.Select(value => DateTime.DaysInMonth(
+                value.Expense.Date.Year, value.Expense.Date.Month) - value.Expense.Date.Day).ToArray();
+            if (monthEndOffsets.All(value => value <= 3) && monthEndOffsets.Max() - monthEndOffsets.Min() <= 2)
+                return WithWindows(CommitmentTimingKind.MonthEnd, null, null, null, evidence,
+                    value => value.Expense.Date.DayNumber - new DateOnly(
+                        value.Expense.Date.Year,
+                        value.Expense.Date.Month,
+                        DateTime.DaysInMonth(value.Expense.Date.Year, value.Expense.Date.Month)).DayNumber);
+            var days = evidence.Select(value => value.Expense.Date.Day).Order().ToArray();
+            var day = days[(days.Length - 1) / 2];
+            return WithWindows(CommitmentTimingKind.DayOfMonth, null, day, null, evidence,
+                value => value.Expense.Date.DayNumber - new DateOnly(
+                    value.Expense.Date.Year,
+                    value.Expense.Date.Month,
+                    Math.Min(day, DateTime.DaysInMonth(value.Expense.Date.Year, value.Expense.Date.Month))).DayNumber);
+        }
+        var reference = YearlyAnchor(2000, commitment).AddDays(medianOffset);
+        return WithWindows(CommitmentTimingKind.MonthAndDay, null, reference.Day, reference.Month, evidence,
+            value => value.Expense.Date.DayNumber - new DateOnly(
+                value.Expense.Date.Year,
+                reference.Month,
+                Math.Min(reference.Day, DateTime.DaysInMonth(value.Expense.Date.Year, reference.Month))).DayNumber);
+    }
+
+    private static TimingProposal WithWindows(
+        CommitmentTimingKind kind,
+        DayOfWeek? weekday,
+        int? day,
+        int? month,
+        IReadOnlyList<CommitmentChangeObservation> evidence,
+        Func<CommitmentChangeObservation, int> offset)
+    {
+        var offsets = evidence.Select(offset).ToArray();
+        return new TimingProposal(kind, weekday, day, month, Math.Max(0, -offsets.Min()), Math.Max(0, offsets.Max()));
+    }
+
+    private static int SignedWeekdayOffset(DayOfWeek expected, DayOfWeek actual) =>
+        ((int)actual - (int)expected + 10) % 7 - 3;
+
+    private static string Fingerprint(
+        Commitment commitment,
+        ObservationIdentity identity,
+        IReadOnlyList<Expense> confirmation,
+        IReadOnlyList<OccurrenceSlot> slots,
+        IReadOnlyList<CommitmentChangeObservation> observations,
+        string kind,
+        object result,
+        DateOnly today)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(FingerprintDomain);
+        Write(stream, AlgorithmVersion);
+        stream.Write(commitment.Id.ToByteArray());
+        Write(stream, kind);
+        Write(stream, commitment.Lifecycle.ToString());
+        Write(stream, commitment.Cadence.ToString());
+        Write(stream, commitment.TimingKind.ToString());
+        Write(stream, commitment.ExpectedDayOfWeek?.ToString() ?? "");
+        Write(stream, commitment.ExpectedDay ?? -1);
+        Write(stream, commitment.ExpectedMonth ?? -1);
+        Write(stream, commitment.WindowBeforeDays);
+        Write(stream, commitment.WindowAfterDays);
+        Write(stream, commitment.AmountMode.ToString());
+        Write(stream, commitment.ExpectedAmount);
+        Write(stream, commitment.ExpectedMinimumAmount);
+        Write(stream, commitment.ExpectedMaximumAmount);
+        Write(stream, identity.Description);
+        Write(stream, identity.Category);
+        Write(stream, confirmation.Count);
+        foreach (var expense in confirmation)
+        {
+            Write(stream, expense.Id);
+            stream.Write(expense.CommitmentEvidenceRevision.ToByteArray());
+        }
+        Write(stream, observations.Count);
+        foreach (var observation in observations.OrderBy(value => value.SlotAnchor).ThenBy(value => value.Expense.Id))
+        {
+            Write(stream, observation.Expense.Id);
+            stream.Write(observation.Expense.CommitmentEvidenceRevision.ToByteArray());
+        }
+        if (kind == "missing")
+        {
+            var relevantSlots = slots.Where(value =>
+                    AcceptedWindowEnd(commitment, value.Anchor) < today
+                    && (value.IsAmbiguous || value.Expenses.Count == 0))
+                .ToArray();
+            Write(stream, relevantSlots.Length);
+            foreach (var slot in relevantSlots)
+                Write(stream, slot.Anchor.DayNumber);
+        }
+        WriteResult(stream, result);
+        return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
+    }
+
+    private static void WriteResult(Stream stream, object result)
+    {
+        switch (result)
+        {
+            case CommitmentAmountChangeAssessment amount:
+                Write(stream, amount.State.ToString());
+                Write(stream, amount.ProposedMode?.ToString() ?? "");
+                Write(stream, amount.ProposedAmount);
+                Write(stream, amount.ProposedMinimumAmount);
+                Write(stream, amount.ProposedMaximumAmount);
+                Write(stream, amount.ObservedMedianAmount);
+                break;
+            case CommitmentTimingChangeAssessment timing:
+                Write(stream, timing.State.ToString());
+                Write(stream, timing.ProposedTimingKind?.ToString() ?? "");
+                Write(stream, timing.ProposedDayOfWeek?.ToString() ?? "");
+                Write(stream, timing.ProposedDay ?? -1);
+                Write(stream, timing.ProposedMonth ?? -1);
+                Write(stream, timing.ProposedWindowBeforeDays ?? -1);
+                Write(stream, timing.ProposedWindowAfterDays ?? -1);
+                break;
+            case CommitmentMissingAssessment missing:
+                Write(stream, missing.State.ToString());
+                foreach (var anchor in missing.MissedSlotAnchors) Write(stream, anchor.DayNumber);
+                break;
+            default:
+                throw new InvalidOperationException("Unsupported commitment change fingerprint result.");
+        }
+    }
+
+    private static void Write(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Write(stream, bytes.Length);
+        stream.Write(bytes);
+    }
+
+    private static void Write(Stream stream, int value)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+        stream.Write(bytes);
+    }
+
+    private static void Write(Stream stream, decimal? value)
+    {
+        Write(stream, value?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "");
+    }
+
+    private static CommitmentChangeDetection Unavailable(
+        Commitment commitment,
+        CommitmentMatchingUnavailableReason reason) => new(
+        commitment.Id,
+        AlgorithmVersion,
+        false,
+        reason,
+        null,
+        null,
+        [],
+        new(CommitmentChangeState.MatchingUnavailable, null, null, null, null, null, null, []),
+        new(CommitmentChangeState.MatchingUnavailable, null, null, null, null, null, null, null, []),
+        new(CommitmentChangeState.MatchingUnavailable, null, []));
+
+    private sealed record ObservationIdentity(string Description, string Category);
+    private sealed record IdentityResult(
+        ObservationIdentity? Identity,
+        CommitmentMatchingUnavailableReason? Reason);
+    private sealed class OccurrenceSlot(DateOnly anchor)
+    {
+        public DateOnly Anchor { get; } = anchor;
+        public List<Expense> Expenses { get; } = [];
+        public bool IsAmbiguous { get; set; }
+    }
+    private sealed record TimingProposal(
+        CommitmentTimingKind Kind,
+        DayOfWeek? DayOfWeek,
+        int? Day,
+        int? Month,
+        int WindowBefore,
+        int WindowAfter);
+}

--- a/docs/commitment-intelligence.md
+++ b/docs/commitment-intelligence.md
@@ -103,7 +103,8 @@ inconsistent, matching is unavailable. If multiple active commitments derive
 the same identity, matching fails closed for the entire identity group; paused
 and ended commitments neither participate nor create ambiguity.
 
-An identity-matching Expense dated after the latest confirmation evidence is
+An identity-matching Expense dated after the latest confirmation evidence and
+not linked as confirmation evidence to any of the owner's commitments is
 qualified to a cadence slot only inside a bounded plausibility envelope. Weekly
 anchors use `max(the accepted window, 3 days)` on each corresponding side;
 monthly and yearly anchors use `max(the accepted window, 6 days)`. These bounds

--- a/docs/commitment-intelligence.md
+++ b/docs/commitment-intelligence.md
@@ -88,3 +88,57 @@ commitment detection, upcoming projections, or automatic transaction matching.
 These are separate product decisions. Schema and backend foundations must not
 be treated as authorization to expose an incomplete user workflow, run a
 production migration, deploy, or perform production data operations.
+
+## Commitment change detection V1
+
+The approved first change-detection slice is a pure, explicitly versioned
+`commitment-change-v1` detector. It does not expose an API or UI and does not
+persist derived matches or proposals.
+
+Only active, owner-scoped commitments participate. Observation identity comes
+from at least two surviving confirmation-linked Expenses that all share one
+normalized description and canonical category. Name and display-category edits
+do not redefine that identity. If confirmation evidence is insufficient or
+inconsistent, matching is unavailable. If multiple active commitments derive
+the same identity, matching fails closed for the entire identity group; paused
+and ended commitments neither participate nor create ambiguity.
+
+An identity-matching Expense dated after the latest confirmation evidence is
+qualified to a cadence slot only inside a bounded plausibility envelope. Weekly
+anchors use `max(the accepted window, 3 days)` on each corresponding side;
+monthly and yearly anchors use `max(the accepted window, 6 days)`. These bounds
+come from the existing weekday and seven-day candidate timing semantics. In
+overlapping envelopes the uniquely nearest anchor wins; equal-distance ties,
+or multiple qualified Expenses in one slot, are ambiguous. Ambiguous evidence
+is never treated as missing. Day-of-month and yearly anchors clamp to the last
+valid calendar day, including February 29 resolving to February 28 in a
+non-leap year; month-end anchors use the actual last day.
+
+For amounts, exact fixed equality or inclusion in the accepted range is normal.
+One, two, or at least three consecutive outside observations mean isolated
+outlier, possible change, or proposed change. A proposal uses at most the six
+latest deviations and proposes a fixed amount when all are equal, otherwise
+their observed minimum/maximum range with the lower median as evidence. A
+normal, missing, or ambiguous closed slot breaks the run.
+
+For timing, accepted before/after windows are inclusive. One, two, or at least
+three consecutive outside observations on the same side mean isolated outlier,
+possible change, or proposed change. An in-window observation, a closed gap,
+ambiguity, or a direction reversal breaks the run. Proposed timing uses at most
+the six latest deviations and the existing weekday, day/month-end, and yearly
+calendar shapes. Amount and timing assessments are independent.
+
+A slot is missed only after its accepted after-window closes. Weekly and
+monthly commitments become `not_seen_recently` after two consecutive missed
+slots and `possibly_ended` after three. Yearly commitments use one and two
+missed slots respectively. No state changes automatically, and evaluation is
+on demand from an injected current date; there is no scheduler.
+
+Non-normal assessments use a SHA-256 fingerprint with an explicit domain and
+algorithm version. It serializes exact semantic baseline fields (not broad
+`UpdatedAt`, name, or display category), derived identity, ordered confirmation
+and qualified Expense IDs with evidence revisions, relevant closed slots, and
+the exact assessment result. A future action boundary must recompute this
+authoritatively and reject stale decisions. A user-visible workflow remains
+blocked until accept/end, durable keep/dismiss, reconsider, and stale-conflict
+handling can ship coherently under separate approval.


### PR DESCRIPTION
## Summary
- add the pure, versioned `commitment-change-v1` detector authorized by #101
- derive owner-scoped future observations with bounded cadence slots and fail-closed ambiguity
- classify amount, timing, and cadence-aware missing states with stable semantic fingerprints
- add 39 focused synthetic tests and record the approved semantics

Part of #101

## Risk
HIGH — implements approved financial-domain change-detection semantics. This PR is limited to the explicitly approved first slice.

## Implementation details
- active commitments only; identity comes from consistent surviving confirmation evidence
- weekly ±3 and monthly/yearly ±6 default plausibility bounds, expanded only by accepted user windows
- shared active identities, slot ties, and multiple Expenses per slot fail closed
- confirmation-linked Expenses across active, paused, and ended commitments are excluded from future change evidence
- independent 1/2/3 amount and timing escalation; yearly 1/2 and weekly/monthly 2/3 missing escalation
- deterministic SHA-256 fingerprints omit broad `UpdatedAt` and include exact baseline, confirmation/observation revisions, relevant slots, and result values

## Verification
- focused `CommitmentChangeDetectorTests`: passed locally, 39/39
- targeted whitespace/diff verification: passed locally
- canonical backend build passed locally; remaining workstation-only contained-PDF instability is unrelated to this change and is disclosed in PR comments
- latest required CI on head `cfb93f9` is green:
  - `Frontend test, lint, and build`
  - `Backend build and tests`
  - `PostgreSQL financial integration`

## Scope boundaries
- no API or application-service integration
- no frontend/UI exposure
- no action workflow
- no schema, EF mapping, or migration
- no dependency change
- no deployment, production access, or data operation

## Impact
- API: none
- schema/migration: none
- dependencies: none
- release: detector remains unexposed until the separately approved coherent workflow exists