### PR TITLE
Add account inflow persistence foundation

### DIFF
--- a/backend.Tests/Financial/AccountInflowTests.cs
+++ b/backend.Tests/Financial/AccountInflowTests.cs
@@ -1,0 +1,59 @@
+using BudgetPlanner.Models;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+public sealed class AccountInflowTests
+{
+    [Fact]
+    public void New_inflows_receive_distinct_nonempty_evidence_revisions()
+    {
+        var first = new AccountInflow();
+        var second = new AccountInflow();
+
+        Assert.NotEqual(Guid.Empty, first.PaycheckEvidenceRevision);
+        Assert.NotEqual(Guid.Empty, second.PaycheckEvidenceRevision);
+        Assert.NotEqual(first.PaycheckEvidenceRevision, second.PaycheckEvidenceRevision);
+    }
+
+    [Fact]
+    public void UpdateEvidence_preserves_revision_for_equivalent_description_formatting()
+    {
+        var inflow = Inflow();
+        var revision = inflow.PaycheckEvidenceRevision;
+
+        var changed = inflow.UpdateEvidence(
+            "  weekly\tpayroll  ",
+            inflow.Amount,
+            inflow.Date);
+
+        Assert.False(changed);
+        Assert.Equal(revision, inflow.PaycheckEvidenceRevision);
+        Assert.Equal("weekly\tpayroll", inflow.Description);
+    }
+
+    [Fact]
+    public void UpdateEvidence_rotates_revision_for_each_material_evidence_change()
+    {
+        var inflow = Inflow();
+        var originalRevision = inflow.PaycheckEvidenceRevision;
+
+        Assert.True(inflow.UpdateEvidence("Different payroll", inflow.Amount, inflow.Date));
+        var descriptionRevision = inflow.PaycheckEvidenceRevision;
+        Assert.NotEqual(originalRevision, descriptionRevision);
+
+        Assert.True(inflow.UpdateEvidence(inflow.Description, inflow.Amount + 1m, inflow.Date));
+        var amountRevision = inflow.PaycheckEvidenceRevision;
+        Assert.NotEqual(descriptionRevision, amountRevision);
+
+        Assert.True(inflow.UpdateEvidence(inflow.Description, inflow.Amount, inflow.Date.AddDays(1)));
+        Assert.NotEqual(amountRevision, inflow.PaycheckEvidenceRevision);
+    }
+
+    private static AccountInflow Inflow() => new()
+    {
+        Description = "Weekly   Payroll",
+        Amount = 1250.25m,
+        Date = new DateOnly(2026, 9, 1)
+    };
+}

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -219,7 +219,9 @@ public sealed class PostgreSqlFinancialApiTests
             [
                 "BatchId:uuid:NO",
                 "SourceRowOrdinal:integer:NO",
-                "AccountInflowId:integer:YES"
+                "OwnerId:text:NO",
+                "AccountInflowId:integer:YES",
+                "AccountInflowOwnerId:text:YES"
             ],
             inflowProvenanceColumns);
         Assert.Equal(
@@ -227,10 +229,13 @@ public sealed class PostgreSqlFinancialApiTests
             await ReadConstraintDefinitionAsync(context, "PK_ImportInflowProvenances"));
         Assert.Contains("ON DELETE CASCADE", await ReadConstraintDefinitionAsync(
             context,
-            "FK_ImportInflowProvenances_ImportPreviewBatches_BatchId"));
+            "FK_ImportInflowProvenance_Batch_Owner"));
         Assert.Contains("ON DELETE SET NULL", await ReadConstraintDefinitionAsync(
             context,
-            "FK_ImportInflowProvenances_AccountInflows_AccountInflowId"));
+            "FK_ImportInflowProvenance_AccountInflow_Owner"));
+        Assert.Contains("\"AccountInflowOwnerId\" = \"OwnerId\"", await ReadConstraintDefinitionAsync(
+            context,
+            "CK_ImportInflowProvenance_OwnerConsistency"));
         var inflowProvenanceIndex = await ReadIndexDefinitionAsync(
             context,
             "IX_ImportInflowProvenances_AccountInflowId");
@@ -354,6 +359,29 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Equal(new DateOnly(2026, 9, 1), persisted.Date);
         Assert.NotEqual(Guid.Empty, persisted.PaycheckEvidenceRevision);
 
