### PR TITLE
Add authoritative commitment change actions

### DIFF
--- a/backend.Tests/Financial/CommitmentsApiTests.cs
+++ b/backend.Tests/Financial/CommitmentsApiTests.cs
@@ -24,6 +24,16 @@ public sealed class CommitmentsApiTests
         Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/commitment-changes")).StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized,
             (await client.PostAsJsonAsync("/api/commitment-candidates/dismiss", new { fingerprint = new string('0', 64) })).StatusCode);
+        foreach (var path in new[]
+        {
+            $"/api/commitment-changes/{Guid.NewGuid()}/amount/accept",
+            $"/api/commitment-changes/{Guid.NewGuid()}/timing/accept",
+            $"/api/commitment-changes/{Guid.NewGuid()}/missing/mark-ended",
+            $"/api/commitment-changes/{Guid.NewGuid()}/amount/keep",
+            $"/api/commitment-changes/{Guid.NewGuid()}/amount/reconsider"
+        })
+            Assert.Equal(HttpStatusCode.Unauthorized,
+                (await client.PostAsJsonAsync(path, new { fingerprint = new string('0', 64) })).StatusCode);
     }
 
     [Fact]
@@ -110,6 +120,7 @@ public sealed class CommitmentsApiTests
         Assert.All(emitted.Skip(1), value => Assert.Equal("manual", value.GetProperty("source").GetString()));
         var amount = changed.GetProperty("amount");
         Assert.Equal("proposed_change", amount.GetProperty("state").GetString());
+        Assert.Equal("pending", amount.GetProperty("decisionState").GetString());
         Assert.Equal("fixed", amount.GetProperty("proposedMode").GetString());
         Assert.Equal(12m, amount.GetProperty("proposedAmount").GetDecimal());
         Assert.Equal(JsonValueKind.Null, amount.GetProperty("proposedMinimumAmount").ValueKind);
@@ -120,6 +131,7 @@ public sealed class CommitmentsApiTests
             amount.GetProperty("evidenceExpenseIds").EnumerateArray().Select(value => value.GetInt32()));
         var timing = changed.GetProperty("timing");
         Assert.Equal("proposed_change", timing.GetProperty("state").GetString());
+        Assert.Equal("pending", timing.GetProperty("decisionState").GetString());
         Assert.Equal("dayofmonth", timing.GetProperty("proposedTimingKind").GetString());
         Assert.Equal(12, timing.GetProperty("proposedDay").GetInt32());
         Assert.Equal(0, timing.GetProperty("proposedWindowBeforeDays").GetInt32());
@@ -130,6 +142,7 @@ public sealed class CommitmentsApiTests
 
         var missing = changes[missingId].GetProperty("missing");
         Assert.Equal("possibly_ended", missing.GetProperty("state").GetString());
