### PR TITLE
Add commitment change read API

### DIFF
--- a/backend.Tests/Financial/CommitmentsApiTests.cs
+++ b/backend.Tests/Financial/CommitmentsApiTests.cs
@@ -2,8 +2,10 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using BudgetPlanner.Data;
+using BudgetPlanner.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace BudgetPlanner.Tests.Financial;
@@ -19,8 +21,270 @@ public sealed class CommitmentsApiTests
 
         Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/commitment-candidates")).StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/commitments")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/commitment-changes")).StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized,
             (await client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint = new string('0', 64) })).StatusCode);
+    }
+
+    [Fact]
+    public async Task Change_read_is_self_contained_owner_scoped_explainable_and_deterministic()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("change-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("change-other@example.com");
+
+        var confirmation = new List<Expense>();
+        foreach (var date in new[] { new DateOnly(2026, 5, 10), new DateOnly(2026, 6, 10), new DateOnly(2026, 7, 10) })
+            confirmation.Add(await app.SeedExpenseAsync(owner.Id, "  Membership  ", 10m, date, " Bills "));
+        var observations = new List<Expense>();
+        foreach (var date in new[] { new DateOnly(2026, 8, 12), new DateOnly(2026, 9, 12), new DateOnly(2026, 10, 12) })
+            observations.Add(await app.SeedExpenseAsync(owner.Id, "membership", 12m, date, "bills"));
+        await SeedImportedProvenanceAsync(app, owner.Id, observations[0].Id);
+        await SeedImportedProvenanceAsync(app, other.Id, observations[1].Id);
+        var changedId = await SeedCommitmentAsync(
+            app, owner.Id, confirmation, name: "Edited display name", category: "custom display");
+
+        var missingConfirmation = new List<Expense>();
+        foreach (var date in new[] { new DateOnly(2026, 5, 20), new DateOnly(2026, 6, 20), new DateOnly(2026, 7, 20) })
+            missingConfirmation.Add(await app.SeedExpenseAsync(owner.Id, "insurance", 25m, date, "bills"));
+        var missingId = await SeedCommitmentAsync(
+            app, owner.Id, missingConfirmation, name: "Insurance", expectedDay: 20, expectedAmount: 25m);
+
+        var otherEvidence = new[]
+        {
+            await app.SeedExpenseAsync(other.Id, "FOREIGN SECRET", 999m, new DateOnly(2026, 6, 10), "private"),
+            await app.SeedExpenseAsync(other.Id, "FOREIGN SECRET", 999m, new DateOnly(2026, 7, 10), "private")
+        };
+        await SeedCommitmentAsync(app, other.Id, otherEvidence, name: "FOREIGN COMMITMENT", category: "private");
+
+        var first = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+        var second = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+
+        Assert.Equal("2026-10-29", first.GetProperty("evaluatedOn").GetString());
+        var changes = first.GetProperty("changes").EnumerateArray().ToDictionary(
+            value => value.GetProperty("commitment").GetProperty("id").GetGuid());
+        Assert.Equal(2, changes.Count);
+        var changed = changes[changedId];
+        var snapshot = changed.GetProperty("commitment");
+        Assert.Equal("Edited display name", snapshot.GetProperty("name").GetString());
+        Assert.Equal("custom display", snapshot.GetProperty("category").GetString());
+        Assert.Equal("active", snapshot.GetProperty("lifecycle").GetString());
+        Assert.Equal("monthly", snapshot.GetProperty("cadence").GetString());
+        Assert.Equal("dayofmonth", snapshot.GetProperty("timingKind").GetString());
+        Assert.Equal(10, snapshot.GetProperty("expectedDay").GetInt32());
+        Assert.Equal("fixed", snapshot.GetProperty("amountMode").GetString());
+        Assert.Equal(10m, snapshot.GetProperty("expectedAmount").GetDecimal());
+        Assert.Equal(JsonValueKind.Null, snapshot.GetProperty("expectedDayOfWeek").ValueKind);
+        Assert.Equal(JsonValueKind.Null, snapshot.GetProperty("expectedMonth").ValueKind);
+        Assert.Equal(0, snapshot.GetProperty("windowBeforeDays").GetInt32());
+        Assert.Equal(0, snapshot.GetProperty("windowAfterDays").GetInt32());
+        Assert.Equal(JsonValueKind.Null, snapshot.GetProperty("expectedMinimumAmount").ValueKind);
+        Assert.Equal(JsonValueKind.Null, snapshot.GetProperty("expectedMaximumAmount").ValueKind);
+        Assert.Equal(
+            new[]
+            {
+                "amountMode", "cadence", "category", "expectedAmount", "expectedDay", "expectedDayOfWeek",
+                "expectedMaximumAmount", "expectedMinimumAmount", "expectedMonth", "id", "lifecycle", "name",
+                "timingKind", "windowAfterDays", "windowBeforeDays"
+            },
+            snapshot.EnumerateObject().Select(value => value.Name).OrderBy(value => value));
+        Assert.False(snapshot.TryGetProperty("updatedAt", out _));
+        Assert.Equal("commitment-change-v1", changed.GetProperty("algorithmVersion").GetString());
+        Assert.True(changed.GetProperty("isMatchingAvailable").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, changed.GetProperty("unavailableReason").ValueKind);
+        Assert.Equal("membership", changed.GetProperty("normalizedDescription").GetString());
+        Assert.Equal("bills", changed.GetProperty("canonicalCategory").GetString());
+
+        var emitted = changed.GetProperty("observations").EnumerateArray().ToArray();
+        Assert.Equal(3, emitted.Length);
+        Assert.Equal(observations[0].Id, emitted[0].GetProperty("expenseId").GetInt32());
+        Assert.Equal("2026-08-12", emitted[0].GetProperty("date").GetString());
+        Assert.Equal(12m, emitted[0].GetProperty("amount").GetDecimal());
+        Assert.Equal("membership", emitted[0].GetProperty("description").GetString());
+        Assert.Equal("bills", emitted[0].GetProperty("category").GetString());
+        Assert.Equal("sunflower_pdf", emitted[0].GetProperty("source").GetString());
+        Assert.Equal("2026-08-10", emitted[0].GetProperty("slotAnchor").GetString());
+        Assert.Equal(2, emitted[0].GetProperty("timingOffsetDays").GetInt32());
+        Assert.False(emitted[0].GetProperty("isWithinTimingWindow").GetBoolean());
+        Assert.All(emitted.Skip(1), value => Assert.Equal("manual", value.GetProperty("source").GetString()));
+        var amount = changed.GetProperty("amount");
+        Assert.Equal("proposed_change", amount.GetProperty("state").GetString());
+        Assert.Equal("fixed", amount.GetProperty("proposedMode").GetString());
+        Assert.Equal(12m, amount.GetProperty("proposedAmount").GetDecimal());
+        Assert.Equal(JsonValueKind.Null, amount.GetProperty("proposedMinimumAmount").ValueKind);
+        Assert.Equal(JsonValueKind.Null, amount.GetProperty("proposedMaximumAmount").ValueKind);
+        Assert.Equal(12m, amount.GetProperty("observedMedianAmount").GetDecimal());
+        Assert.Equal(64, amount.GetProperty("fingerprint").GetString()!.Length);
+        Assert.Equal(observations.Select(value => value.Id),
+            amount.GetProperty("evidenceExpenseIds").EnumerateArray().Select(value => value.GetInt32()));
+        var timing = changed.GetProperty("timing");
+        Assert.Equal("proposed_change", timing.GetProperty("state").GetString());
+        Assert.Equal("dayofmonth", timing.GetProperty("proposedTimingKind").GetString());
+        Assert.Equal(12, timing.GetProperty("proposedDay").GetInt32());
+        Assert.Equal(0, timing.GetProperty("proposedWindowBeforeDays").GetInt32());
+        Assert.Equal(0, timing.GetProperty("proposedWindowAfterDays").GetInt32());
+        Assert.Equal(64, timing.GetProperty("fingerprint").GetString()!.Length);
+        Assert.Equal(observations.Select(value => value.Id),
+            timing.GetProperty("evidenceExpenseIds").EnumerateArray().Select(value => value.GetInt32()));
+
+        var missing = changes[missingId].GetProperty("missing");
+        Assert.Equal("possibly_ended", missing.GetProperty("state").GetString());
+        Assert.Equal(3, missing.GetProperty("missedSlotAnchors").GetArrayLength());
+        Assert.Equal(
+            new[] { "2026-08-20", "2026-09-20", "2026-10-20" },
+            missing.GetProperty("missedSlotAnchors").EnumerateArray().Select(value => value.GetString()));
+        Assert.Equal(64, missing.GetProperty("fingerprint").GetString()!.Length);
+        Assert.Equal(
+            amount.GetProperty("fingerprint").GetString(),
+            second.GetProperty("changes").EnumerateArray()
+                .Single(value => value.GetProperty("commitment").GetProperty("id").GetGuid() == changedId)
+                .GetProperty("amount").GetProperty("fingerprint").GetString());
+        Assert.DoesNotContain("FOREIGN", first.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("private", first.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Change_read_returns_all_matching_unavailable_reasons_as_data()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("unavailable@example.com");
+
+        var one = await app.SeedExpenseAsync(owner.Id, "single", 10m, new DateOnly(2026, 7, 10), "bills");
+        var insufficientId = await SeedCommitmentAsync(app, owner.Id, [one], name: "Insufficient");
+        var inconsistentId = await SeedCommitmentAsync(app, owner.Id,
+            [
+                await app.SeedExpenseAsync(owner.Id, "first", 10m, new DateOnly(2026, 6, 10), "bills"),
+                await app.SeedExpenseAsync(owner.Id, "second", 10m, new DateOnly(2026, 7, 10), "bills")
+            ], name: "Inconsistent");
+        var sharedAId = await SeedCommitmentAsync(app, owner.Id,
+            [
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 4, 10), "bills"),
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 5, 10), "bills")
+            ], name: "Shared A");
+        var sharedBId = await SeedCommitmentAsync(app, owner.Id,
+            [
+                await app.SeedExpenseAsync(owner.Id, " SHARED ", 10m, new DateOnly(2026, 6, 10), " BILLS "),
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 7, 10), "bills")
+            ], name: "Shared B");
+
+        var body = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+        var changes = body.GetProperty("changes").EnumerateArray().ToDictionary(
+            value => value.GetProperty("commitment").GetProperty("id").GetGuid());
+
+        AssertUnavailable(changes[insufficientId], "insufficient_confirmation_evidence");
+        AssertUnavailable(changes[inconsistentId], "inconsistent_confirmation_identity");
+        AssertUnavailable(changes[sharedAId], "shared_active_identity");
+        AssertUnavailable(changes[sharedBId], "shared_active_identity");
+    }
+
+    [Fact]
+    public async Task Change_read_withholds_inactive_commitments_and_excludes_their_confirmation_expenses()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("lifecycle-change@example.com");
+
+        var activeId = await SeedCommitmentAsync(app, owner.Id,
+            [
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 4, 10), "bills"),
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 5, 10), "bills")
+            ], name: "Active");
+        await SeedCommitmentAsync(app, owner.Id,
+            [
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 6, 10), "bills"),
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 7, 10), "bills")
+            ], name: "Paused", lifecycle: CommitmentLifecycle.Paused);
+        await SeedCommitmentAsync(app, owner.Id,
+            [
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 3, 10), "bills"),
+                await app.SeedExpenseAsync(owner.Id, "shared", 10m, new DateOnly(2026, 8, 10), "bills")
+            ], name: "Ended", lifecycle: CommitmentLifecycle.Ended);
+
+        var body = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+        var change = Assert.Single(body.GetProperty("changes").EnumerateArray());
+
+        Assert.Equal(activeId, change.GetProperty("commitment").GetProperty("id").GetGuid());
+        Assert.True(change.GetProperty("isMatchingAvailable").GetBoolean());
+        Assert.Empty(change.GetProperty("observations").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Change_read_fails_closed_for_foreign_linked_confirmation_evidence()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("foreign-link-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("foreign-link-other@example.com");
+        var foreign = new[]
+        {
+            await app.SeedExpenseAsync(other.Id, "FOREIGN DESCRIPTION", 50m, new DateOnly(2026, 6, 10), "SECRET CATEGORY"),
+            await app.SeedExpenseAsync(other.Id, "FOREIGN DESCRIPTION", 50m, new DateOnly(2026, 7, 10), "SECRET CATEGORY")
+        };
+        await SeedCommitmentAsync(app, owner.Id, foreign, name: "Owner display");
+
+        var body = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+        var change = Assert.Single(body.GetProperty("changes").EnumerateArray());
+
+        AssertUnavailable(change, "insufficient_confirmation_evidence");
+        Assert.DoesNotContain("FOREIGN DESCRIPTION", body.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("SECRET CATEGORY", body.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Change_read_recomputes_after_expense_edit_and_delete_without_persisting_derived_state()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("change-recompute@example.com");
+        var confirmation = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 6, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 7, 10), "bills")
+        };
+        await SeedCommitmentAsync(app, owner.Id, confirmation);
+        var observed = await app.SeedExpenseAsync(owner.Id, "membership", 12m, new DateOnly(2026, 8, 10), "bills");
+
+        var first = Assert.Single((await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes"))
+            .GetProperty("changes").EnumerateArray());
+        var firstFingerprint = first.GetProperty("amount").GetProperty("fingerprint").GetString();
+        using var update = await owner.Client.PutAsJsonAsync($"/api/expenses/{observed.Id}", new
+        {
+            id = observed.Id,
+            description = observed.Description,
+            amount = 13m,
+            date = observed.Date.ToString("yyyy-MM-dd"),
+            category = observed.Category
+        });
+        update.EnsureSuccessStatusCode();
+        var edited = Assert.Single((await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes"))
+            .GetProperty("changes").EnumerateArray());
+        Assert.NotEqual(firstFingerprint, edited.GetProperty("amount").GetProperty("fingerprint").GetString());
+
+        Assert.Equal(HttpStatusCode.NoContent, (await owner.Client.DeleteAsync($"/api/expenses/{observed.Id}")).StatusCode);
+        var deleted = Assert.Single((await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes"))
+            .GetProperty("changes").EnumerateArray());
+        Assert.Empty(deleted.GetProperty("observations").EnumerateArray());
+        Assert.Equal("within_expectation", deleted.GetProperty("amount").GetProperty("state").GetString());
+        Assert.Equal(JsonValueKind.Null, deleted.GetProperty("amount").GetProperty("fingerprint").ValueKind);
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(2, await context.CommitmentOccurrences.CountAsync());
+    }
+
+    [Fact]
+    public async Task Change_read_without_active_commitments_returns_dated_empty_collection()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("empty-changes@example.com");
+
+        var body = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+
+        Assert.Equal("2026-08-29", body.GetProperty("evaluatedOn").GetString());
+        Assert.Empty(body.GetProperty("changes").EnumerateArray());
     }
 
     [Fact]
@@ -309,6 +573,92 @@ public sealed class CommitmentsApiTests
         return result;
     }
 
+    private static async Task<Guid> SeedCommitmentAsync(
+        FinancialApiTestApplicationBase app,
+        string ownerId,
+        IEnumerable<Expense> evidence,
+        string name = "Membership",
+        string category = "bills",
+        int expectedDay = 10,
+        decimal expectedAmount = 10m,
+        CommitmentLifecycle lifecycle = CommitmentLifecycle.Active)
+    {
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var commitment = new Commitment
+        {
+            Id = Guid.NewGuid(),
+            OwnerId = ownerId,
+            Name = name,
+            Category = category,
+            Lifecycle = lifecycle,
+            Cadence = CommitmentCadence.Monthly,
+            TimingKind = CommitmentTimingKind.DayOfMonth,
+            ExpectedDay = expectedDay,
+            WindowBeforeDays = 0,
+            WindowAfterDays = 0,
+            AmountMode = CommitmentAmountMode.Fixed,
+            ExpectedAmount = expectedAmount,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Occurrences = evidence.Select(expense => new CommitmentOccurrence
+            {
+                ExpenseId = expense.Id,
+                Kind = CommitmentOccurrenceKind.ConfirmationEvidence,
+                LinkedAt = now
+            }).ToList()
+        };
+        context.Commitments.Add(commitment);
+        await context.SaveChangesAsync();
+        return commitment.Id;
+    }
+
+    private static async Task SeedImportedProvenanceAsync(
+        FinancialApiTestApplicationBase app,
+        string ownerId,
+        int expenseId)
+    {
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var now = new DateTime(2026, 10, 29, 0, 0, 0, DateTimeKind.Utc);
+        var digest = new byte[32];
+        BitConverter.GetBytes(expenseId).CopyTo(digest, 0);
+        context.ImportPreviewBatches.Add(new ImportPreviewBatch
+        {
+            Id = Guid.NewGuid(),
+            OwnerId = ownerId,
+            SourceType = "sunflower_pdf",
+            ParserRuleVersion = "change-read-test-v1",
+            DocumentDigest = digest,
+            CreatedAt = now.AddHours(-1),
+            ExpiresAt = now.AddHours(1),
+            Lifecycle = ImportPreviewLifecycle.Confirmed,
+            ConfirmedAt = now,
+            Provenance =
+            [
+                new ImportExpenseProvenance
+                {
+                    SourceRowOrdinal = 1,
+                    ExpenseId = expenseId
+                }
+            ]
+        });
+        await context.SaveChangesAsync();
+    }
+
+    private static void AssertUnavailable(JsonElement change, string reason)
+    {
+        Assert.False(change.GetProperty("isMatchingAvailable").GetBoolean());
+        Assert.Equal(reason, change.GetProperty("unavailableReason").GetString());
+        Assert.Equal(JsonValueKind.Null, change.GetProperty("normalizedDescription").ValueKind);
+        Assert.Equal(JsonValueKind.Null, change.GetProperty("canonicalCategory").ValueKind);
+        Assert.Empty(change.GetProperty("observations").EnumerateArray());
+        Assert.Equal("matching_unavailable", change.GetProperty("amount").GetProperty("state").GetString());
+        Assert.Equal("matching_unavailable", change.GetProperty("timing").GetProperty("state").GetString());
+        Assert.Equal("matching_unavailable", change.GetProperty("missing").GetProperty("state").GetString());
+    }
+
     private static DateOnly[] RecentMonthlyDates()
     {
         var now = DateTime.UtcNow;
@@ -340,4 +690,19 @@ public sealed class CommitmentsApiTests
         expectedMinimumAmount = (decimal?)null,
         expectedMaximumAmount = (decimal?)null
     };
+}
+
+internal sealed class ClockedCommitmentFinancialApiTestApplication(FixedCommitmentTimeProvider clock)
+    : FinancialApiTestApplication
+{
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<TimeProvider>();
+        services.AddSingleton<TimeProvider>(clock);
+    }
+}
+
+internal sealed class FixedCommitmentTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
 }

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -458,6 +458,88 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Commitment_change_read_executes_owner_scoped_relational_query_and_provenance_mapping()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-commitment-change@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("postgres-commitment-change-other@example.com");
+        var utcToday = DateTime.UtcNow;
+        var currentAnchor = new DateOnly(utcToday.Year, utcToday.Month, 1);
+        foreach (var date in new[]
+                 {
+                     currentAnchor.AddMonths(-3),
+                     currentAnchor.AddMonths(-2),
+                     currentAnchor.AddMonths(-1)
+                 })
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, date, "bills");
+        var fingerprint = await ReadCandidateFingerprintAsync(owner.Client);
+        using var confirmation = await owner.Client.PostAsJsonAsync(
+            "/api/commitment-candidates/confirm",
+            new
+            {
+                fingerprint,
+                name = "Membership display",
+                category = "custom display",
+                cadence = "monthly",
+                timingKind = "dayOfMonth",
+                expectedDayOfWeek = (string?)null,
+                expectedDay = 1,
+                expectedMonth = (int?)null,
+                windowBeforeDays = 0,
+                windowAfterDays = 0,
+                amountMode = "fixed",
+                expectedAmount = 10m,
+                expectedMinimumAmount = (decimal?)null,
+                expectedMaximumAmount = (decimal?)null
+            });
+        Assert.Equal(HttpStatusCode.Created, confirmation.StatusCode);
+        var observed = await app.SeedExpenseAsync(owner.Id, "membership", 12m, currentAnchor, "bills");
+        await app.SeedExpenseAsync(other.Id, "RELATIONAL SECRET", 999m, currentAnchor, "private");
+
+        using (var setupScope = app.Services.CreateScope())
+        {
+            var context = setupScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var now = DateTime.UtcNow;
+            var digest = new byte[32];
+            BitConverter.GetBytes(observed.Id).CopyTo(digest, 0);
+            context.ImportPreviewBatches.Add(new ImportPreviewBatch
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = owner.Id,
+                SourceType = "sunflower_pdf",
+                ParserRuleVersion = "commitment-change-postgresql-v1",
+                DocumentDigest = digest,
+                CreatedAt = now.AddHours(-1),
+                ExpiresAt = now.AddHours(1),
+                Lifecycle = ImportPreviewLifecycle.Confirmed,
+                ConfirmedAt = now,
+                Provenance =
+                [
+                    new ImportExpenseProvenance
+                    {
+                        SourceRowOrdinal = 1,
+                        ExpenseId = observed.Id
+                    }
+                ]
+            });
+            await context.SaveChangesAsync();
+        }
+
+        var body = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+        var change = Assert.Single(body.GetProperty("changes").EnumerateArray());
+        var observation = Assert.Single(change.GetProperty("observations").EnumerateArray());
+
+        Assert.Equal("Membership display", change.GetProperty("commitment").GetProperty("name").GetString());
+        Assert.Equal("custom display", change.GetProperty("commitment").GetProperty("category").GetString());
+        Assert.Equal("membership", change.GetProperty("normalizedDescription").GetString());
+        Assert.Equal("bills", change.GetProperty("canonicalCategory").GetString());
+        Assert.Equal(observed.Id, observation.GetProperty("expenseId").GetInt32());
+        Assert.Equal("sunflower_pdf", observation.GetProperty("source").GetString());
+        Assert.Equal("isolated_outlier", change.GetProperty("amount").GetProperty("state").GetString());
+        Assert.DoesNotContain("RELATIONAL SECRET", body.ToString(), StringComparison.Ordinal);
+    }
+
+    [PostgreSqlFact]
     public async Task Concurrent_candidate_confirmations_create_one_commitment_and_return_one_retry()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();