+        using var otherOwner = await app.CreateAuthenticatedUserAsync("account-inflow-other-owner@example.com");
+        var otherOwnerInflow = new AccountInflow
+        {
+            OwnerId = otherOwner.Id,
+            Description = "OTHER OWNER DEPOSIT",
+            Amount = 500m,
+            Date = new DateOnly(2026, 9, 1)
+        };
+        context.AccountInflows.Add(otherOwnerInflow);
+        await context.SaveChangesAsync();
+
+        var crossOwnerLink = await Assert.ThrowsAsync<PostgresException>(() =>
+            context.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "ImportInflowProvenances"
+                    ("BatchId", "SourceRowOrdinal", "OwnerId", "AccountInflowId", "AccountInflowOwnerId")
+                VALUES ({batch.Id}, {2}, {owner.Id}, {otherOwnerInflow.Id}, {otherOwner.Id})
+                """));
+        Assert.Equal(PostgresErrorCodes.CheckViolation, crossOwnerLink.SqlState);
+        Assert.Equal("CK_ImportInflowProvenance_OwnerConsistency", crossOwnerLink.ConstraintName);
+        context.AccountInflows.Remove(otherOwnerInflow);
+        await context.SaveChangesAsync();
+
         Task InsertInflowAsync(string description, decimal amount) =>
             context.Database.ExecuteSqlInterpolatedAsync(
                 $"""
@@ -374,8 +402,9 @@ public sealed class PostgreSqlFinancialApiTests
         var invalidOrdinal = await Assert.ThrowsAsync<PostgresException>(() =>
             context.Database.ExecuteSqlInterpolatedAsync(
                 $"""
-                INSERT INTO "ImportInflowProvenances" ("BatchId", "SourceRowOrdinal", "AccountInflowId")
-                VALUES ({batch.Id}, {0}, {persisted.Id})
+                INSERT INTO "ImportInflowProvenances"
+                    ("BatchId", "SourceRowOrdinal", "OwnerId", "AccountInflowId", "AccountInflowOwnerId")
+                VALUES ({batch.Id}, {0}, {owner.Id}, {persisted.Id}, {owner.Id})
                 """));
         Assert.Equal(PostgresErrorCodes.CheckViolation, invalidOrdinal.SqlState);
         Assert.Equal("CK_ImportInflowProvenance_PositiveSourceRowOrdinal", invalidOrdinal.ConstraintName);
@@ -383,8 +412,9 @@ public sealed class PostgreSqlFinancialApiTests
         var duplicateLink = await Assert.ThrowsAsync<PostgresException>(() =>
             context.Database.ExecuteSqlInterpolatedAsync(
                 $"""
-                INSERT INTO "ImportInflowProvenances" ("BatchId", "SourceRowOrdinal", "AccountInflowId")
-                VALUES ({batch.Id}, {2}, {persisted.Id})
+                INSERT INTO "ImportInflowProvenances"
+                    ("BatchId", "SourceRowOrdinal", "OwnerId", "AccountInflowId", "AccountInflowOwnerId")
+                VALUES ({batch.Id}, {2}, {owner.Id}, {persisted.Id}, {owner.Id})
                 """));
         Assert.Equal(PostgresErrorCodes.UniqueViolation, duplicateLink.SqlState);
         Assert.Equal("IX_ImportInflowProvenances_AccountInflowId", duplicateLink.ConstraintName);
@@ -398,7 +428,10 @@ public sealed class PostgreSqlFinancialApiTests
         context.AccountInflows.Remove(await context.AccountInflows.SingleAsync());
         await context.SaveChangesAsync();
         context.ChangeTracker.Clear();
-        Assert.Null((await context.ImportInflowProvenances.AsNoTracking().SingleAsync()).AccountInflowId);
+        var retainedProvenance = await context.ImportInflowProvenances.AsNoTracking().SingleAsync();
+        Assert.Equal(owner.Id, retainedProvenance.OwnerId);
+        Assert.Null(retainedProvenance.AccountInflowId);
+        Assert.Null(retainedProvenance.AccountInflowOwnerId);
 
         var secondInflow = new AccountInflow
         {
@@ -411,6 +444,7 @@ public sealed class PostgreSqlFinancialApiTests
         context.ImportInflowProvenances.Add(new ImportInflowProvenance
         {
             BatchId = batch.Id,
+            OwnerId = owner.Id,
             SourceRowOrdinal = 2,
             AccountInflow = secondInflow
         });

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -159,6 +159,85 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Contains("(\"ExpenseId\")", provenanceExpenseIndex);
         Assert.Contains("WHERE (\"ExpenseId\" IS NOT NULL)", provenanceExpenseIndex);
 
+        var inflowAmountType = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT data_type || ':' || numeric_precision || ':' || numeric_scale AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'AccountInflows'
+              AND column_name = 'Amount'
+            """).SingleAsync();
+        Assert.Equal("numeric:18:2", inflowAmountType);
+
+        var inflowDateType = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT data_type AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'AccountInflows'
+              AND column_name = 'Date'
+            """).SingleAsync();
+        Assert.Equal("date", inflowDateType);
+
+        var paycheckEvidenceRevision = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT data_type || ':' || is_nullable || ':' || (column_default LIKE '%gen_random_uuid%') AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'AccountInflows'
+              AND column_name = 'PaycheckEvidenceRevision'
+            """).SingleAsync();
+        Assert.Equal("uuid:NO:true", paycheckEvidenceRevision);
+
+        Assert.Contains("\"Amount\" >", await ReadConstraintDefinitionAsync(
+            context,
+            "CK_AccountInflow_PositiveAmount"));
+        var inflowDescriptionCheck = await ReadConstraintDefinitionAsync(
+            context,
+            "CK_AccountInflow_Description");
+        Assert.Contains("btrim", inflowDescriptionCheck);
+        Assert.Contains("\"Description\"", inflowDescriptionCheck);
+        Assert.Contains("ON DELETE CASCADE", await ReadConstraintDefinitionAsync(
+            context,
+            "FK_AccountInflows_AspNetUsers_OwnerId"));
+
+        var inflowOwnerDateIndex = await ReadIndexDefinitionAsync(
+            context,
+            "IX_AccountInflows_OwnerId_Date");
+        Assert.Contains("CREATE INDEX", inflowOwnerDateIndex);
+        Assert.Contains("(\"OwnerId\", \"Date\")", inflowOwnerDateIndex);
+
+        var inflowProvenanceColumns = await context.Database.SqlQueryRaw<string>(
+            """
+            SELECT column_name || ':' || data_type || ':' || is_nullable AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'ImportInflowProvenances'
+            ORDER BY ordinal_position
+            """).ToListAsync();
+        Assert.Equal(
+            [
+                "BatchId:uuid:NO",
+                "SourceRowOrdinal:integer:NO",
+                "AccountInflowId:integer:YES"
+            ],
+            inflowProvenanceColumns);
+        Assert.Equal(
+            "PRIMARY KEY (\"BatchId\", \"SourceRowOrdinal\")",
+            await ReadConstraintDefinitionAsync(context, "PK_ImportInflowProvenances"));
+        Assert.Contains("ON DELETE CASCADE", await ReadConstraintDefinitionAsync(
+            context,
+            "FK_ImportInflowProvenances_ImportPreviewBatches_BatchId"));
+        Assert.Contains("ON DELETE SET NULL", await ReadConstraintDefinitionAsync(
+            context,
+            "FK_ImportInflowProvenances_AccountInflows_AccountInflowId"));
+        var inflowProvenanceIndex = await ReadIndexDefinitionAsync(
+            context,
+            "IX_ImportInflowProvenances_AccountInflowId");
+        Assert.Contains("CREATE UNIQUE INDEX", inflowProvenanceIndex);
+        Assert.Contains("(\"AccountInflowId\")", inflowProvenanceIndex);
+        Assert.Contains("WHERE (\"AccountInflowId\" IS NOT NULL)", inflowProvenanceIndex);
+
         Assert.Contains("CHECK", await ReadConstraintDefinitionAsync(context, "CK_Commitment_Timing"));
         Assert.Contains("CHECK", await ReadConstraintDefinitionAsync(context, "CK_Commitment_Amount"));
         Assert.Contains("ON DELETE CASCADE", await ReadConstraintDefinitionAsync(
@@ -200,6 +279,152 @@ public sealed class PostgreSqlFinancialApiTests
         Assert.Contains(
             "(\"OwnerId\", \"CommitmentId\", \"AlgorithmVersion\", \"Dimension\", \"EvidenceFingerprint\")",
             changeDismissalUniqueIndex);
+    }
+
+    [PostgreSqlFact]
+    public async Task Account_inflow_foundation_migration_upgrades_additively()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var migrator = context.GetService<IMigrator>();
+
+        await context.Database.EnsureDeletedAsync();
+        await migrator.MigrateAsync("20260830053939_AddCommitmentChangeDismissals");
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO "AspNetUsers"
+                ("Id", "EmailConfirmed", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled", "AccessFailedCount")
+            VALUES
+                ('account-inflow-migration-user', false, false, false, false, 0);
+
+            INSERT INTO "Expenses" ("Description", "Amount", "Date", "Category", "UserId")
+            VALUES
+                ('existing expense', 10.00, DATE '2026-09-01', 'food', 'account-inflow-migration-user');
+            """);
+
+        await migrator.MigrateAsync();
+
+        Assert.True(await context.Users.AnyAsync(value => value.Id == "account-inflow-migration-user"));
+        Assert.True(await context.Expenses.AnyAsync(value => value.UserId == "account-inflow-migration-user"));
+        Assert.Empty(await context.AccountInflows.ToListAsync());
+        Assert.Empty(await context.ImportInflowProvenances.ToListAsync());
+        Assert.False((await context.Database.GetPendingMigrationsAsync()).Any());
+    }
+
+    [PostgreSqlFact]
+    public async Task Account_inflow_foundation_enforces_constraints_provenance_and_safe_rollback()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("account-inflow-owner@example.com");
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var now = DateTime.UtcNow;
+        var batch = new ImportPreviewBatch
+        {
+            Id = Guid.NewGuid(),
+            OwnerId = owner.Id,
+            SourceType = SunflowerStatementParser.SourceType,
+            ParserRuleVersion = SunflowerStatementParser.RuleVersion,
+            DocumentDigest = Enumerable.Repeat((byte)1, 32).ToArray(),
+            CreatedAt = now,
+            ExpiresAt = now.AddMinutes(30),
+            Lifecycle = ImportPreviewLifecycle.Open
+        };
+        var inflow = new AccountInflow
+        {
+            OwnerId = owner.Id,
+            Description = "SYNTHETIC PAYROLL DEPOSIT",
+            Amount = 2450m,
+            Date = new DateOnly(2026, 9, 1)
+        };
+        batch.InflowProvenance.Add(new ImportInflowProvenance
+        {
+            SourceRowOrdinal = 1,
+            AccountInflow = inflow
+        });
+        context.ImportPreviewBatches.Add(batch);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        var persisted = await context.AccountInflows.AsNoTracking().SingleAsync();
+        Assert.Equal(owner.Id, persisted.OwnerId);
+        Assert.Equal(2450m, persisted.Amount);
+        Assert.Equal(new DateOnly(2026, 9, 1), persisted.Date);
+        Assert.NotEqual(Guid.Empty, persisted.PaycheckEvidenceRevision);
+
+        Task InsertInflowAsync(string description, decimal amount) =>
+            context.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "AccountInflows" ("OwnerId", "Description", "Amount", "Date")
+                VALUES ({owner.Id}, {description}, {amount}, DATE '2026-09-02')
+                """);
+
+        var nonPositive = await Assert.ThrowsAsync<PostgresException>(() =>
+            InsertInflowAsync("invalid amount", 0m));
+        Assert.Equal(PostgresErrorCodes.CheckViolation, nonPositive.SqlState);
+        Assert.Equal("CK_AccountInflow_PositiveAmount", nonPositive.ConstraintName);
+
+        var blankDescription = await Assert.ThrowsAsync<PostgresException>(() =>
+            InsertInflowAsync("   ", 1m));
+        Assert.Equal(PostgresErrorCodes.CheckViolation, blankDescription.SqlState);
+        Assert.Equal("CK_AccountInflow_Description", blankDescription.ConstraintName);
+
+        var invalidOrdinal = await Assert.ThrowsAsync<PostgresException>(() =>
+            context.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "ImportInflowProvenances" ("BatchId", "SourceRowOrdinal", "AccountInflowId")
+                VALUES ({batch.Id}, {0}, {persisted.Id})
+                """));
+        Assert.Equal(PostgresErrorCodes.CheckViolation, invalidOrdinal.SqlState);
+        Assert.Equal("CK_ImportInflowProvenance_PositiveSourceRowOrdinal", invalidOrdinal.ConstraintName);
+
+        var duplicateLink = await Assert.ThrowsAsync<PostgresException>(() =>
+            context.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "ImportInflowProvenances" ("BatchId", "SourceRowOrdinal", "AccountInflowId")
+                VALUES ({batch.Id}, {2}, {persisted.Id})
+                """));
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, duplicateLink.SqlState);
+        Assert.Equal("IX_ImportInflowProvenances_AccountInflowId", duplicateLink.ConstraintName);
+
+        var migrator = context.GetService<IMigrator>();
+        var rollback = await Assert.ThrowsAsync<PostgresException>(() =>
+            migrator.MigrateAsync("20260830053939_AddCommitmentChangeDismissals"));
+        Assert.Contains("Cannot roll back account inflow foundation", rollback.MessageText);
+        Assert.Single(await context.AccountInflows.AsNoTracking().ToListAsync());
+
+        context.AccountInflows.Remove(await context.AccountInflows.SingleAsync());
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        Assert.Null((await context.ImportInflowProvenances.AsNoTracking().SingleAsync()).AccountInflowId);
+
+        var secondInflow = new AccountInflow
+        {
+            OwnerId = owner.Id,
+            Description = "SECOND SYNTHETIC DEPOSIT",
+            Amount = 100m,
+            Date = new DateOnly(2026, 9, 2)
+        };
+        context.AccountInflows.Add(secondInflow);
+        context.ImportInflowProvenances.Add(new ImportInflowProvenance
+        {
+            BatchId = batch.Id,
+            SourceRowOrdinal = 2,
+            AccountInflow = secondInflow
+        });
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        context.ImportPreviewBatches.Remove(await context.ImportPreviewBatches.SingleAsync());
+        await context.SaveChangesAsync();
+        Assert.Empty(await context.ImportInflowProvenances.AsNoTracking().ToListAsync());
+        Assert.Single(await context.AccountInflows.AsNoTracking().ToListAsync());
+
+        context.Users.Remove(await context.Users.SingleAsync(value => value.Id == owner.Id));
+        await context.SaveChangesAsync();
+        Assert.Empty(await context.AccountInflows.AsNoTracking().ToListAsync());
     }
 
     [PostgreSqlFact]

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -10,11 +10,13 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
     public BudgetContext(DbContextOptions<BudgetContext> options) : base(options) {}
 
     public DbSet<Expense> Expenses { get; set; }
+    public DbSet<AccountInflow> AccountInflows { get; set; }
     public DbSet<BudgetLimit> BudgetLimits { get; set; }
     public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
     public DbSet<ImportPreviewBatch> ImportPreviewBatches { get; set; }
     public DbSet<ImportPreviewRow> ImportPreviewRows { get; set; }
     public DbSet<ImportExpenseProvenance> ImportExpenseProvenances { get; set; }
+    public DbSet<ImportInflowProvenance> ImportInflowProvenances { get; set; }
     public DbSet<Commitment> Commitments { get; set; }
     public DbSet<CommitmentOccurrence> CommitmentOccurrences { get; set; }
     public DbSet<CommitmentCandidateDismissal> CommitmentCandidateDismissals { get; set; }
@@ -45,6 +47,27 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             .WithMany()
             .HasForeignKey(e => e.UserId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<AccountInflow>(inflow =>
+        {
+            inflow.ToTable(table =>
+            {
+                table.HasCheckConstraint(
+                    "CK_AccountInflow_PositiveAmount",
+                    "\"Amount\" > 0");
+                table.HasCheckConstraint(
+                    "CK_AccountInflow_Description",
+                    "length(btrim(\"Description\")) > 0");
+            });
+            inflow.Property(value => value.Description).HasMaxLength(500);
+            inflow.Property(value => value.Amount).HasColumnType("numeric(18,2)");
+            inflow.Property(value => value.Date).HasColumnType("date");
+            inflow.Property(value => value.PaycheckEvidenceRevision)
+                .HasDefaultValueSql("gen_random_uuid()");
+            inflow.HasOne(value => value.Owner).WithMany().HasForeignKey(value => value.OwnerId)
+                .OnDelete(DeleteBehavior.Cascade);
+            inflow.HasIndex(value => new { value.OwnerId, value.Date });
+        });
 
         modelBuilder.Entity<ImportPreviewBatch>(batch =>
         {
@@ -127,6 +150,25 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             provenance.HasIndex(value => value.ExpenseId)
                 .IsUnique()
                 .HasFilter("\"ExpenseId\" IS NOT NULL");
+        });
+
+        modelBuilder.Entity<ImportInflowProvenance>(provenance =>
+        {
+            provenance.ToTable(table => table.HasCheckConstraint(
+                "CK_ImportInflowProvenance_PositiveSourceRowOrdinal",
+                "\"SourceRowOrdinal\" > 0"));
+            provenance.HasKey(value => new { value.BatchId, value.SourceRowOrdinal });
+            provenance.HasOne(value => value.Batch)
+                .WithMany(value => value.InflowProvenance)
+                .HasForeignKey(value => value.BatchId)
+                .OnDelete(DeleteBehavior.Cascade);
+            provenance.HasOne(value => value.AccountInflow)
+                .WithMany()
+                .HasForeignKey(value => value.AccountInflowId)
+                .OnDelete(DeleteBehavior.SetNull);
+            provenance.HasIndex(value => value.AccountInflowId)
+                .IsUnique()
+                .HasFilter("\"AccountInflowId\" IS NOT NULL");
         });
 
         modelBuilder.Entity<Commitment>(commitment =>

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -64,6 +64,8 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             inflow.Property(value => value.Date).HasColumnType("date");
             inflow.Property(value => value.PaycheckEvidenceRevision)
                 .HasDefaultValueSql("gen_random_uuid()");
+            inflow.HasAlternateKey(value => new { value.Id, value.OwnerId })
+                .HasName("AK_AccountInflows_Id_OwnerId");
             inflow.HasOne(value => value.Owner).WithMany().HasForeignKey(value => value.OwnerId)
                 .OnDelete(DeleteBehavior.Cascade);
             inflow.HasIndex(value => new { value.OwnerId, value.Date });
@@ -85,6 +87,8 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             batch.Property(value => value.ParserRuleVersion).HasMaxLength(100);
             batch.Property(value => value.DocumentDigest).HasColumnType("bytea").HasMaxLength(32);
             batch.Property(value => value.Lifecycle).HasConversion<string>().HasMaxLength(20);
+            batch.HasAlternateKey(value => new { value.Id, value.OwnerId })
+                .HasName("AK_ImportPreviewBatches_Id_OwnerId");
             batch.HasOne(value => value.Owner).WithMany().HasForeignKey(value => value.OwnerId)
                 .OnDelete(DeleteBehavior.Cascade);
             batch.HasIndex(value => new { value.OwnerId, value.SourceType, value.DocumentDigest })
@@ -154,17 +158,29 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
 
         modelBuilder.Entity<ImportInflowProvenance>(provenance =>
         {
-            provenance.ToTable(table => table.HasCheckConstraint(
-                "CK_ImportInflowProvenance_PositiveSourceRowOrdinal",
-                "\"SourceRowOrdinal\" > 0"));
+            provenance.ToTable(table =>
+            {
+                table.HasCheckConstraint(
+                    "CK_ImportInflowProvenance_PositiveSourceRowOrdinal",
+                    "\"SourceRowOrdinal\" > 0");
+                table.HasCheckConstraint(
+                    "CK_ImportInflowProvenance_OwnerConsistency",
+                    "(\"AccountInflowId\" IS NULL AND \"AccountInflowOwnerId\" IS NULL) OR " +
+                    "(\"AccountInflowId\" IS NOT NULL AND \"AccountInflowOwnerId\" IS NOT NULL AND " +
+                    "\"AccountInflowOwnerId\" = \"OwnerId\")");
+            });
             provenance.HasKey(value => new { value.BatchId, value.SourceRowOrdinal });
             provenance.HasOne(value => value.Batch)
                 .WithMany(value => value.InflowProvenance)
-                .HasForeignKey(value => value.BatchId)
+                .HasForeignKey(value => new { value.BatchId, value.OwnerId })
+                .HasPrincipalKey(value => new { value.Id, value.OwnerId })
+                .HasConstraintName("FK_ImportInflowProvenance_Batch_Owner")
                 .OnDelete(DeleteBehavior.Cascade);
             provenance.HasOne(value => value.AccountInflow)
                 .WithMany()
-                .HasForeignKey(value => value.AccountInflowId)
+                .HasForeignKey(value => new { value.AccountInflowId, value.AccountInflowOwnerId })
+                .HasPrincipalKey(value => new { value.Id, value.OwnerId })
+                .HasConstraintName("FK_ImportInflowProvenance_AccountInflow_Owner")
                 .OnDelete(DeleteBehavior.SetNull);
             provenance.HasIndex(value => value.AccountInflowId)
                 .IsUnique()

--- a/backend/Migrations/20260903004657_AddAccountInflowFoundation.Designer.cs
+++ b/backend/Migrations/20260903004657_AddAccountInflowFoundation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260903004657_AddAccountInflowFoundation")]
+    partial class AddAccountInflowFoundation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260903004657_AddAccountInflowFoundation.Designer.cs
+++ b/backend/Migrations/20260903004657_AddAccountInflowFoundation.Designer.cs
@@ -55,6 +55,9 @@ namespace backend.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasAlternateKey("Id", "OwnerId")
+                        .HasName("AK_AccountInflows_Id_OwnerId");
+
                     b.HasIndex("OwnerId", "Date");
 
                     b.ToTable("AccountInflows", t =>
@@ -460,14 +463,27 @@ namespace backend.Migrations
                     b.Property<int?>("AccountInflowId")
                         .HasColumnType("integer");
 
+                    b.Property<string>("AccountInflowOwnerId")
+                        .HasColumnType("text");
+
+                    b.Property<string>("OwnerId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("BatchId", "SourceRowOrdinal");
 
                     b.HasIndex("AccountInflowId")
                         .IsUnique()
                         .HasFilter("\"AccountInflowId\" IS NOT NULL");
 
+                    b.HasIndex("AccountInflowId", "AccountInflowOwnerId");
+
+                    b.HasIndex("BatchId", "OwnerId");
+
                     b.ToTable("ImportInflowProvenances", t =>
                         {
+                            t.HasCheckConstraint("CK_ImportInflowProvenance_OwnerConsistency", "(\"AccountInflowId\" IS NULL AND \"AccountInflowOwnerId\" IS NULL) OR (\"AccountInflowId\" IS NOT NULL AND \"AccountInflowOwnerId\" IS NOT NULL AND \"AccountInflowOwnerId\" = \"OwnerId\")");
+
                             t.HasCheckConstraint("CK_ImportInflowProvenance_PositiveSourceRowOrdinal", "\"SourceRowOrdinal\" > 0");
                         });
                 });
@@ -512,6 +528,9 @@ namespace backend.Migrations
                         .HasColumnType("character varying(50)");
 
                     b.HasKey("Id");
+
+                    b.HasAlternateKey("Id", "OwnerId")
+                        .HasName("AK_ImportPreviewBatches_Id_OwnerId");
 
                     b.HasIndex("ExpiresAt");
 
@@ -889,14 +908,18 @@ namespace backend.Migrations
                 {
                     b.HasOne("BudgetPlanner.Models.AccountInflow", "AccountInflow")
                         .WithMany()
-                        .HasForeignKey("AccountInflowId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("AccountInflowId", "AccountInflowOwnerId")
+                        .HasPrincipalKey("Id", "OwnerId")
+                        .OnDelete(DeleteBehavior.SetNull)
+                        .HasConstraintName("FK_ImportInflowProvenance_AccountInflow_Owner");
 
                     b.HasOne("BudgetPlanner.Models.ImportPreviewBatch", "Batch")
                         .WithMany("InflowProvenance")
-                        .HasForeignKey("BatchId")
+                        .HasForeignKey("BatchId", "OwnerId")
+                        .HasPrincipalKey("Id", "OwnerId")
                         .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .IsRequired()
+                        .HasConstraintName("FK_ImportInflowProvenance_Batch_Owner");
 
                     b.Navigation("AccountInflow");
 

--- a/backend/Migrations/20260903004657_AddAccountInflowFoundation.cs
+++ b/backend/Migrations/20260903004657_AddAccountInflowFoundation.cs
@@ -12,6 +12,11 @@ namespace backend.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_ImportPreviewBatches_Id_OwnerId",
+                table: "ImportPreviewBatches",
+                columns: new[] { "Id", "OwnerId" });
+
             migrationBuilder.CreateTable(
                 name: "AccountInflows",
                 columns: table => new
@@ -27,6 +32,7 @@ namespace backend.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_AccountInflows", x => x.Id);
+                    table.UniqueConstraint("AK_AccountInflows_Id_OwnerId", x => new { x.Id, x.OwnerId });
                     table.CheckConstraint("CK_AccountInflow_Description", "length(btrim(\"Description\")) > 0");
                     table.CheckConstraint("CK_AccountInflow_PositiveAmount", "\"Amount\" > 0");
                     table.ForeignKey(
@@ -43,23 +49,26 @@ namespace backend.Migrations
                 {
                     BatchId = table.Column<Guid>(type: "uuid", nullable: false),
                     SourceRowOrdinal = table.Column<int>(type: "integer", nullable: false),
-                    AccountInflowId = table.Column<int>(type: "integer", nullable: true)
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    AccountInflowId = table.Column<int>(type: "integer", nullable: true),
+                    AccountInflowOwnerId = table.Column<string>(type: "text", nullable: true)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_ImportInflowProvenances", x => new { x.BatchId, x.SourceRowOrdinal });
+                    table.CheckConstraint("CK_ImportInflowProvenance_OwnerConsistency", "(\"AccountInflowId\" IS NULL AND \"AccountInflowOwnerId\" IS NULL) OR (\"AccountInflowId\" IS NOT NULL AND \"AccountInflowOwnerId\" IS NOT NULL AND \"AccountInflowOwnerId\" = \"OwnerId\")");
                     table.CheckConstraint("CK_ImportInflowProvenance_PositiveSourceRowOrdinal", "\"SourceRowOrdinal\" > 0");
                     table.ForeignKey(
-                        name: "FK_ImportInflowProvenances_AccountInflows_AccountInflowId",
-                        column: x => x.AccountInflowId,
+                        name: "FK_ImportInflowProvenance_AccountInflow_Owner",
+                        columns: x => new { x.AccountInflowId, x.AccountInflowOwnerId },
                         principalTable: "AccountInflows",
-                        principalColumn: "Id",
+                        principalColumns: new[] { "Id", "OwnerId" },
                         onDelete: ReferentialAction.SetNull);
                     table.ForeignKey(
-                        name: "FK_ImportInflowProvenances_ImportPreviewBatches_BatchId",
-                        column: x => x.BatchId,
+                        name: "FK_ImportInflowProvenance_Batch_Owner",
+                        columns: x => new { x.BatchId, x.OwnerId },
                         principalTable: "ImportPreviewBatches",
-                        principalColumn: "Id",
+                        principalColumns: new[] { "Id", "OwnerId" },
                         onDelete: ReferentialAction.Cascade);
                 });
 
@@ -74,6 +83,16 @@ namespace backend.Migrations
                 column: "AccountInflowId",
                 unique: true,
                 filter: "\"AccountInflowId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportInflowProvenances_AccountInflowId_AccountInflowOwnerId",
+                table: "ImportInflowProvenances",
+                columns: new[] { "AccountInflowId", "AccountInflowOwnerId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportInflowProvenances_BatchId_OwnerId",
+                table: "ImportInflowProvenances",
+                columns: new[] { "BatchId", "OwnerId" });
         }
 
         /// <inheritdoc />
@@ -95,6 +114,10 @@ namespace backend.Migrations
 
             migrationBuilder.DropTable(
                 name: "AccountInflows");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_ImportPreviewBatches_Id_OwnerId",
+                table: "ImportPreviewBatches");
         }
     }
 }

--- a/backend/Migrations/20260903004657_AddAccountInflowFoundation.cs
+++ b/backend/Migrations/20260903004657_AddAccountInflowFoundation.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccountInflowFoundation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AccountInflows",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Amount = table.Column<decimal>(type: "numeric(18,2)", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    PaycheckEvidenceRevision = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AccountInflows", x => x.Id);
+                    table.CheckConstraint("CK_AccountInflow_Description", "length(btrim(\"Description\")) > 0");
+                    table.CheckConstraint("CK_AccountInflow_PositiveAmount", "\"Amount\" > 0");
+                    table.ForeignKey(
+                        name: "FK_AccountInflows_AspNetUsers_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImportInflowProvenances",
+                columns: table => new
+                {
+                    BatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceRowOrdinal = table.Column<int>(type: "integer", nullable: false),
+                    AccountInflowId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportInflowProvenances", x => new { x.BatchId, x.SourceRowOrdinal });
+                    table.CheckConstraint("CK_ImportInflowProvenance_PositiveSourceRowOrdinal", "\"SourceRowOrdinal\" > 0");
+                    table.ForeignKey(
+                        name: "FK_ImportInflowProvenances_AccountInflows_AccountInflowId",
+                        column: x => x.AccountInflowId,
+                        principalTable: "AccountInflows",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ImportInflowProvenances_ImportPreviewBatches_BatchId",
+                        column: x => x.BatchId,
+                        principalTable: "ImportPreviewBatches",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AccountInflows_OwnerId_Date",
+                table: "AccountInflows",
+                columns: new[] { "OwnerId", "Date" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportInflowProvenances_AccountInflowId",
+                table: "ImportInflowProvenances",
+                column: "AccountInflowId",
+                unique: true,
+                filter: "\"AccountInflowId\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DO $migration$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM "AccountInflows")
+                        OR EXISTS (SELECT 1 FROM "ImportInflowProvenances") THEN
+                        RAISE EXCEPTION 'Cannot roll back account inflow foundation while durable inflow evidence exists.';
+                    END IF;
+                END $migration$;
+                """);
+
+            migrationBuilder.DropTable(
+                name: "ImportInflowProvenances");
+
+            migrationBuilder.DropTable(
+                name: "AccountInflows");
+        }
+    }
+}