+        Assert.Equal("pending", missing.GetProperty("decisionState").GetString());
         Assert.Equal(3, missing.GetProperty("missedSlotAnchors").GetArrayLength());
         Assert.Equal(
             new[] { "2026-08-20", "2026-09-20", "2026-10-20" },
@@ -285,6 +298,404 @@ public sealed class CommitmentsApiTests
 
         Assert.Equal("2026-08-29", body.GetProperty("evaluatedOn").GetString());
         Assert.Empty(body.GetProperty("changes").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Keep_and_reconsider_are_exact_idempotent_owner_scoped_decisions()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("keep-change-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("keep-change-other@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 5, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 6, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 7, 10), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(app, owner.Id, evidence);
+        foreach (var date in new[] { new DateOnly(2026, 8, 10), new DateOnly(2026, 9, 10), new DateOnly(2026, 10, 10) })
+            await app.SeedExpenseAsync(owner.Id, "membership", 12m, date, "bills");
+        var amount = ChangeFor(await GetChangesAsync(owner.Client), commitmentId).GetProperty("amount");
+        var fingerprint = amount.GetProperty("fingerprint").GetString()!;
+
+        foreach (var path in new[]
+        {
+            $"/api/commitment-changes/{commitmentId}/amount/accept",
+            $"/api/commitment-changes/{commitmentId}/timing/accept",
+            $"/api/commitment-changes/{commitmentId}/missing/mark-ended",
+            $"/api/commitment-changes/{commitmentId}/amount/keep",
+            $"/api/commitment-changes/{commitmentId}/amount/reconsider"
+        })
+            Assert.Equal(HttpStatusCode.NotFound,
+                (await other.Client.PostAsJsonAsync(path, new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/unknown/keep", new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/keep", new { fingerprint = "invalid" })).StatusCode);
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/keep", new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/keep", new { fingerprint })).StatusCode);
+        var kept = ChangeFor(await GetChangesAsync(owner.Client), commitmentId);
+        Assert.Equal("kept", kept.GetProperty("amount").GetProperty("decisionState").GetString());
+        Assert.Equal(JsonValueKind.Null, kept.GetProperty("timing").GetProperty("decisionState").ValueKind);
+
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/reconsider",
+                new { fingerprint = new string('f', 64) })).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/reconsider", new { fingerprint })).StatusCode);
+        Assert.Equal("pending", ChangeFor(await GetChangesAsync(owner.Client), commitmentId)
+            .GetProperty("amount").GetProperty("decisionState").GetString());
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/reconsider", new { fingerprint })).StatusCode);
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Empty(await context.CommitmentChangeDismissals.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Changed_evidence_resurfaces_a_kept_assessment_and_leaves_the_old_record_inert()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("resurface-change@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 5, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 6, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 7, 10), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(app, owner.Id, evidence);
+        var observations = new List<Expense>();
+        foreach (var date in new[] { new DateOnly(2026, 8, 10), new DateOnly(2026, 9, 10), new DateOnly(2026, 10, 10) })
+            observations.Add(await app.SeedExpenseAsync(owner.Id, "membership", 12m, date, "bills"));
+        var originalFingerprint = ChangeFor(await GetChangesAsync(owner.Client), commitmentId)
+            .GetProperty("amount").GetProperty("fingerprint").GetString()!;
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/keep",
+                new { fingerprint = originalFingerprint })).StatusCode);
+
+        using (var update = await owner.Client.PutAsJsonAsync($"/api/expenses/{observations[^1].Id}", new
+        {
+            id = observations[^1].Id,
+            description = observations[^1].Description,
+            amount = 13m,
+            date = observations[^1].Date.ToString("yyyy-MM-dd"),
+            category = observations[^1].Category
+        }))
+            update.EnsureSuccessStatusCode();
+        var current = ChangeFor(await GetChangesAsync(owner.Client), commitmentId).GetProperty("amount");
+
+        Assert.NotEqual(originalFingerprint, current.GetProperty("fingerprint").GetString());
+        Assert.Equal("pending", current.GetProperty("decisionState").GetString());
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/reconsider",
+                new { fingerprint = originalFingerprint })).StatusCode);
+        using var scope = app.Services.CreateScope();
+        var dismissal = Assert.Single(await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .CommitmentChangeDismissals.AsNoTracking().ToListAsync());
+        Assert.Equal(Convert.FromHexString(originalFingerprint), dismissal.EvidenceFingerprint);
+    }
+
+    [Fact]
+    public async Task Accept_amount_and_timing_recompute_and_mutate_only_the_selected_baseline()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("accept-change@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 5, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 6, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 7, 10), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(
+            app, owner.Id, evidence, name: "Custom name", category: "custom category");
+        foreach (var date in new[] { new DateOnly(2026, 8, 12), new DateOnly(2026, 9, 12), new DateOnly(2026, 10, 12) })
+            await app.SeedExpenseAsync(owner.Id, "membership", 12m, date, "bills");
+        var initial = ChangeFor(await GetChangesAsync(owner.Client), commitmentId);
+        var amountFingerprint = initial.GetProperty("amount").GetProperty("fingerprint").GetString()!;
+        var initialTimingFingerprint = initial.GetProperty("timing").GetProperty("fingerprint").GetString()!;
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/accept",
+                new { fingerprint = amountFingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/accept",
+                new { fingerprint = amountFingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/timing/accept",
+                new { fingerprint = initialTimingFingerprint })).StatusCode);
+
+        var afterAmount = ChangeFor(await GetChangesAsync(owner.Client), commitmentId);
+        var timingFingerprint = afterAmount.GetProperty("timing").GetProperty("fingerprint").GetString()!;
+        Assert.NotEqual(initialTimingFingerprint, timingFingerprint);
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/timing/accept",
+                new { fingerprint = timingFingerprint })).StatusCode);
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var persisted = await context.Commitments.SingleAsync(value => value.Id == commitmentId);
+        Assert.Equal("Custom name", persisted.Name);
+        Assert.Equal("custom category", persisted.Category);
+        Assert.Equal(CommitmentLifecycle.Active, persisted.Lifecycle);
+        Assert.Equal(CommitmentCadence.Monthly, persisted.Cadence);
+        Assert.Equal(CommitmentAmountMode.Fixed, persisted.AmountMode);
+        Assert.Equal(12m, persisted.ExpectedAmount);
+        Assert.Null(persisted.ExpectedMinimumAmount);
+        Assert.Null(persisted.ExpectedMaximumAmount);
+        Assert.Equal(CommitmentTimingKind.DayOfMonth, persisted.TimingKind);
+        Assert.Equal(12, persisted.ExpectedDay);
+        Assert.Equal(0, persisted.WindowBeforeDays);
+        Assert.Equal(0, persisted.WindowAfterDays);
+        Assert.True(persisted.UpdatedAt > new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Accept_amount_copies_a_proposed_range_and_clears_the_fixed_value()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("accept-range-change@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 5, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 6, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 7, 10), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(app, owner.Id, evidence);
+        foreach (var observation in new[]
+                 {
+                     (Date: new DateOnly(2026, 8, 10), Amount: 12m),
+                     (Date: new DateOnly(2026, 9, 10), Amount: 15m),
+                     (Date: new DateOnly(2026, 10, 10), Amount: 13m)
+                 })
+            await app.SeedExpenseAsync(owner.Id, "membership", observation.Amount, observation.Date, "bills");
+        var amount = ChangeFor(await GetChangesAsync(owner.Client), commitmentId).GetProperty("amount");
+        Assert.Equal("range", amount.GetProperty("proposedMode").GetString());
+        var fingerprint = amount.GetProperty("fingerprint").GetString()!;
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/accept", new { fingerprint })).StatusCode);
+
+        using var scope = app.Services.CreateScope();
+        var persisted = await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .Commitments.SingleAsync(value => value.Id == commitmentId);
+        Assert.Equal(CommitmentAmountMode.Range, persisted.AmountMode);
+        Assert.Null(persisted.ExpectedAmount);
+        Assert.Equal(12m, persisted.ExpectedMinimumAmount);
+        Assert.Equal(15m, persisted.ExpectedMaximumAmount);
+        Assert.Equal(10, persisted.ExpectedDay);
+        Assert.Equal(CommitmentLifecycle.Active, persisted.Lifecycle);
+    }
+
+    [Theory]
+    [InlineData("weekly")]
+    [InlineData("month_end")]
+    [InlineData("yearly")]
+    public async Task Accept_timing_copies_each_supported_proposal_shape_without_changing_cadence_or_amount(
+        string scenario)
+    {
+        var now = scenario == "weekly"
+            ? new DateTimeOffset(2026, 10, 22, 18, 0, 0, TimeSpan.Zero)
+            : scenario == "yearly"
+                ? new DateTimeOffset(2026, 3, 10, 18, 0, 0, TimeSpan.Zero)
+                : new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero);
+        var cadence = scenario switch
+        {
+            "weekly" => CommitmentCadence.Weekly,
+            "yearly" => CommitmentCadence.Yearly,
+            _ => CommitmentCadence.Monthly
+        };
+        var timingKind = scenario switch
+        {
+            "weekly" => CommitmentTimingKind.Weekday,
+            "yearly" => CommitmentTimingKind.MonthAndDay,
+            _ => CommitmentTimingKind.MonthEnd
+        };
+        var evidenceDates = scenario switch
+        {
+            "weekly" => new[] { new DateOnly(2026, 9, 21), new DateOnly(2026, 9, 28) },
+            "yearly" => new[] { new DateOnly(2022, 2, 28), new DateOnly(2023, 2, 28) },
+            _ => new[] { new DateOnly(2026, 6, 30), new DateOnly(2026, 7, 31) }
+        };
+        var observationDates = scenario switch
+        {
+            "weekly" => new[] { new DateOnly(2026, 10, 7), new DateOnly(2026, 10, 14), new DateOnly(2026, 10, 21) },
+            "yearly" => new[] { new DateOnly(2024, 3, 2), new DateOnly(2025, 3, 2), new DateOnly(2026, 3, 2) },
+            _ => new[] { new DateOnly(2026, 8, 28), new DateOnly(2026, 9, 27), new DateOnly(2026, 10, 28) }
+        };
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(new FixedCommitmentTimeProvider(now));
+        using var owner = await app.CreateAuthenticatedUserAsync($"accept-{scenario}-change@example.com");
+        var evidence = new List<Expense>();
+        foreach (var date in evidenceDates)
+            evidence.Add(await app.SeedExpenseAsync(owner.Id, scenario, 10m, date, "bills"));
+        var commitmentId = await SeedCommitmentAsync(
+            app,
+            owner.Id,
+            evidence,
+            name: $"{scenario} display",
+            expectedDay: scenario == "yearly" ? 28 : 10,
+            cadence: cadence,
+            timingKind: timingKind,
+            expectedDayOfWeek: scenario == "weekly" ? DayOfWeek.Monday : null,
+            expectedMonth: scenario == "yearly" ? 2 : null);
+        foreach (var date in observationDates)
+            await app.SeedExpenseAsync(owner.Id, scenario, 10m, date, "bills");
+        var timing = ChangeFor(await GetChangesAsync(owner.Client), commitmentId).GetProperty("timing");
+        Assert.Equal("proposed_change", timing.GetProperty("state").GetString());
+        var fingerprint = timing.GetProperty("fingerprint").GetString()!;
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/timing/accept", new { fingerprint })).StatusCode);
+
+        using var scope = app.Services.CreateScope();
+        var persisted = await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .Commitments.SingleAsync(value => value.Id == commitmentId);
+        Assert.Equal(timing.GetProperty("proposedTimingKind").GetString(),
+            persisted.TimingKind.ToString().ToLowerInvariant());
+        Assert.Equal(NullableEnumName(persisted.ExpectedDayOfWeek),
+            NullableString(timing.GetProperty("proposedDayOfWeek")));
+        Assert.Equal(persisted.ExpectedDay, NullableInt(timing.GetProperty("proposedDay")));
+        Assert.Equal(persisted.ExpectedMonth, NullableInt(timing.GetProperty("proposedMonth")));
+        Assert.Equal(timing.GetProperty("proposedWindowBeforeDays").GetInt32(), persisted.WindowBeforeDays);
+        Assert.Equal(timing.GetProperty("proposedWindowAfterDays").GetInt32(), persisted.WindowAfterDays);
+        Assert.Equal(cadence, persisted.Cadence);
+        Assert.Equal(CommitmentAmountMode.Fixed, persisted.AmountMode);
+        Assert.Equal(10m, persisted.ExpectedAmount);
+        Assert.Equal(CommitmentLifecycle.Active, persisted.Lifecycle);
+        Assert.Equal($"{scenario} display", persisted.Name);
+    }
+
+    [Fact]
+    public async Task Stale_accept_is_rejected_after_evidence_changes_without_mutating_commitment()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("stale-change@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 5, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 6, 10), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "membership", 10m, new DateOnly(2026, 7, 10), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(app, owner.Id, evidence);
+        var observations = new List<Expense>();
+        foreach (var date in new[] { new DateOnly(2026, 8, 10), new DateOnly(2026, 9, 10), new DateOnly(2026, 10, 10) })
+            observations.Add(await app.SeedExpenseAsync(owner.Id, "membership", 12m, date, "bills"));
+        var fingerprint = ChangeFor(await GetChangesAsync(owner.Client), commitmentId)
+            .GetProperty("amount").GetProperty("fingerprint").GetString()!;
+
+        using (var update = await owner.Client.PutAsJsonAsync($"/api/expenses/{observations[^1].Id}", new
+        {
+            id = observations[^1].Id,
+            description = observations[^1].Description,
+            amount = 13m,
+            date = observations[^1].Date.ToString("yyyy-MM-dd"),
+            category = observations[^1].Category
+        }))
+            update.EnsureSuccessStatusCode();
+        var response = await owner.Client.PostAsJsonAsync(
+            $"/api/commitment-changes/{commitmentId}/amount/accept", new { fingerprint });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.Equal("change_proposal_changed",
+            (await response.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString());
+        using var scope = app.Services.CreateScope();
+        var persisted = await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .Commitments.SingleAsync(value => value.Id == commitmentId);
+        Assert.Equal(10m, persisted.ExpectedAmount);
+    }
+
+    [Fact]
+    public async Task Mark_ended_requires_the_exact_current_possibly_ended_assessment()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("end-change@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "insurance", 25m, new DateOnly(2026, 5, 20), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "insurance", 25m, new DateOnly(2026, 6, 20), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "insurance", 25m, new DateOnly(2026, 7, 20), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(
+            app, owner.Id, evidence, name: "Insurance", expectedDay: 20, expectedAmount: 25m);
+        var fingerprint = ChangeFor(await GetChangesAsync(owner.Client), commitmentId)
+            .GetProperty("missing").GetProperty("fingerprint").GetString()!;
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/missing/mark-ended", new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/missing/mark-ended", new { fingerprint })).StatusCode);
+        using var scope = app.Services.CreateScope();
+        var persisted = await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .Commitments.SingleAsync(value => value.Id == commitmentId);
+        Assert.Equal(CommitmentLifecycle.Ended, persisted.Lifecycle);
+        Assert.Equal(25m, persisted.ExpectedAmount);
+        Assert.Equal(20, persisted.ExpectedDay);
+    }
+
+    [Fact]
+    public async Task Not_seen_recently_can_be_kept_but_cannot_mark_the_commitment_ended()
+    {
+        var clock = new FixedCommitmentTimeProvider(new DateTimeOffset(2026, 9, 29, 18, 0, 0, TimeSpan.Zero));
+        await using var app = new ClockedCommitmentFinancialApiTestApplication(clock);
+        using var owner = await app.CreateAuthenticatedUserAsync("not-seen-change@example.com");
+        var evidence = new[]
+        {
+            await app.SeedExpenseAsync(owner.Id, "insurance", 25m, new DateOnly(2026, 5, 20), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "insurance", 25m, new DateOnly(2026, 6, 20), "bills"),
+            await app.SeedExpenseAsync(owner.Id, "insurance", 25m, new DateOnly(2026, 7, 20), "bills")
+        };
+        var commitmentId = await SeedCommitmentAsync(
+            app, owner.Id, evidence, name: "Insurance", expectedDay: 20, expectedAmount: 25m);
+        var missing = ChangeFor(await GetChangesAsync(owner.Client), commitmentId).GetProperty("missing");
+        Assert.Equal("not_seen_recently", missing.GetProperty("state").GetString());
+        var fingerprint = missing.GetProperty("fingerprint").GetString()!;
+
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/missing/mark-ended", new { fingerprint })).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/missing/keep", new { fingerprint })).StatusCode);
+        Assert.Equal("kept", ChangeFor(await GetChangesAsync(owner.Client), commitmentId)
+            .GetProperty("missing").GetProperty("decisionState").GetString());
+        clock.SetUtcNow(new DateTimeOffset(2026, 10, 29, 18, 0, 0, TimeSpan.Zero));
+        var advanced = ChangeFor(await GetChangesAsync(owner.Client), commitmentId).GetProperty("missing");
+        Assert.Equal("possibly_ended", advanced.GetProperty("state").GetString());
+        Assert.Equal("pending", advanced.GetProperty("decisionState").GetString());
+        Assert.NotEqual(fingerprint, advanced.GetProperty("fingerprint").GetString());
+        Assert.Equal(HttpStatusCode.Conflict,
+            (await owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/missing/keep", new { fingerprint })).StatusCode);
+        using var scope = app.Services.CreateScope();
+        Assert.Equal(CommitmentLifecycle.Active,
+            (await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+                .Commitments.SingleAsync(value => value.Id == commitmentId)).Lifecycle);
     }
 
     [Fact]
@@ -581,7 +992,11 @@ public sealed class CommitmentsApiTests
         string category = "bills",
         int expectedDay = 10,
         decimal expectedAmount = 10m,
-        CommitmentLifecycle lifecycle = CommitmentLifecycle.Active)
+        CommitmentLifecycle lifecycle = CommitmentLifecycle.Active,
+        CommitmentCadence cadence = CommitmentCadence.Monthly,
+        CommitmentTimingKind timingKind = CommitmentTimingKind.DayOfMonth,
+        DayOfWeek? expectedDayOfWeek = null,
+        int? expectedMonth = null)
     {
         using var scope = app.Services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
@@ -593,9 +1008,13 @@ public sealed class CommitmentsApiTests
             Name = name,
             Category = category,
             Lifecycle = lifecycle,
-            Cadence = CommitmentCadence.Monthly,
-            TimingKind = CommitmentTimingKind.DayOfMonth,
-            ExpectedDay = expectedDay,
+            Cadence = cadence,
+            TimingKind = timingKind,
+            ExpectedDayOfWeek = expectedDayOfWeek,
+            ExpectedDay = timingKind is CommitmentTimingKind.DayOfMonth or CommitmentTimingKind.MonthAndDay
+                ? expectedDay
+                : null,
+            ExpectedMonth = expectedMonth,
             WindowBeforeDays = 0,
             WindowAfterDays = 0,
             AmountMode = CommitmentAmountMode.Fixed,
@@ -657,6 +1076,9 @@ public sealed class CommitmentsApiTests
         Assert.Equal("matching_unavailable", change.GetProperty("amount").GetProperty("state").GetString());
         Assert.Equal("matching_unavailable", change.GetProperty("timing").GetProperty("state").GetString());
         Assert.Equal("matching_unavailable", change.GetProperty("missing").GetProperty("state").GetString());
+        Assert.Equal(JsonValueKind.Null, change.GetProperty("amount").GetProperty("decisionState").ValueKind);
+        Assert.Equal(JsonValueKind.Null, change.GetProperty("timing").GetProperty("decisionState").ValueKind);
+        Assert.Equal(JsonValueKind.Null, change.GetProperty("missing").GetProperty("decisionState").ValueKind);
     }
 
     private static DateOnly[] RecentMonthlyDates()