--- a/backend/Commitments/CommitmentService.cs
+++ b/backend/Commitments/CommitmentService.cs
@@ -25,6 +25,7 @@ public interface ICommitmentService
     Task<CommitmentOperation<bool>> ReconsiderAsync(string ownerId, CandidateDecisionRequest request, CancellationToken cancellationToken);
     Task<CommitmentOperation<ConfirmCommitmentResponse>> ConfirmAsync(string ownerId, ConfirmCommitmentRequest request, CancellationToken cancellationToken);
     Task<IReadOnlyList<CommitmentResponse>> GetCommitmentsAsync(string ownerId, CancellationToken cancellationToken);
+    Task<CommitmentChangesResponse> GetChangesAsync(string ownerId, CancellationToken cancellationToken);
     Task<CommitmentOperation<CommitmentResponse>> UpdateAsync(string ownerId, Guid id, UpdateCommitmentRequest request, CancellationToken cancellationToken);
     Task<CommitmentOperation<CommitmentResponse>> UpdateLifecycleAsync(string ownerId, Guid id, UpdateCommitmentLifecycleRequest request, CancellationToken cancellationToken);
 }
@@ -32,6 +33,7 @@ public interface ICommitmentService
 public sealed class CommitmentService(
     BudgetContext context,
     ICommitmentDetector detector,
+    ICommitmentChangeDetector changeDetector,
     TimeProvider clock) : ICommitmentService
 {
     public async Task<CommitmentCandidatesResponse> GetCandidatesAsync(
@@ -250,6 +252,34 @@ public sealed class CommitmentService(
         return commitments.Select(value => ToCommitmentResponse(value, importedIds)).ToArray();
     }
 
+    public async Task<CommitmentChangesResponse> GetChangesAsync(
+        string ownerId,
+        CancellationToken cancellationToken)
+    {
+        var evaluatedOn = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
+        var commitments = await context.Commitments.AsNoTracking()
+            .Where(value => value.OwnerId == ownerId)
+            .Include(value => value.Occurrences)
+            .OrderBy(value => value.Id)
+            .ToListAsync(cancellationToken);
+        var expenses = await context.Expenses.AsNoTracking()
+            .Where(value => value.UserId == ownerId && value.Date <= evaluatedOn)
+            .ToListAsync(cancellationToken);
+        var expensesById = expenses.ToDictionary(value => value.Id);
+        foreach (var occurrence in commitments.SelectMany(value => value.Occurrences))
+            occurrence.Expense = expensesById.GetValueOrDefault(occurrence.ExpenseId);
+
+        var detections = changeDetector.Detect(ownerId, commitments, expenses, evaluatedOn);
+        var commitmentsById = commitments.ToDictionary(value => value.Id);
+        var importedIds = await LoadImportedExpenseIdsAsync(ownerId, cancellationToken);
+        return new CommitmentChangesResponse(
+            evaluatedOn,
+            detections.Select(detection => ToChangeResponse(
+                detection,
+                commitmentsById[detection.CommitmentId],
+                importedIds)).ToArray());
+    }
+
     public async Task<CommitmentOperation<CommitmentResponse>> UpdateAsync(
         string ownerId,
         Guid id,
@@ -314,7 +344,9 @@ public sealed class CommitmentService(
 
     private async Task<HashSet<int>> LoadImportedExpenseIdsAsync(string ownerId, CancellationToken cancellationToken) =>
         await context.ImportExpenseProvenances.AsNoTracking()
-            .Where(value => value.ExpenseId != null && value.Expense!.UserId == ownerId)
+            .Where(value => value.ExpenseId != null
+                && value.Batch!.OwnerId == ownerId
+                && value.Expense!.UserId == ownerId)
             .Select(value => value.ExpenseId!.Value)
             .ToHashSetAsync(cancellationToken);
 
@@ -401,6 +433,92 @@ public sealed class CommitmentService(
             .Where(value => value.Expense is not null)
             .OrderBy(value => value.Expense!.Date).ThenBy(value => value.ExpenseId)
             .Select(value => ToEvidenceResponse(value.Expense!, importedExpenseIds)).ToArray());
+
+    private static CommitmentChangeResponse ToChangeResponse(
+        CommitmentChangeDetection detection,
+        Commitment commitment,
+        IReadOnlySet<int> importedExpenseIds) => new(
+        new CommitmentChangeSnapshotResponse(
+            commitment.Id,
+            commitment.Name,
+            commitment.Category,
+            EnumName(commitment.Lifecycle),
+            EnumName(commitment.Cadence),
+            EnumName(commitment.TimingKind),
+            commitment.ExpectedDayOfWeek is null ? null : EnumName(commitment.ExpectedDayOfWeek.Value),
+            commitment.ExpectedDay,
+            commitment.ExpectedMonth,
+            commitment.WindowBeforeDays,
+            commitment.WindowAfterDays,
+            EnumName(commitment.AmountMode),
+            commitment.ExpectedAmount,
+            commitment.ExpectedMinimumAmount,
+            commitment.ExpectedMaximumAmount),
+        detection.AlgorithmVersion,
+        detection.IsMatchingAvailable,
+        detection.UnavailableReason is null ? null : MatchingUnavailableReasonName(detection.UnavailableReason.Value),
+        detection.NormalizedDescription,
+        detection.CanonicalCategory,
+        detection.Observations.Select(value => ToChangeObservationResponse(value, importedExpenseIds)).ToArray(),
+        new CommitmentAmountChangeResponse(
+            ChangeStateName(detection.Amount.State),
+            detection.Amount.Fingerprint,
+            detection.Amount.ProposedMode is null ? null : EnumName(detection.Amount.ProposedMode.Value),
+            detection.Amount.ProposedAmount,
+            detection.Amount.ProposedMinimumAmount,
+            detection.Amount.ProposedMaximumAmount,
+            detection.Amount.ObservedMedianAmount,
+            detection.Amount.Evidence.Select(value => value.Expense.Id).ToArray()),
+        new CommitmentTimingChangeResponse(
+            ChangeStateName(detection.Timing.State),
+            detection.Timing.Fingerprint,
+            detection.Timing.ProposedTimingKind is null ? null : EnumName(detection.Timing.ProposedTimingKind.Value),
+            detection.Timing.ProposedDayOfWeek is null ? null : EnumName(detection.Timing.ProposedDayOfWeek.Value),
+            detection.Timing.ProposedDay,
+            detection.Timing.ProposedMonth,
+            detection.Timing.ProposedWindowBeforeDays,
+            detection.Timing.ProposedWindowAfterDays,
+            detection.Timing.Evidence.Select(value => value.Expense.Id).ToArray()),
+        new CommitmentMissingResponse(
+            ChangeStateName(detection.Missing.State),
+            detection.Missing.Fingerprint,
+            detection.Missing.MissedSlotAnchors));
+
+    private static CommitmentChangeObservationResponse ToChangeObservationResponse(
+        CommitmentChangeObservation observation,
+        IReadOnlySet<int> importedExpenseIds) => new(
+        observation.Expense.Id,
+        observation.Expense.Date,
+        observation.Expense.Amount,
+        observation.Expense.Description,
+        observation.Expense.Category,
+        importedExpenseIds.Contains(observation.Expense.Id) ? "sunflower_pdf" : "manual",
+        observation.SlotAnchor,
+        observation.TimingOffsetDays,
+        observation.IsWithinTimingWindow);
+
+    private static string EnumName<T>(T value) where T : struct, Enum =>
+        value.ToString().ToLowerInvariant();
+
+    private static string ChangeStateName(CommitmentChangeState value) => value switch
+    {
+        CommitmentChangeState.WithinExpectation => "within_expectation",
+        CommitmentChangeState.IsolatedOutlier => "isolated_outlier",
+        CommitmentChangeState.PossibleChange => "possible_change",
+        CommitmentChangeState.ProposedChange => "proposed_change",
+        CommitmentChangeState.NotSeenRecently => "not_seen_recently",
+        CommitmentChangeState.PossiblyEnded => "possibly_ended",
+        CommitmentChangeState.MatchingUnavailable => "matching_unavailable",
+        _ => throw new InvalidOperationException($"Unsupported commitment change value '{value}'.")
+    };
+
+    private static string MatchingUnavailableReasonName(CommitmentMatchingUnavailableReason value) => value switch
+    {
+        CommitmentMatchingUnavailableReason.InsufficientConfirmationEvidence => "insufficient_confirmation_evidence",
+        CommitmentMatchingUnavailableReason.InconsistentConfirmationIdentity => "inconsistent_confirmation_identity",
+        CommitmentMatchingUnavailableReason.SharedActiveIdentity => "shared_active_identity",
+        _ => throw new InvalidOperationException($"Unsupported matching-unavailable reason '{value}'.")
+    };
 
     private static CommitmentEvidenceResponse ToEvidenceResponse(Expense expense, IReadOnlySet<int> importedExpenseIds) =>
         new(expense.Id, expense.Date, expense.Amount, expense.Description, expense.Category,

--- a/backend/Contracts/Commitments/CommitmentChangeContracts.cs
+++ b/backend/Contracts/Commitments/CommitmentChangeContracts.cs
@@ -1,0 +1,71 @@
+namespace BudgetPlanner.Contracts.Commitments;
+
+public sealed record CommitmentChangesResponse(
+    DateOnly EvaluatedOn,
+    IReadOnlyList<CommitmentChangeResponse> Changes);
+
+public sealed record CommitmentChangeResponse(
+    CommitmentChangeSnapshotResponse Commitment,
+    string AlgorithmVersion,
+    bool IsMatchingAvailable,
+    string? UnavailableReason,
+    string? NormalizedDescription,
+    string? CanonicalCategory,
+    IReadOnlyList<CommitmentChangeObservationResponse> Observations,
+    CommitmentAmountChangeResponse Amount,
+    CommitmentTimingChangeResponse Timing,
+    CommitmentMissingResponse Missing);
+
+public sealed record CommitmentChangeSnapshotResponse(
+    Guid Id,
+    string Name,
+    string Category,
+    string Lifecycle,
+    string Cadence,
+    string TimingKind,
+    string? ExpectedDayOfWeek,
+    int? ExpectedDay,
+    int? ExpectedMonth,
+    int WindowBeforeDays,
+    int WindowAfterDays,
+    string AmountMode,
+    decimal? ExpectedAmount,
+    decimal? ExpectedMinimumAmount,
+    decimal? ExpectedMaximumAmount);
+
+public sealed record CommitmentChangeObservationResponse(
+    int ExpenseId,
+    DateOnly Date,
+    decimal Amount,
+    string Description,
+    string Category,
+    string Source,
+    DateOnly SlotAnchor,
+    int TimingOffsetDays,
+    bool IsWithinTimingWindow);
+
+public sealed record CommitmentAmountChangeResponse(
+    string State,
+    string? Fingerprint,
+    string? ProposedMode,
+    decimal? ProposedAmount,
+    decimal? ProposedMinimumAmount,
+    decimal? ProposedMaximumAmount,
+    decimal? ObservedMedianAmount,
+    IReadOnlyList<int> EvidenceExpenseIds);
+
+public sealed record CommitmentTimingChangeResponse(
+    string State,
+    string? Fingerprint,
+    string? ProposedTimingKind,
+    string? ProposedDayOfWeek,
+    int? ProposedDay,
+    int? ProposedMonth,
+    int? ProposedWindowBeforeDays,
+    int? ProposedWindowAfterDays,
+    IReadOnlyList<int> EvidenceExpenseIds);
+
+public sealed record CommitmentMissingResponse(
+    string State,
+    string? Fingerprint,
+    IReadOnlyList<DateOnly> MissedSlotAnchors);

--- a/backend/Controllers/CommitmentsController.cs
+++ b/backend/Controllers/CommitmentsController.cs
@@ -65,6 +65,15 @@ public sealed class CommitmentsController(ICommitmentService commitments) : Cont
             : Ok(await commitments.GetCommitmentsAsync(ownerId, cancellationToken));
     }
 
+    [HttpGet("commitment-changes")]
+    public async Task<IActionResult> GetChanges(CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        return ownerId is null
+            ? Unauthorized()
+            : Ok(await commitments.GetChangesAsync(ownerId, cancellationToken));
+    }
+
     [HttpPut("commitments/{id:guid}")]
     public async Task<IActionResult> Update(
         Guid id,

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -40,6 +40,7 @@ builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton(new ImportPreviewProcessingOptions());
 builder.Services.AddScoped<IImportPreviewService, ImportPreviewService>();
 builder.Services.AddSingleton<ICommitmentDetector, CommitmentDetector>();
+builder.Services.AddSingleton<ICommitmentChangeDetector, CommitmentChangeDetector>();
 builder.Services.AddScoped<ICommitmentService, CommitmentService>();
 
 builder.Services

--- a/docs/commitment-intelligence.md
+++ b/docs/commitment-intelligence.md
@@ -92,8 +92,10 @@ production migration, deploy, or perform production data operations.
 ## Commitment change detection V1
 
 The approved first change-detection slice is a pure, explicitly versioned
-`commitment-change-v1` detector. It does not expose an API or UI and does not
-persist derived matches or proposals.
+`commitment-change-v1` detector. The authenticated read-only
+`GET /api/commitment-changes` endpoint evaluates it on demand for the current
+owner and returns explicit response DTOs; it does not expose a UI or persist
+derived matches or proposals.
 
 Only active, owner-scoped commitments participate. Observation identity comes
 from at least two surviving confirmation-linked Expenses that all share one
@@ -143,3 +145,14 @@ the exact assessment result. A future action boundary must recompute this
 authoritatively and reject stale decisions. A user-visible workflow remains
 blocked until accept/end, durable keep/dismiss, reconsider, and stale-conflict
 handling can ship coherently under separate approval.
+
+Each read captures one UTC calendar date and returns it as `evaluatedOn`. Every
+active-commitment result contains the exact commitment snapshot supplied to the
+detector in that invocation: display name/category, lifecycle, cadence,
+timing/window fields, and amount fields. Display name and editable category are
+presentation-only and remain distinct from the evidence-derived normalized
+description/category identity. Owner identity comes only from the authenticated
+claim, and commitments, Expenses, confirmation evidence, and import provenance
+are filtered to that owner before response mapping. Paused and ended
+commitments are not returned. Matching-unavailable cases are successful data,
+and a user with no active commitments receives a dated empty collection.


### PR DESCRIPTION
## Summary

Adds the approved Stage 2 authenticated read-only commitment-change API. The endpoint evaluates the merged `commitment-change-v1` detector on demand and returns owner-scoped, explainable observations and assessments with the exact commitment snapshot used for the same detector invocation.

## Issue

References #101

## Risk

- [ ] LOW
- [ ] MEDIUM
- [x] HIGH

The governing issue contains explicit owner approval for this exact read-only implementation boundary.

## Changes

- adds `GET /api/commitment-changes` with explicit response DTOs and one captured UTC `evaluatedOn` date;
- loads owner-scoped commitments, occurrence links, Expenses, and import provenance without eager-loading arbitrary linked financial rows;
- attaches only owned confirmation Expenses before invoking the existing detector;
- returns the same loaded commitment snapshot used by the detector, while keeping editable display fields distinct from the evidence-derived identity;
- maps deterministic amount, timing, missing, ambiguity, fingerprint, evidence-ID, slot, and source-provenance results;
- adds hostile cross-owner, lifecycle, unavailable-reason, deterministic-time, recomputation, and PostgreSQL relational coverage;
- records the read contract in the approved commitment semantics document.

## Non-goals

No frontend/UI consumer; accept/update/end actions; keep/dismiss/reconsider actions; stale-action handling; detector-semantic change; derived-state persistence; schema or migration; caching/materialization; scheduler/background work; deployment; or production access/operation.

## Verification

### Passed locally

- `dotnet test backend.Tests/backend.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~CommitmentsApiTests"` — 14/14 passed on the final revision.
- Focused commitment API plus detector run — 53/53 passed before the final owner-provenance hardening; the affected API suite was rerun afterward as noted above.
- `git diff --cached --check` — passed before commit.
- Backend and test projects compile cleanly as part of the final focused run.

### Not run locally — capability unavailable

- `./scripts/verify.sh postgresql` — not run because `BUDGETPLANNER_POSTGRESQL_TEST_CONNECTION` is not configured for an approved disposable local database.

### Required/proven by CI

Passed on commit `b96dd5350196d13fb2a5f7c014d29792d5b5bba6`:

- **Backend build and tests**
- **PostgreSQL financial integration**
- **Frontend test, lint, and build**

### Smoke checks (supplemental)

Not applicable; this is an authenticated backend read contract with focused API integration coverage and no user-visible workflow.

### Preview evidence (non-blocking)

- Vercel and Vercel Preview Comments passed. No frontend changes require preview inspection.

### Remaining verification gaps

None. The required Backend and PostgreSQL CI lanes passed. During local iteration, one complete backend lane passed 292/292; a later repeat exposed two unrelated PDF-extractor flakes, but the authoritative Backend CI lane passed on the final commit. No PDF/import code changed.

## API impact

Adds authenticated `GET /api/commitment-changes`. It accepts no route, query, body, owner, or evaluation-date input. The response contains `evaluatedOn` and ordered active-commitment change results with a nested current commitment snapshot, derived identity, observations, and amount/timing/missing assessments. Empty and matching-unavailable states return `200` data.

## Database / migration impact

None. No schema, migration, backfill, or persisted derived state.

Rollback is code-only: remove the endpoint, DTOs, service read/mapping, detector registration, tests, and documentation update.

## Dependency impact

None.

## Deployment considerations

None. Deployment and production operations are outside the approved scope.

## Review notes

Please focus on:

- claim-only ownership and dual owner filtering for import batch provenance and Expense data;
- fail-closed handling of anomalous foreign-linked confirmation evidence;
- mapping the nested snapshot from the exact commitment instance passed to the detector;
- preservation of detector ordering, fingerprints, and evidence references without reproducing financial semantics in the service.

After merge is confirmed and the work is complete, clean up the merged remote feature branch according to `AGENTS.md`. This is a post-merge action.