--- a/backend/Migrations/BudgetContextModelSnapshot.cs
+++ b/backend/Migrations/BudgetContextModelSnapshot.cs
@@ -52,6 +52,9 @@ namespace backend.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasAlternateKey("Id", "OwnerId")
+                        .HasName("AK_AccountInflows_Id_OwnerId");
+
                     b.HasIndex("OwnerId", "Date");
 
                     b.ToTable("AccountInflows", t =>
@@ -457,14 +460,27 @@ namespace backend.Migrations
                     b.Property<int?>("AccountInflowId")
                         .HasColumnType("integer");
 
+                    b.Property<string>("AccountInflowOwnerId")
+                        .HasColumnType("text");
+
+                    b.Property<string>("OwnerId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("BatchId", "SourceRowOrdinal");
 
                     b.HasIndex("AccountInflowId")
                         .IsUnique()
                         .HasFilter("\"AccountInflowId\" IS NOT NULL");
 
+                    b.HasIndex("AccountInflowId", "AccountInflowOwnerId");
+
+                    b.HasIndex("BatchId", "OwnerId");
+
                     b.ToTable("ImportInflowProvenances", t =>
                         {
+                            t.HasCheckConstraint("CK_ImportInflowProvenance_OwnerConsistency", "(\"AccountInflowId\" IS NULL AND \"AccountInflowOwnerId\" IS NULL) OR (\"AccountInflowId\" IS NOT NULL AND \"AccountInflowOwnerId\" IS NOT NULL AND \"AccountInflowOwnerId\" = \"OwnerId\")");
+
                             t.HasCheckConstraint("CK_ImportInflowProvenance_PositiveSourceRowOrdinal", "\"SourceRowOrdinal\" > 0");
                         });
                 });