@@ -672,6 +1094,22 @@ public sealed class CommitmentsApiTests
         return Assert.Single(response.GetProperty("candidates").EnumerateArray())
             .GetProperty("fingerprint").GetString()!;
     }
+
+    private static async Task<JsonElement> GetChangesAsync(HttpClient client) =>
+        await client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+
+    private static JsonElement ChangeFor(JsonElement response, Guid commitmentId) =>
+        response.GetProperty("changes").EnumerateArray().Single(value =>
+            value.GetProperty("commitment").GetProperty("id").GetGuid() == commitmentId);
+
+    private static string? NullableString(JsonElement value) =>
+        value.ValueKind == JsonValueKind.Null ? null : value.GetString();
+
+    private static int? NullableInt(JsonElement value) =>
+        value.ValueKind == JsonValueKind.Null ? null : value.GetInt32();
+
+    private static string? NullableEnumName<T>(T? value) where T : struct, Enum =>
+        value?.ToString().ToLowerInvariant();
 
     private static object FixedConfirmation(string fingerprint) => new
     {
@@ -704,5 +1142,9 @@ internal sealed class ClockedCommitmentFinancialApiTestApplication(FixedCommitme
 
 internal sealed class FixedCommitmentTimeProvider(DateTimeOffset utcNow) : TimeProvider
 {
-    public override DateTimeOffset GetUtcNow() => utcNow;
+    private DateTimeOffset _utcNow = utcNow;
+
+    public override DateTimeOffset GetUtcNow() => _utcNow;
+
+    public void SetUtcNow(DateTimeOffset value) => _utcNow = value;
 }

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -720,6 +720,52 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Concurrent_change_accepts_commit_once_and_maps_the_stale_write_to_conflict()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-change-accept-race@example.com");
+        var utcToday = DateTime.UtcNow;
+        var currentAnchor = new DateOnly(utcToday.Year, utcToday.Month, 1);
+        var evidence = new List<Expense>();
+        foreach (var date in new[]
+                 {
+                     currentAnchor.AddMonths(-5),
+                     currentAnchor.AddMonths(-4),
+                     currentAnchor.AddMonths(-3)
+                 })
+            evidence.Add(await app.SeedExpenseAsync(owner.Id, "membership", 10m, date, "bills"));
+        var commitmentId = await SeedChangeCommitmentAsync(app, owner.Id, evidence, expectedDay: 1);
+        foreach (var date in new[]
+                 {
+                     currentAnchor.AddMonths(-2),
+                     currentAnchor.AddMonths(-1),
+                     currentAnchor
+                 })
+            await app.SeedExpenseAsync(owner.Id, "membership", 12m, date, "bills");
+        var changes = await owner.Client.GetFromJsonAsync<JsonElement>("/api/commitment-changes");
+        var change = Assert.Single(changes.GetProperty("changes").EnumerateArray());
+        var fingerprint = change.GetProperty("amount").GetProperty("fingerprint").GetString()!;
+
+        var responses = await Task.WhenAll(
+            owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/accept", new { fingerprint }),
+            owner.Client.PostAsJsonAsync(
+                $"/api/commitment-changes/{commitmentId}/amount/accept", new { fingerprint }));
+
+        Assert.Single(responses, response => response.StatusCode == HttpStatusCode.NoContent);
+        var conflict = Assert.Single(responses, response => response.StatusCode == HttpStatusCode.Conflict);
+        Assert.Equal("change_proposal_changed",
+            (await conflict.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString());
+        using var scope = app.Services.CreateScope();
+        var persisted = await scope.ServiceProvider.GetRequiredService<BudgetContext>()
+            .Commitments.SingleAsync(value => value.Id == commitmentId);
+        Assert.Equal(CommitmentAmountMode.Fixed, persisted.AmountMode);
+        Assert.Equal(12m, persisted.ExpectedAmount);
+        Assert.Equal(CommitmentCadence.Monthly, persisted.Cadence);
+        Assert.Equal(1, persisted.ExpectedDay);
+    }
+
+    [PostgreSqlFact]
     public async Task Concurrent_candidate_confirmations_create_one_commitment_and_return_one_retry()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
@@ -1576,6 +1622,41 @@ public sealed class PostgreSqlFinancialApiTests
         var now = DateTime.UtcNow;
         var current = new DateOnly(now.Year, now.Month, 10);
         return [current.AddMonths(-2), current.AddMonths(-1), current];
+    }
+
+    private static async Task<Guid> SeedChangeCommitmentAsync(
+        FinancialApiTestApplicationBase app,
+        string ownerId,
+        IEnumerable<Expense> evidence,
+        int expectedDay)
+    {
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var now = DateTime.UtcNow.AddYears(-1);
+        var commitment = new Commitment
+        {
+            Id = Guid.NewGuid(),
+            OwnerId = ownerId,
+            Name = "Membership",
+            Category = "bills",
+            Lifecycle = CommitmentLifecycle.Active,
+            Cadence = CommitmentCadence.Monthly,
+            TimingKind = CommitmentTimingKind.DayOfMonth,
+            ExpectedDay = expectedDay,
+            AmountMode = CommitmentAmountMode.Fixed,
+            ExpectedAmount = 10m,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Occurrences = evidence.Select(expense => new CommitmentOccurrence
+            {
+                ExpenseId = expense.Id,
+                Kind = CommitmentOccurrenceKind.ConfirmationEvidence,
+                LinkedAt = now
+            }).ToList()
+        };
+        context.Commitments.Add(commitment);
+        await context.SaveChangesAsync();
+        return commitment.Id;
     }
 
     private static async Task<string> ReadCandidateFingerprintAsync(HttpClient client)

--- a/backend/Commitments/CommitmentService.cs
+++ b/backend/Commitments/CommitmentService.cs
@@ -26,6 +26,18 @@ public interface ICommitmentService
     Task<CommitmentOperation<ConfirmCommitmentResponse>> ConfirmAsync(string ownerId, ConfirmCommitmentRequest request, CancellationToken cancellationToken);
     Task<IReadOnlyList<CommitmentResponse>> GetCommitmentsAsync(string ownerId, CancellationToken cancellationToken);
     Task<CommitmentChangesResponse> GetChangesAsync(string ownerId, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> AcceptAmountChangeAsync(
+        string ownerId, Guid commitmentId, CommitmentChangeDecisionRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> AcceptTimingChangeAsync(
+        string ownerId, Guid commitmentId, CommitmentChangeDecisionRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> MarkEndedFromChangeAsync(
+        string ownerId, Guid commitmentId, CommitmentChangeDecisionRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> KeepChangeAsync(
+        string ownerId, Guid commitmentId, string? dimension,
+        CommitmentChangeDecisionRequest request, CancellationToken cancellationToken);
+    Task<CommitmentOperation<bool>> ReconsiderChangeAsync(
+        string ownerId, Guid commitmentId, string? dimension,
+        CommitmentChangeDecisionRequest request, CancellationToken cancellationToken);
     Task<CommitmentOperation<CommitmentResponse>> UpdateAsync(string ownerId, Guid id, UpdateCommitmentRequest request, CancellationToken cancellationToken);
     Task<CommitmentOperation<CommitmentResponse>> UpdateLifecycleAsync(string ownerId, Guid id, UpdateCommitmentLifecycleRequest request, CancellationToken cancellationToken);
 }
@@ -257,27 +269,144 @@ public sealed class CommitmentService(
         CancellationToken cancellationToken)
     {
         var evaluatedOn = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
-        var commitments = await context.Commitments.AsNoTracking()
-            .Where(value => value.OwnerId == ownerId)
-            .Include(value => value.Occurrences)
-            .OrderBy(value => value.Id)
-            .ToListAsync(cancellationToken);
-        var expenses = await context.Expenses.AsNoTracking()
-            .Where(value => value.UserId == ownerId && value.Date <= evaluatedOn)
-            .ToListAsync(cancellationToken);
-        var expensesById = expenses.ToDictionary(value => value.Id);
-        foreach (var occurrence in commitments.SelectMany(value => value.Occurrences))
-            occurrence.Expense = expensesById.GetValueOrDefault(occurrence.ExpenseId);
-
-        var detections = changeDetector.Detect(ownerId, commitments, expenses, evaluatedOn);
-        var commitmentsById = commitments.ToDictionary(value => value.Id);
-        var importedIds = await LoadImportedExpenseIdsAsync(ownerId, cancellationToken);
+        var state = await LoadChangeStateAsync(ownerId, evaluatedOn, cancellationToken);
+        var commitmentsById = state.Commitments.ToDictionary(value => value.Id);
         return new CommitmentChangesResponse(
             evaluatedOn,
-            detections.Select(detection => ToChangeResponse(
+            state.Detections.Select(detection => ToChangeResponse(
                 detection,
                 commitmentsById[detection.CommitmentId],
-                importedIds)).ToArray());
+                state.ImportedExpenseIds,
+                state.Dismissals)).ToArray());
+    }
+
+    public Task<CommitmentOperation<bool>> AcceptAmountChangeAsync(
+        string ownerId,
+        Guid commitmentId,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        ApplyChangeDecisionAsync(ownerId, commitmentId, CommitmentChangeDimension.Amount,
+            ChangeDecisionAction.Accept, request, cancellationToken);
+
+    public Task<CommitmentOperation<bool>> AcceptTimingChangeAsync(
+        string ownerId,
+        Guid commitmentId,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        ApplyChangeDecisionAsync(ownerId, commitmentId, CommitmentChangeDimension.Timing,
+            ChangeDecisionAction.Accept, request, cancellationToken);
+
+    public Task<CommitmentOperation<bool>> MarkEndedFromChangeAsync(
+        string ownerId,
+        Guid commitmentId,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        ApplyChangeDecisionAsync(ownerId, commitmentId, CommitmentChangeDimension.Missing,
+            ChangeDecisionAction.MarkEnded, request, cancellationToken);
+
+    public Task<CommitmentOperation<bool>> KeepChangeAsync(
+        string ownerId,
+        Guid commitmentId,
+        string? dimension,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        TryParseChangeDimension(dimension, out var parsed)
+            ? ApplyChangeDecisionAsync(ownerId, commitmentId, parsed, ChangeDecisionAction.Keep, request, cancellationToken)
+            : Task.FromResult(InvalidChangeDimension());
+
+    public Task<CommitmentOperation<bool>> ReconsiderChangeAsync(
+        string ownerId,
+        Guid commitmentId,
+        string? dimension,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        TryParseChangeDimension(dimension, out var parsed)
+            ? ApplyChangeDecisionAsync(ownerId, commitmentId, parsed, ChangeDecisionAction.Reconsider, request, cancellationToken)
+            : Task.FromResult(InvalidChangeDimension());
+
+    private async Task<CommitmentOperation<bool>> ApplyChangeDecisionAsync(
+        string ownerId,
+        Guid commitmentId,
+        CommitmentChangeDimension dimension,
+        ChangeDecisionAction action,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseFingerprint(request.Fingerprint, out var fingerprint))
+            return InvalidChangeFingerprint();
+
+        await using var transaction = await BeginSerializableTransactionAsync(cancellationToken);
+        try
+        {
+            var now = clock.GetUtcNow().UtcDateTime;
+            var evaluatedOn = DateOnly.FromDateTime(now);
+            var state = await LoadChangeStateAsync(ownerId, evaluatedOn, cancellationToken);
+            if (state.Commitments.All(value => value.Id != commitmentId))
+            {
+                await RollbackAsync(transaction);
+                return NotFound<bool>();
+            }
+
+            var detection = state.Detections.SingleOrDefault(value => value.CommitmentId == commitmentId);
+            if (detection is null
+                || !IsEligible(detection, dimension, action)
+                || !CurrentFingerprintMatches(detection, dimension, fingerprint))
+            {
+                await RollbackAsync(transaction);
+                return ChangeProposalChanged();
+            }
+
+            var dismissal = state.Dismissals.SingleOrDefault(value =>
+                value.CommitmentId == commitmentId
+                && value.AlgorithmVersion == detection.AlgorithmVersion
+                && value.Dimension == dimension
+                && FingerprintsEqual(value.EvidenceFingerprint, fingerprint));
+
+            if (action == ChangeDecisionAction.Keep)
+            {
+                if (dismissal is null)
+                {
+                    context.CommitmentChangeDismissals.Add(new CommitmentChangeDismissal
+                    {
+                        Id = Guid.NewGuid(),
+                        OwnerId = ownerId,
+                        CommitmentId = commitmentId,
+                        AlgorithmVersion = detection.AlgorithmVersion,
+                        Dimension = dimension,
+                        EvidenceFingerprint = fingerprint,
+                        DismissedAt = now
+                    });
+                    await context.SaveChangesAsync(cancellationToken);
+                }
+            }
+            else if (action == ChangeDecisionAction.Reconsider)
+            {
+                if (dismissal is null)
+                {
+                    await RollbackAsync(transaction);
+                    return ChangeProposalChanged();
+                }
+                context.CommitmentChangeDismissals.Remove(dismissal);
+                await context.SaveChangesAsync(cancellationToken);
+            }
+            else
+            {
+                var commitment = await context.Commitments.SingleAsync(value =>
+                    value.Id == commitmentId && value.OwnerId == ownerId, cancellationToken);
+                ApplyAcceptedChange(commitment, detection, dimension, action);
+                commitment.UpdatedAt = now;
+                await context.SaveChangesAsync(cancellationToken);
+            }
+
+            await CommitAsync(transaction, cancellationToken);
+            return CommitmentOperation<bool>.Success(true);
+        }
+        catch (Exception exception) when (IsConcurrencyConflict(exception))
+        {
+            await RollbackAsync(transaction);
+            context.ChangeTracker.Clear();
+            return ChangeProposalChanged();
+        }
     }
 
     public async Task<CommitmentOperation<CommitmentResponse>> UpdateAsync(
@@ -339,6 +468,32 @@ public sealed class CommitmentService(
             detected,
             linked,
             dismissals,
+            await LoadImportedExpenseIdsAsync(ownerId, cancellationToken));
+    }
+
+    private async Task<ChangeState> LoadChangeStateAsync(
+        string ownerId,
+        DateOnly evaluatedOn,
+        CancellationToken cancellationToken)
+    {
+        var commitments = await context.Commitments.AsNoTracking()
+            .Where(value => value.OwnerId == ownerId)
+            .Include(value => value.Occurrences)
+            .OrderBy(value => value.Id)
+            .ToListAsync(cancellationToken);
+        var expenses = await context.Expenses.AsNoTracking()
+            .Where(value => value.UserId == ownerId && value.Date <= evaluatedOn)
+            .ToListAsync(cancellationToken);
+        var expensesById = expenses.ToDictionary(value => value.Id);
+        foreach (var occurrence in commitments.SelectMany(value => value.Occurrences))
+            occurrence.Expense = expensesById.GetValueOrDefault(occurrence.ExpenseId);
+
+        return new ChangeState(
+            commitments,
+            changeDetector.Detect(ownerId, commitments, expenses, evaluatedOn),
+            await context.CommitmentChangeDismissals.AsNoTracking()
+                .Where(value => value.OwnerId == ownerId)
+                .ToListAsync(cancellationToken),
             await LoadImportedExpenseIdsAsync(ownerId, cancellationToken));
     }
 
@@ -437,7 +592,8 @@ public sealed class CommitmentService(
     private static CommitmentChangeResponse ToChangeResponse(
         CommitmentChangeDetection detection,
         Commitment commitment,
-        IReadOnlySet<int> importedExpenseIds) => new(
+        IReadOnlySet<int> importedExpenseIds,
+        IReadOnlyList<CommitmentChangeDismissal> dismissals) => new(
         new CommitmentChangeSnapshotResponse(
             commitment.Id,
             commitment.Name,
@@ -463,6 +619,7 @@ public sealed class CommitmentService(
         new CommitmentAmountChangeResponse(
             ChangeStateName(detection.Amount.State),
             detection.Amount.Fingerprint,
+            DecisionState(detection, CommitmentChangeDimension.Amount, detection.Amount.Fingerprint, dismissals),
             detection.Amount.ProposedMode is null ? null : EnumName(detection.Amount.ProposedMode.Value),
             detection.Amount.ProposedAmount,
             detection.Amount.ProposedMinimumAmount,
@@ -472,6 +629,7 @@ public sealed class CommitmentService(
         new CommitmentTimingChangeResponse(
             ChangeStateName(detection.Timing.State),
             detection.Timing.Fingerprint,
+            DecisionState(detection, CommitmentChangeDimension.Timing, detection.Timing.Fingerprint, dismissals),
             detection.Timing.ProposedTimingKind is null ? null : EnumName(detection.Timing.ProposedTimingKind.Value),
             detection.Timing.ProposedDayOfWeek is null ? null : EnumName(detection.Timing.ProposedDayOfWeek.Value),
             detection.Timing.ProposedDay,
@@ -482,7 +640,106 @@ public sealed class CommitmentService(
         new CommitmentMissingResponse(
             ChangeStateName(detection.Missing.State),
             detection.Missing.Fingerprint,
+            DecisionState(detection, CommitmentChangeDimension.Missing, detection.Missing.Fingerprint, dismissals),
             detection.Missing.MissedSlotAnchors));
+
+    private static string? DecisionState(
+        CommitmentChangeDetection detection,
+        CommitmentChangeDimension dimension,
+        string? fingerprintText,
+        IReadOnlyList<CommitmentChangeDismissal> dismissals)
+    {
+        if (!IsEligible(detection, dimension, ChangeDecisionAction.Keep)
+            || !TryParseFingerprint(fingerprintText, out var fingerprint))
+            return null;
+
+        return dismissals.Any(value =>
+            value.CommitmentId == detection.CommitmentId
+            && value.AlgorithmVersion == detection.AlgorithmVersion
+            && value.Dimension == dimension
+            && FingerprintsEqual(value.EvidenceFingerprint, fingerprint))
+            ? "kept"
+            : "pending";
+    }
+
+    private static bool IsEligible(
+        CommitmentChangeDetection detection,
+        CommitmentChangeDimension dimension,
+        ChangeDecisionAction action) => dimension switch
+        {
+            CommitmentChangeDimension.Amount =>
+                action != ChangeDecisionAction.MarkEnded
+                && detection.Amount.State == CommitmentChangeState.ProposedChange,
+            CommitmentChangeDimension.Timing =>
+                action != ChangeDecisionAction.MarkEnded
+                && detection.Timing.State == CommitmentChangeState.ProposedChange,
+            CommitmentChangeDimension.Missing when action == ChangeDecisionAction.MarkEnded =>
+                detection.Missing.State == CommitmentChangeState.PossiblyEnded,
+            CommitmentChangeDimension.Missing when action is ChangeDecisionAction.Keep or ChangeDecisionAction.Reconsider =>
+                detection.Missing.State is CommitmentChangeState.NotSeenRecently or CommitmentChangeState.PossiblyEnded,
+            _ => false
+        };
+
+    private static bool CurrentFingerprintMatches(
+        CommitmentChangeDetection detection,
+        CommitmentChangeDimension dimension,
+        byte[] fingerprint)
+    {
+        var current = dimension switch
+        {
+            CommitmentChangeDimension.Amount => detection.Amount.Fingerprint,
+            CommitmentChangeDimension.Timing => detection.Timing.Fingerprint,
+            CommitmentChangeDimension.Missing => detection.Missing.Fingerprint,
+            _ => null
+        };
+        return TryParseFingerprint(current, out var currentFingerprint)
+            && FingerprintsEqual(currentFingerprint, fingerprint);
+    }
+
+    private static void ApplyAcceptedChange(
+        Commitment commitment,
+        CommitmentChangeDetection detection,
+        CommitmentChangeDimension dimension,
+        ChangeDecisionAction action)
+    {
+        if (action == ChangeDecisionAction.MarkEnded)
+        {
+            commitment.Lifecycle = CommitmentLifecycle.Ended;
+            return;
+        }
+
+        if (dimension == CommitmentChangeDimension.Amount)
+        {
+            commitment.AmountMode = detection.Amount.ProposedMode
+                ?? throw new InvalidOperationException("An eligible amount proposal must have an amount mode.");
+            commitment.ExpectedAmount = detection.Amount.ProposedAmount;
+            commitment.ExpectedMinimumAmount = detection.Amount.ProposedMinimumAmount;
+            commitment.ExpectedMaximumAmount = detection.Amount.ProposedMaximumAmount;
+            return;
+        }
+
+        if (dimension == CommitmentChangeDimension.Timing)
+        {
+            commitment.TimingKind = detection.Timing.ProposedTimingKind
+                ?? throw new InvalidOperationException("An eligible timing proposal must have a timing kind.");
+            commitment.ExpectedDayOfWeek = detection.Timing.ProposedDayOfWeek;
+            commitment.ExpectedDay = detection.Timing.ProposedDay;
+            commitment.ExpectedMonth = detection.Timing.ProposedMonth;
+            commitment.WindowBeforeDays = detection.Timing.ProposedWindowBeforeDays
+                ?? throw new InvalidOperationException("An eligible timing proposal must have a before window.");
+            commitment.WindowAfterDays = detection.Timing.ProposedWindowAfterDays
+                ?? throw new InvalidOperationException("An eligible timing proposal must have an after window.");
+        }
+    }
+
+    private static bool TryParseChangeDimension(string? value, out CommitmentChangeDimension dimension)
+    {
+        dimension = default;
+        return value is not null
+            && Enum.GetNames<CommitmentChangeDimension>()
+                .Any(name => name.Equals(value, StringComparison.OrdinalIgnoreCase))
+            && Enum.TryParse(value, true, out dimension);
+    }
 
     private static CommitmentChangeObservationResponse ToChangeObservationResponse(
         CommitmentChangeObservation observation,
@@ -671,7 +928,8 @@ public sealed class CommitmentService(
     private static bool FingerprintsEqual(byte[] left, byte[] right) =>
         left.Length == right.Length && CryptographicOperations.FixedTimeEquals(left, right);
     private static bool IsConcurrencyConflict(Exception exception) =>
-        FindPostgresException(exception)?.SqlState is
+        exception is DbUpdateConcurrencyException
+        || FindPostgresException(exception)?.SqlState is
             PostgresErrorCodes.UniqueViolation or PostgresErrorCodes.SerializationFailure;
 
     private static PostgresException? FindPostgresException(Exception? exception)
@@ -690,6 +948,14 @@ public sealed class CommitmentService(
         CommitmentOperation<T>.Failure("candidate_changed", "The candidate changed or is no longer available.");
     private static CommitmentOperation<T> NotFound<T>() =>
         CommitmentOperation<T>.Failure("commitment_not_found", "Commitment was not found.");
+    private static CommitmentOperation<bool> InvalidChangeFingerprint() =>
+        CommitmentOperation<bool>.Failure("fingerprint_invalid", "Change proposal fingerprint is invalid.");
+    private static CommitmentOperation<bool> InvalidChangeDimension() =>
+        CommitmentOperation<bool>.Failure("dimension_invalid", "Dimension must be amount, timing, or missing.");
+    private static CommitmentOperation<bool> ChangeProposalChanged() =>
+        CommitmentOperation<bool>.Failure(
+            "change_proposal_changed",
+            "The change proposal changed or is no longer available.");
     private static CommitmentOperation<Expectation> InvalidExpectation(string code, string message) =>
         CommitmentOperation<Expectation>.Failure(code, message);
 
@@ -698,6 +964,20 @@ public sealed class CommitmentService(
         HashSet<int> LinkedExpenseIds,
         IReadOnlyList<CommitmentCandidateDismissal> Dismissals,
         HashSet<int> ImportedExpenseIds);
+
+    private sealed record ChangeState(
+        IReadOnlyList<Commitment> Commitments,
+        IReadOnlyList<CommitmentChangeDetection> Detections,
+        IReadOnlyList<CommitmentChangeDismissal> Dismissals,
+        HashSet<int> ImportedExpenseIds);
+
+    private enum ChangeDecisionAction
+    {
+        Accept,
+        MarkEnded,
+        Keep,
+        Reconsider
+    }
 
     private sealed record Expectation(
         string Name,

--- a/backend/Contracts/Commitments/CommitmentChangeContracts.cs
+++ b/backend/Contracts/Commitments/CommitmentChangeContracts.cs
@@ -47,6 +47,7 @@ public sealed record CommitmentChangeObservationResponse(
 public sealed record CommitmentAmountChangeResponse(
     string State,
     string? Fingerprint,
+    string? DecisionState,
     string? ProposedMode,
     decimal? ProposedAmount,
     decimal? ProposedMinimumAmount,
@@ -57,6 +58,7 @@ public sealed record CommitmentAmountChangeResponse(
 public sealed record CommitmentTimingChangeResponse(
     string State,
     string? Fingerprint,
+    string? DecisionState,
     string? ProposedTimingKind,
     string? ProposedDayOfWeek,
     int? ProposedDay,
@@ -68,4 +70,7 @@ public sealed record CommitmentTimingChangeResponse(
 public sealed record CommitmentMissingResponse(
     string State,
     string? Fingerprint,
+    string? DecisionState,
     IReadOnlyList<DateOnly> MissedSlotAnchors);
+
+public sealed record CommitmentChangeDecisionRequest(string? Fingerprint);

--- a/backend/Controllers/CommitmentsController.cs
+++ b/backend/Controllers/CommitmentsController.cs
@@ -74,6 +74,48 @@ public sealed class CommitmentsController(ICommitmentService commitments) : Cont
             : Ok(await commitments.GetChangesAsync(ownerId, cancellationToken));
     }
 
+    [HttpPost("commitment-changes/{commitmentId:guid}/amount/accept")]
+    public async Task<IActionResult> AcceptAmountChange(
+        Guid commitmentId,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        await ChangeDecisionResult(
+            ownerId => commitments.AcceptAmountChangeAsync(ownerId, commitmentId, request, cancellationToken));
+
+    [HttpPost("commitment-changes/{commitmentId:guid}/timing/accept")]
+    public async Task<IActionResult> AcceptTimingChange(
+        Guid commitmentId,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        await ChangeDecisionResult(
+            ownerId => commitments.AcceptTimingChangeAsync(ownerId, commitmentId, request, cancellationToken));
+
+    [HttpPost("commitment-changes/{commitmentId:guid}/missing/mark-ended")]
+    public async Task<IActionResult> MarkEndedFromChange(
+        Guid commitmentId,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        await ChangeDecisionResult(
+            ownerId => commitments.MarkEndedFromChangeAsync(ownerId, commitmentId, request, cancellationToken));
+
+    [HttpPost("commitment-changes/{commitmentId:guid}/{dimension}/keep")]
+    public async Task<IActionResult> KeepChange(
+        Guid commitmentId,
+        string dimension,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        await ChangeDecisionResult(
+            ownerId => commitments.KeepChangeAsync(ownerId, commitmentId, dimension, request, cancellationToken));
+
+    [HttpPost("commitment-changes/{commitmentId:guid}/{dimension}/reconsider")]
+    public async Task<IActionResult> ReconsiderChange(
+        Guid commitmentId,
+        string dimension,
+        CommitmentChangeDecisionRequest request,
+        CancellationToken cancellationToken) =>
+        await ChangeDecisionResult(
+            ownerId => commitments.ReconsiderChangeAsync(ownerId, commitmentId, dimension, request, cancellationToken));
+
     [HttpPut("commitments/{id:guid}")]
     public async Task<IActionResult> Update(
         Guid id,
@@ -100,15 +142,24 @@ public sealed class CommitmentsController(ICommitmentService commitments) : Cont
 
     private string? OwnerId() => User.FindFirstValue(ClaimTypes.NameIdentifier);
 
+    private async Task<IActionResult> ChangeDecisionResult(
+        Func<string, Task<CommitmentOperation<bool>>> operation)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await operation(ownerId);
+        return result.IsSuccess ? NoContent() : ErrorResult(result.Error!);
+    }
+
     private IActionResult ErrorResult(CommitmentError error)
     {
         var status = error.Code switch
         {
             "commitment_not_found" => StatusCodes.Status404NotFound,
-            "candidate_changed" or "candidate_dismissed" or "confirmation_conflict" =>
+            "candidate_changed" or "candidate_dismissed" or "confirmation_conflict" or "change_proposal_changed" =>
                 StatusCodes.Status409Conflict,
             "fingerprint_invalid" or "name_invalid" or "category_invalid" or "cadence_invalid"
-                or "timing_invalid" or "amount_invalid" or "lifecycle_invalid" =>
+                or "timing_invalid" or "amount_invalid" or "lifecycle_invalid" or "dimension_invalid" =>
                 StatusCodes.Status400BadRequest,
             _ => StatusCodes.Status422UnprocessableEntity
         };

--- a/docs/commitment-intelligence.md
+++ b/docs/commitment-intelligence.md
@@ -141,10 +141,8 @@ Non-normal assessments use a SHA-256 fingerprint with an explicit domain and
 algorithm version. It serializes exact semantic baseline fields (not broad
 `UpdatedAt`, name, or display category), derived identity, ordered confirmation
 and qualified Expense IDs with evidence revisions, relevant closed slots, and
-the exact assessment result. A future action boundary must recompute this
-authoritatively and reject stale decisions. A user-visible workflow remains
-blocked until accept/end, durable keep/dismiss, reconsider, and stale-conflict
-handling can ship coherently under separate approval.
+the exact assessment result. The action boundary recomputes this
+authoritatively and rejects stale decisions.
 
 Each read captures one UTC calendar date and returns it as `evaluatedOn`. Every
 active-commitment result contains the exact commitment snapshot supplied to the
@@ -182,3 +180,36 @@ Production rollback is not automatic. Application rollback does not remove
 the table, and removing an empty or inert table requires a separately reviewed
 corrective migration. Once durable dismissal rows can exist, they must not be
 deleted by deployment tooling or an unreviewed migration rollback.
+
+### Authoritative change decisions
+
+The backend change-review slice makes the read response dismissal-aware. Each
+actionable amount, timing, or missing assessment reports `decisionState` as
+`pending` or `kept`; non-actionable assessments report no decision state. A
+row is current only when owner, commitment, detector version, dimension, and
+fingerprint all match the recomputed assessment. Old rows remain inert and are
+not pruned by reads.
+
+Authenticated action requests contain only the exact assessment fingerprint.
+The service captures one UTC time, opens a serializable relational transaction,
+reloads the same owner-scoped commitments, links, Expenses, provenance, and
+dismissals used by the read path, and invokes the detector once. It returns
+`404 commitment_not_found` for a missing or foreign commitment and
+`409 change_proposal_changed` for a missing, stale, ineligible, or concurrently
+changed assessment. Invalid fingerprints or dimensions return `400`.
+
+Amount and timing accepts require a current `proposed_change` and copy only the
+detector-proposed fields for that dimension. Timing acceptance never changes
+cadence. Mark-ended requires current `possibly_ended` missing evidence and
+changes only lifecycle. These mutations update `UpdatedAt`; an exact retry is
+stale. Keep is valid for amount/timing proposals and `not_seen_recently` or
+`possibly_ended` missing assessments, persists only the exact dismissal tuple,
+and is sequentially idempotent. Reconsider requires and deletes that same
+current exact tuple. Accept and mark-ended never create dismissals.
+
+This backend capability does not itself authorize deployment or UI exposure.
+Its artifact must not be deployed until the target database is verified at or
+beyond `20260830053939_AddCommitmentChangeDismissals`. The complete frontend
+workflow remains a separately scoped, default-off implementation slice, and
+production migration, deployment, and flag enablement require separate owner
+authorization.


### PR DESCRIPTION
## Summary

- make `GET /api/commitment-changes` dismissal-aware with exact `pending` / `kept` decision state
- add exact-fingerprint amount/timing accept, missing mark-ended, keep, and reconsider endpoints
- recompute owner-scoped detector state inside serializable writes and map stale or concurrent decisions to `409 change_proposal_changed`
- cover fixed/range amount updates, weekly/monthly/month-end/yearly timing updates, missing decisions, privacy, staleness, and PostgreSQL concurrency

Implements the authorized PR2 backend slice of #101. Issue #101 remains open for the separately scoped frontend and cleanup slices.

## Risk classification

HIGH — financial baseline and lifecycle mutations. Implementation follows the owner-approved plan recorded on issue #101.

## Important implementation details

- owner identity comes only from the authenticated claim; commitments, Expenses, confirmation links, provenance, and dismissals are owner-scoped before detection
- every action accepts only a fingerprint, captures one UTC time, recomputes once, and applies only the requested dimension
- accept/end retries are stale; keep is sequentially idempotent; reconsider requires the exact current persisted keep
- obsolete dismissal rows remain inert and reads do not prune them

## Verification

Passed locally:

- `./scripts/verify.sh backend` — 302 tests
- `./scripts/verify.sh postgresql` — safety guard plus 27 PostgreSQL integration tests
- focused `CommitmentsApiTests` — 24 tests
- `git diff --check`

Required CI (passed):

- Backend build and tests
- Frontend test, lint, and build
- PostgreSQL financial integration

## Scope boundaries

No detector-semantic changes, frontend workflow, feature-flag change, new dependency, schema/migration change, production migration, deployment, production access/data operation, or merge.

## Release prerequisite

This backend artifact must not be deployed until the target database is verified at or beyond `20260830053939_AddCommitmentChangeDismissals`. Production migration and deployment remain separately unauthorized.