@@ -509,6 +525,9 @@ namespace backend.Migrations
                         .HasColumnType("character varying(50)");
 
                     b.HasKey("Id");
+
+                    b.HasAlternateKey("Id", "OwnerId")
+                        .HasName("AK_ImportPreviewBatches_Id_OwnerId");
 
                     b.HasIndex("ExpiresAt");
 
@@ -886,14 +905,18 @@ namespace backend.Migrations
                 {
                     b.HasOne("BudgetPlanner.Models.AccountInflow", "AccountInflow")
                         .WithMany()
-                        .HasForeignKey("AccountInflowId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("AccountInflowId", "AccountInflowOwnerId")
+                        .HasPrincipalKey("Id", "OwnerId")
+                        .OnDelete(DeleteBehavior.SetNull)
+                        .HasConstraintName("FK_ImportInflowProvenance_AccountInflow_Owner");
 
                     b.HasOne("BudgetPlanner.Models.ImportPreviewBatch", "Batch")
                         .WithMany("InflowProvenance")
-                        .HasForeignKey("BatchId")
+                        .HasForeignKey("BatchId", "OwnerId")
+                        .HasPrincipalKey("Id", "OwnerId")
                         .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .IsRequired()
+                        .HasConstraintName("FK_ImportInflowProvenance_Batch_Owner");
 
                     b.Navigation("AccountInflow");
 

--- a/backend/Models/AccountInflow.cs
+++ b/backend/Models/AccountInflow.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+
+namespace BudgetPlanner.Models;
+
+public partial class AccountInflow
+{
+    public int Id { get; set; }
+    public string OwnerId { get; set; } = "";
+    public ApplicationUser? Owner { get; set; }
+    public string Description { get; set; } = "";
+    public decimal Amount { get; set; }
+    public DateOnly Date { get; set; }
+    public Guid PaycheckEvidenceRevision { get; set; } = Guid.NewGuid();
+
+    public bool UpdateEvidence(string description, decimal amount, DateOnly date)
+    {
+        var trimmedDescription = description.Trim();
+        var materiallyChanged = Amount != amount
+            || Date != date
+            || NormalizeDescriptionIdentity(Description) != NormalizeDescriptionIdentity(trimmedDescription);
+
+        Description = trimmedDescription;
+        Amount = amount;
+        Date = date;
+        if (materiallyChanged)
+        {
+            PaycheckEvidenceRevision = Guid.NewGuid();
+        }
+
+        return materiallyChanged;
+    }
+
+    private static string NormalizeDescriptionIdentity(string? value) =>
+        WhitespaceRegex().Replace((value ?? "").Trim(), " ").ToLowerInvariant();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/backend/Models/ImportInflowProvenance.cs
+++ b/backend/Models/ImportInflowProvenance.cs
@@ -4,7 +4,9 @@ public class ImportInflowProvenance
 {
     public Guid BatchId { get; set; }
     public ImportPreviewBatch? Batch { get; set; }
+    public string OwnerId { get; set; } = "";
     public int SourceRowOrdinal { get; set; }
     public int? AccountInflowId { get; set; }
+    public string? AccountInflowOwnerId { get; set; }
     public AccountInflow? AccountInflow { get; set; }
 }

--- a/backend/Models/ImportInflowProvenance.cs
+++ b/backend/Models/ImportInflowProvenance.cs
@@ -1,0 +1,10 @@
+namespace BudgetPlanner.Models;
+
+public class ImportInflowProvenance
+{
+    public Guid BatchId { get; set; }
+    public ImportPreviewBatch? Batch { get; set; }
+    public int SourceRowOrdinal { get; set; }
+    public int? AccountInflowId { get; set; }
+    public AccountInflow? AccountInflow { get; set; }
+}

--- a/backend/Models/ImportPreviewBatch.cs
+++ b/backend/Models/ImportPreviewBatch.cs
@@ -21,4 +21,5 @@ public class ImportPreviewBatch
     public DateTime? ConfirmedAt { get; set; }
     public List<ImportPreviewRow> Rows { get; set; } = [];
     public List<ImportExpenseProvenance> Provenance { get; set; } = [];
+    public List<ImportInflowProvenance> InflowProvenance { get; set; } = [];
 }


### PR DESCRIPTION
## Summary

- add the generic owner-scoped AccountInflow persistence model, separate from Expense
- add import batch/row provenance with nullable one-to-one inflow linkage
- add revision behavior that ignores normalized-description-only formatting changes and rotates for material evidence changes
- add the additive EF migration plus unit and PostgreSQL migration/constraint tests

References #108.

## Risk

HIGH. This is the explicitly approved Stage 1 financial-domain/schema slice from issue #108.

## Important implementation details

- amounts use positive numeric(18,2); dates use PostgreSQL date
- descriptions are required, blank-rejected, capped at 500 characters, and trimmed by the evidence update boundary
- PaycheckEvidenceRevision is non-null and generated for new evidence
- owner deletion cascades inflows; batch deletion cascades provenance; inflow deletion retains provenance with a null link
- imported provenance is unique per linked inflow and keyed by batch plus source row ordinal

## Verification

- ./scripts/verify.sh frontend — passed: 30 files, 167 tests, lint, production build
- ./scripts/verify.sh backend — passed: 305 tests
- ./scripts/verify.sh postgresql — passed: migration chain 1 test; PostgreSQL integration 29 tests, using a dedicated disposable local PostgreSQL 16 container
- dotnet ef migrations has-pending-model-changes — passed: no pending model changes
- git diff --cached --check — passed

The first backend run had one unrelated PDF worker test fail during startup; the exact test passed immediately in isolation and the complete backend lane then passed twice, including after the final semantic correction.

## Scope boundaries

Stage 1 only. This PR adds no endpoints, import runtime behavior, candidate detector, paycheck profile, UI, backfill, deployment, production access, production migration, or data operation. It does not classify persisted credits as income.

## Migration, API, and dependency impact

- Migration: additive AccountInflows and ImportInflowProvenances tables, constraints, indexes, and foreign keys
- Rollback: application rollback leaves these tables inert; migration Down refuses to remove them while durable inflow/provenance rows exist
- API: none
- Dependencies: none

No production migration or deployment is authorized by this PR.