### PR TITLE
Implement Paycheck Candidate Detector and Projector V1

### DIFF
--- a/backend.Tests/Financial/AccountInflowTests.cs
+++ b/backend.Tests/Financial/AccountInflowTests.cs
@@ -33,6 +33,19 @@ public sealed class AccountInflowTests
     }
 
     [Fact]
+    public void Shared_identity_normalization_matches_update_evidence_materiality()
+    {
+        Assert.Equal(
+            "weekly payroll",
+            AccountInflowIdentity.NormalizeDescription("  WEEKLY\t\n PAYROLL  "));
+
+        var inflow = Inflow();
+        var revision = inflow.PaycheckEvidenceRevision;
+        Assert.False(inflow.UpdateEvidence("\nweekly\tpayroll ", inflow.Amount, inflow.Date));
+        Assert.Equal(revision, inflow.PaycheckEvidenceRevision);
+    }
+
+    [Fact]
     public void UpdateEvidence_rotates_revision_for_each_material_evidence_change()
     {
         var inflow = Inflow();

--- a/backend.Tests/Financial/PaycheckCandidateDetectorTests.cs
+++ b/backend.Tests/Financial/PaycheckCandidateDetectorTests.cs
@@ -1,0 +1,528 @@
+using System.Globalization;
+using BudgetPlanner.Models;
+using BudgetPlanner.Paychecks;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+public sealed class PaycheckCandidateDetectorTests
+{
+    private static readonly DateOnly EvaluatedOn = new(2026, 9, 3);
+    private readonly PaycheckCandidateDetector detector = new();
+
+    [Fact]
+    public void Weekly_requires_six_consecutive_slots_and_preserves_phase_and_windows()
+    {
+        var anchors = Dates(new(2026, 7, 3), 7, 6);
+        var offsets = new[] { -3, -2, 0, 0, 2, 3 };
+        var six = anchors.Select((anchor, index) => Inflow(index + 1, anchor.AddDays(offsets[index]))).ToArray();
+
+        Assert.Empty(detector.Detect(six[..5], EvaluatedOn));
+        var candidate = Assert.Single(detector.Detect(six, EvaluatedOn));
+
+        var schedule = Assert.IsType<WeeklyPaycheckSchedule>(candidate.Schedule);
+        Assert.Equal(anchors[0], schedule.ReferenceAnchor);
+        Assert.Equal(3, candidate.WindowBeforeDays);
+        Assert.Equal(3, candidate.WindowAfterDays);
+        Assert.Equal(offsets, candidate.Evidence.Select(value => value.TimingOffsetDays));
+    }
+
+    [Fact]
+    public void Weekly_rejects_four_day_offsets_and_handles_year_boundaries()
+    {
+        var dates = Dates(new(2025, 12, 12), 7, 6);
+        var valid = dates.Select((date, index) => Inflow(index + 1, date)).ToArray();
+        Assert.IsType<WeeklyPaycheckSchedule>(Assert.Single(detector.Detect(valid, new(2026, 1, 31))).Schedule);
+
+        valid[0].Date = valid[0].Date.AddDays(-3);
+        valid[^1].Date = valid[^1].Date.AddDays(4);
+        Assert.Empty(detector.Detect(valid, new(2026, 1, 31)));
+    }
+
+    [Fact]
+    public void Biweekly_requires_four_slots_spanning_42_days_and_preserves_alternating_week_phase()
+    {
+        var four = Dates(new(2026, 6, 5), 14, 4)
+            .Select((date, index) => Inflow(index + 1, date))
+            .ToArray();
+
+        Assert.Empty(detector.Detect(four[..3], EvaluatedOn));
+        var candidate = Assert.Single(detector.Detect(four, EvaluatedOn));
+
+        var schedule = Assert.IsType<BiweeklyPaycheckSchedule>(candidate.Schedule);
+        Assert.Equal(four[0].Date, schedule.ReferenceAnchor);
+        Assert.All(candidate.Evidence.Zip(candidate.Evidence.Skip(1)), pair =>
+            Assert.Equal(14, pair.Second.SlotAnchor.DayNumber - pair.First.SlotAnchor.DayNumber));
+    }
+
+    [Fact]
+    public void Monthly_requires_consecutive_months_and_uses_canonical_month_end_across_leap_february()
+    {
+        var monthEnd = new[]
+        {
+            Inflow(1, new(2024, 1, 31)),
+            Inflow(2, new(2024, 2, 29)),
+            Inflow(3, new(2024, 3, 31))
+        };
+        var candidate = Assert.Single(detector.Detect(monthEnd, new(2024, 4, 1)));
+        var schedule = Assert.IsType<MonthlyPaycheckSchedule>(candidate.Schedule);
+        Assert.Equal(PaycheckMonthAnchor.MonthEnd, schedule.Anchor);
+
+        monthEnd[1].Date = new DateOnly(2023, 2, 28);
+        Assert.Empty(detector.Detect(monthEnd, new(2024, 4, 1)));
+    }
+
+    [Fact]
+    public void Monthly_day_anchor_clamps_in_short_months_and_day_31_canonicalizes_to_month_end()
+    {
+        var candidate = Assert.Single(detector.Detect(
+        [
+            Inflow(1, new(2025, 1, 30)),
+            Inflow(2, new(2025, 2, 28)),
+            Inflow(3, new(2025, 3, 30))
+        ], new(2025, 4, 1)));
+
+        Assert.Equal(PaycheckMonthAnchor.DayOfMonth(30), Assert.IsType<MonthlyPaycheckSchedule>(candidate.Schedule).Anchor);
+        Assert.Equal(PaycheckMonthAnchor.MonthEnd, PaycheckMonthAnchor.DayOfMonth(31));
+    }
+
+    [Fact]
+    public void Semimonthly_requires_six_alternating_slots_across_three_months()
+    {
+        var six = new[]
+        {
+            Inflow(1, new(2026, 1, 15)), Inflow(2, new(2026, 1, 31)),
+            Inflow(3, new(2026, 2, 15)), Inflow(4, new(2026, 2, 28)),
+            Inflow(5, new(2026, 3, 15)), Inflow(6, new(2026, 3, 31))
+        };
+
+        Assert.DoesNotContain(
+            detector.Detect(six[..5], new(2026, 4, 1)),
+            candidate => candidate.Schedule is SemimonthlyPaycheckSchedule);
+        var schedule = Assert.IsType<SemimonthlyPaycheckSchedule>(
+            Assert.Single(detector.Detect(six, new(2026, 4, 1))).Schedule);
+        Assert.Equal(PaycheckMonthAnchor.DayOfMonth(15), schedule.First);
+        Assert.Equal(PaycheckMonthAnchor.MonthEnd, schedule.Second);
+    }
+
+    [Fact]
+    public void Semimonthly_handles_adjacent_month_early_posting_and_is_not_a_fifteen_day_interval()
+    {
+        var evidence = new[]
+        {
+            Inflow(1, new(2026, 1, 15)), Inflow(2, new(2026, 1, 29)),
+            Inflow(3, new(2026, 2, 13)), Inflow(4, new(2026, 2, 26)),
+            Inflow(5, new(2026, 3, 13)), Inflow(6, new(2026, 3, 29))
+        };
+
+        var candidate = Assert.Single(detector.Detect(evidence, new(2026, 4, 1)));
+        Assert.IsType<SemimonthlyPaycheckSchedule>(candidate.Schedule);
+        Assert.Equal(2, candidate.WindowBeforeDays);
+        Assert.Contains(candidate.Evidence.Zip(candidate.Evidence.Skip(1)), pair =>
+            pair.Second.SlotAnchor.DayNumber - pair.First.SlotAnchor.DayNumber != 15);
+    }
+
+    [Fact]
+    public void Semimonthly_supports_day_day_anchors_and_leap_february_day_month_end_anchors()
+    {
+        var dayDay = new[]
+        {
+            Inflow(1, new(2026, 1, 5)), Inflow(2, new(2026, 1, 20)),
+            Inflow(3, new(2026, 2, 5)), Inflow(4, new(2026, 2, 20)),
+            Inflow(5, new(2026, 3, 5)), Inflow(6, new(2026, 3, 20))
+        };
+        var dayDaySchedule = Assert.IsType<SemimonthlyPaycheckSchedule>(
+            Assert.Single(detector.Detect(dayDay, new(2026, 3, 25))).Schedule);
+        Assert.Equal(PaycheckMonthAnchor.DayOfMonth(5), dayDaySchedule.First);
+        Assert.Equal(PaycheckMonthAnchor.DayOfMonth(20), dayDaySchedule.Second);
+
+        var leap = new[]
+        {
+            Inflow(11, new(2023, 12, 10)), Inflow(12, new(2023, 12, 31)),
+            Inflow(13, new(2024, 1, 10)), Inflow(14, new(2024, 1, 31)),
+            Inflow(15, new(2024, 2, 10)), Inflow(16, new(2024, 2, 29))
+        };
+        var leapSchedule = Assert.IsType<SemimonthlyPaycheckSchedule>(
+            Assert.Single(detector.Detect(leap, new(2024, 3, 1))).Schedule);
+        Assert.Equal(PaycheckMonthAnchor.DayOfMonth(10), leapSchedule.First);
+        Assert.Equal(PaycheckMonthAnchor.MonthEnd, leapSchedule.Second);
+    }
+
+    [Fact]
+    public void Semimonthly_rejects_pairs_that_can_collapse_or_be_less_than_seven_days_apart()
+    {
+        Assert.Throws<ArgumentException>(() => new SemimonthlyPaycheckSchedule(
+            PaycheckMonthAnchor.DayOfMonth(25), PaycheckMonthAnchor.MonthEnd));
+        Assert.Throws<ArgumentException>(() => new SemimonthlyPaycheckSchedule(
+            PaycheckMonthAnchor.DayOfMonth(30), PaycheckMonthAnchor.MonthEnd));
+        Assert.Throws<ArgumentException>(() => new SemimonthlyPaycheckSchedule(
+            PaycheckMonthAnchor.DayOfMonth(15), PaycheckMonthAnchor.DayOfMonth(10)));
+    }
+
+    [Fact]
+    public void Normalization_groups_case_and_dotnet_whitespace_but_preserves_meaningful_text_distinctions()
+    {
+        var payroll = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date, description: index switch
+            {
+                0 => "  ACME   PAYROLL ",
+                1 => "acme\tpayroll",
+                2 => "Acme\npayroll",
+                _ => "acme payroll"
+            }))
+            .ToList();
+        payroll.AddRange(Dates(new(2026, 7, 4), 7, 6)
+            .Select((date, index) => Inflow(20 + index, date, description: "acme payroll bonus")));
+
+        var candidates = detector.Detect(payroll, EvaluatedOn);
+
+        Assert.Equal(new[] { "acme payroll", "acme payroll bonus" },
+            candidates.Select(value => value.NormalizedDescriptionIdentity));
+    }
+
+    [Fact]
+    public void Source_navigation_state_and_raw_formatting_do_not_affect_identity_or_fingerprint()
+    {
+        var first = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date, description: "Payroll Source"))
+            .ToArray();
+        var second = first.Select(value => new AccountInflow
+        {
+            Id = value.Id,
+            OwnerId = value.OwnerId,
+            Description = value.Id % 2 == 0 ? " payroll\tsource " : "PAYROLL   SOURCE",
+            Amount = value.Amount,
+            Date = value.Date,
+            PaycheckEvidenceRevision = value.PaycheckEvidenceRevision,
+            Owner = new ApplicationUser()
+        }).ToArray();
+
+        Assert.Equal(
+            Assert.Single(detector.Detect(first, EvaluatedOn)).EvidenceFingerprint,
+            Assert.Single(detector.Detect(second, EvaluatedOn)).EvidenceFingerprint);
+    }
+
+    [Fact]
+    public void Mixed_or_blank_owners_fail_closed_for_the_whole_invocation()
+    {
+        var evidence = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date))
+            .ToArray();
+        evidence[^1].OwnerId = "other-owner";
+        Assert.Empty(detector.Detect(evidence, EvaluatedOn));
+
+        evidence[^1].OwnerId = " ";
+        Assert.Empty(detector.Detect(evidence, EvaluatedOn));
+    }
+
+    [Fact]
+    public void Duplicate_ids_empty_revisions_and_invalid_financial_fields_withhold_only_affected_identity()
+    {
+        var invalid = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date, description: "invalid payroll"))
+            .ToList();
+        invalid[0].PaycheckEvidenceRevision = Guid.Empty;
+        invalid[1].Amount = 0m;
+        invalid[2].Amount = 10.001m;
+        invalid.Add(Inflow(4, new(2026, 8, 20), description: "invalid payroll"));
+        var valid = Dates(new(2026, 7, 4), 7, 6)
+            .Select((date, index) => Inflow(20 + index, date, description: "valid payroll"));
+
+        var candidate = Assert.Single(detector.Detect(invalid.Concat(valid), EvaluatedOn));
+        Assert.Equal("valid payroll", candidate.NormalizedDescriptionIdentity);
+    }
+
+    [Fact]
+    public void Horizon_is_eighteen_calendar_months_inclusive_and_future_rows_are_ignored()
+    {
+        var evaluatedOn = new DateOnly(2026, 9, 3);
+        var horizonStart = new DateOnly(2025, 4, 1);
+        var evidence = new[]
+        {
+            Inflow(1, horizonStart),
+            Inflow(2, new(2025, 5, 1)),
+            Inflow(3, new(2025, 6, 1)),
+            Inflow(4, horizonStart.AddDays(-1)),
+            Inflow(5, evaluatedOn.AddDays(1))
+        };
+
+        var candidate = Assert.Single(detector.Detect(evidence, evaluatedOn));
+        Assert.Equal(new[] { 1, 2, 3 }, candidate.Evidence.Select(value => value.AccountInflowId));
+    }
+
+    [Fact]
+    public void Out_of_horizon_rows_do_not_participate_in_owner_validation()
+    {
+        var current = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date));
+        var oldOtherOwner = Inflow(20, new(2025, 3, 31), ownerId: "other-owner");
+
+        Assert.Single(detector.Detect(current.Append(oldOtherOwner), EvaluatedOn));
+    }
+
+    [Fact]
+    public void Extra_observation_between_biweekly_slots_is_a_barrier_and_is_not_silently_dropped()
+    {
+        var anchors = Dates(new(2026, 6, 5), 14, 4);
+        var evidence = anchors.Select((date, index) => Inflow(index + 1, date)).ToList();
+        evidence.Add(Inflow(20, anchors[1].AddDays(7)));
+
+        Assert.Empty(detector.Detect(evidence, EvaluatedOn));
+    }
+
+    [Fact]
+    public void Multiple_observations_in_one_slot_break_the_run_but_a_newer_qualifying_run_can_win()
+    {
+        var old = Dates(new(2026, 5, 1), 7, 3)
+            .Select((date, index) => Inflow(index + 1, date))
+            .ToList();
+        old.Add(Inflow(10, old[1].Date));
+        var recent = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(20 + index, date))
+            .ToArray();
+
+        var candidate = Assert.Single(detector.Detect(old.Concat(recent), EvaluatedOn));
+        Assert.Equal(recent.Select(value => value.Id), candidate.Evidence.Select(value => value.AccountInflowId));
+    }
+
+    [Fact]
+    public void Most_recent_qualifying_maximal_run_wins_over_an_older_longer_run()
+    {
+        var older = Dates(new(2026, 3, 6), 7, 8)
+            .Select((date, index) => Inflow(index + 1, date, amount: 1000m))
+            .ToArray();
+        var newer = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(20 + index, date, amount: 1200m))
+            .ToArray();
+
+        var candidate = Assert.Single(detector.Detect(older.Concat(newer), EvaluatedOn));
+
+        Assert.Equal(newer.Select(value => value.Id), candidate.Evidence.Select(value => value.AccountInflowId));
+        Assert.Equal(1200m, Assert.IsType<FixedObservedPaycheckAmount>(candidate.ObservedAmount).Amount);
+    }
+
+    [Fact]
+    public void Equal_rank_distinct_monthly_rules_fail_closed_instead_of_using_enumeration_order()
+    {
+        var evidence = new[]
+        {
+            Inflow(1, new(2026, 4, 14)),
+            Inflow(2, new(2026, 5, 15)),
+            Inflow(3, new(2026, 6, 14)),
+            Inflow(4, new(2026, 7, 15))
+        };
+
+        Assert.Empty(detector.Detect(evidence, new(2026, 8, 1)));
+    }
+
+    [Fact]
+    public void Exact_anchor_minimizes_total_offset_before_a_shifted_timing_rule()
+    {
+        var evidence = new[]
+        {
+            Inflow(1, new(2026, 4, 10)),
+            Inflow(2, new(2026, 5, 10)),
+            Inflow(3, new(2026, 6, 10))
+        };
+
+        var schedule = Assert.IsType<MonthlyPaycheckSchedule>(
+            Assert.Single(detector.Detect(evidence, new(2026, 7, 1))).Schedule);
+        Assert.Equal(PaycheckMonthAnchor.DayOfMonth(10), schedule.Anchor);
+    }
+
+    [Fact]
+    public void Longer_equal_end_run_wins_before_total_offset_score()
+    {
+        var anchors = Dates(new(2026, 6, 5), 7, 7);
+        var evidence = anchors.Select((anchor, index) =>
+            Inflow(index + 1, anchor.AddDays(index == 0 ? -3 : 1))).ToArray();
+
+        var candidate = Assert.Single(detector.Detect(evidence, EvaluatedOn));
+
+        Assert.Equal(7, candidate.Evidence.Count);
+        Assert.Equal(anchors[0], Assert.IsType<WeeklyPaycheckSchedule>(candidate.Schedule).ReferenceAnchor);
+    }
+
+    [Fact]
+    public void Equal_rank_biweekly_and_semimonthly_cadence_fits_are_withheld()
+    {
+        var evidence = new[]
+        {
+            Inflow(1, new(2026, 1, 1)), Inflow(2, new(2026, 1, 15)),
+            Inflow(3, new(2026, 1, 29)), Inflow(4, new(2026, 2, 12)),
+            Inflow(5, new(2026, 3, 1)), Inflow(6, new(2026, 3, 15))
+        };
+
+        Assert.Empty(detector.Detect(evidence, new(2026, 3, 20)));
+    }
+
+    [Fact]
+    public void Duplicate_same_slot_observation_withholds_an_otherwise_supported_run()
+    {
+        var evidence = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date))
+            .Append(Inflow(20, new(2026, 7, 17)))
+            .ToArray();
+
+        Assert.Empty(detector.Detect(evidence, EvaluatedOn));
+    }
+
+    [Fact]
+    public void Amount_summary_is_fixed_or_uses_raw_minimum_lower_median_and_maximum()
+    {
+        var fixedCandidate = Assert.Single(detector.Detect(
+            Dates(new(2026, 7, 3), 7, 6).Select((date, index) => Inflow(index + 1, date, 1000m)),
+            EvaluatedOn));
+        Assert.Equal(1000m, Assert.IsType<FixedObservedPaycheckAmount>(fixedCandidate.ObservedAmount).Amount);
+
+        var amounts = new[] { 1400m, 1000m, 1300m, 1100m, 1500m, 1200m };
+        var variableCandidate = Assert.Single(detector.Detect(
+            Dates(new(2026, 7, 3), 7, 6).Select((date, index) => Inflow(index + 1, date, amounts[index])),
+            EvaluatedOn));
+        var variable = Assert.IsType<VariableObservedPaycheckAmount>(variableCandidate.ObservedAmount);
+        Assert.Equal(1000m, variable.Minimum);
+        Assert.Equal(1200m, variable.LowerMedian);
+        Assert.Equal(1500m, variable.Maximum);
+    }
+
+    [Fact]
+    public void Candidate_and_evidence_order_and_fingerprint_are_stable_across_input_and_culture()
+    {
+        var alpha = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date, description: "Alpha Payroll"));
+        var zeta = Dates(new(2026, 7, 4), 7, 6)
+            .Select((date, index) => Inflow(20 + index, date, description: "Zeta Payroll"));
+        var input = alpha.Concat(zeta).ToArray();
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            var first = detector.Detect(input, EvaluatedOn);
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            var second = detector.Detect(input.Reverse(), EvaluatedOn);
+
+            Assert.Equal(new[] { "alpha payroll", "zeta payroll" }, first.Select(value => value.NormalizedDescriptionIdentity));
+            Assert.Equal(first.Select(value => value.EvidenceFingerprint), second.Select(value => value.EvidenceFingerprint));
+            Assert.All(second, candidate => Assert.Equal(
+                candidate.Evidence.OrderBy(value => value.PostedDate).ThenBy(value => value.AccountInflowId),
+                candidate.Evidence));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void Candidate_evidence_is_an_immutable_snapshot_of_mutable_persistence_objects()
+    {
+        var evidence = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date))
+            .ToArray();
+        var candidate = Assert.Single(detector.Detect(evidence, EvaluatedOn));
+        var captured = candidate.Evidence[0];
+
+        evidence[0].Description = "mutated";
+        evidence[0].Amount = 42m;
+        evidence[0].Date = evidence[0].Date.AddDays(2);
+        evidence[0].PaycheckEvidenceRevision = Guid.NewGuid();
+
+        Assert.Equal("Payroll", captured.Description);
+        Assert.Equal(1000m, captured.Amount);
+        Assert.Equal(new DateOnly(2026, 7, 3), captured.PostedDate);
+        Assert.Equal(Revision(1), captured.PaycheckEvidenceRevision);
+    }
+
+    [Fact]
+    public void Fingerprint_is_lowercase_sha256_and_changes_with_id_or_revision()
+    {
+        var evidence = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date))
+            .ToArray();
+        var original = Assert.Single(detector.Detect(evidence, EvaluatedOn)).EvidenceFingerprint;
+        Assert.Matches("^[0-9a-f]{64}$", original);
+
+        evidence[^1].PaycheckEvidenceRevision = Revision(99);
+        var revised = Assert.Single(detector.Detect(evidence, EvaluatedOn)).EvidenceFingerprint;
+        Assert.NotEqual(original, revised);
+
+        evidence[^1].Id = 99;
+        var renumbered = Assert.Single(detector.Detect(evidence, EvaluatedOn)).EvidenceFingerprint;
+        Assert.NotEqual(revised, renumbered);
+    }
+
+    [Fact]
+    public void Fingerprint_changes_with_semantic_identity_timing_windows_and_evidence_membership()
+    {
+        var evidence = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date))
+            .ToArray();
+        var original = Assert.Single(detector.Detect(evidence, EvaluatedOn)).EvidenceFingerprint;
+
+        var renamed = evidence.Select(Clone).ToArray();
+        foreach (var inflow in renamed) inflow.Description = "Other Payroll";
+        Assert.NotEqual(original, Assert.Single(detector.Detect(renamed, EvaluatedOn)).EvidenceFingerprint);
+
+        var windowed = evidence.Select(Clone).ToArray();
+        windowed[0].Date = windowed[0].Date.AddDays(-1);
+        windowed[^1].Date = windowed[^1].Date.AddDays(1);
+        Assert.NotEqual(original, Assert.Single(detector.Detect(windowed, EvaluatedOn)).EvidenceFingerprint);
+
+        var shifted = evidence.Select(Clone).ToArray();
+        foreach (var inflow in shifted) inflow.Date = inflow.Date.AddDays(1);
+        Assert.NotEqual(original, Assert.Single(detector.Detect(shifted, EvaluatedOn)).EvidenceFingerprint);
+
+        var extended = evidence.Append(Inflow(20, new(2026, 8, 14))).ToArray();
+        Assert.NotEqual(original, Assert.Single(detector.Detect(extended, EvaluatedOn)).EvidenceFingerprint);
+    }
+
+    [Fact]
+    public void Fingerprint_has_locked_v1_golden_vector()
+    {
+        var evidence = Dates(new(2026, 7, 3), 7, 6)
+            .Select((date, index) => Inflow(index + 1, date, 1000m, "Golden Payroll"))
+            .ToArray();
+
+        Assert.Equal(
+            "95e69386cfddd380b1641b5c54eb06f46510f21f1c0170a378dcf9bd1bbdff58",
+            Assert.Single(detector.Detect(evidence, EvaluatedOn)).EvidenceFingerprint);
+    }
+
+    [Fact]
+    public void Public_candidate_contract_does_not_claim_unapproved_payroll_semantics()
+    {
+        var propertyNames = typeof(PaycheckCandidate).GetProperties().Select(property => property.Name).ToHashSet();
+        var prohibited = new[] { "GrossPay", "Tax", "Deduction", "IncomeClassification", "Confidence", "Bonus", "Commission", "Guarantee" };
+        Assert.DoesNotContain(prohibited, propertyNames.Contains);
+    }
+
+    private static DateOnly[] Dates(DateOnly first, int intervalDays, int count) =>
+        Enumerable.Range(0, count).Select(index => first.AddDays(index * intervalDays)).ToArray();
+
+    private static AccountInflow Inflow(
+        int id,
+        DateOnly date,
+        decimal amount = 1000m,
+        string description = "Payroll",
+        string ownerId = "owner") => new()
+        {
+            Id = id,
+            OwnerId = ownerId,
+            Description = description,
+            Amount = amount,
+            Date = date,
+            PaycheckEvidenceRevision = Revision(id)
+        };
+
+    private static AccountInflow Clone(AccountInflow value) => new()
+    {
+        Id = value.Id,
+        OwnerId = value.OwnerId,
+        Description = value.Description,
+        Amount = value.Amount,
+        Date = value.Date,
+        PaycheckEvidenceRevision = value.PaycheckEvidenceRevision
+    };
+
+    private static Guid Revision(int id) => Guid.Parse($"00000000-0000-0000-0000-{id:000000000000}");
+}

--- a/backend.Tests/Financial/PaycheckProjectorTests.cs
+++ b/backend.Tests/Financial/PaycheckProjectorTests.cs
@@ -1,0 +1,121 @@
+using BudgetPlanner.Paychecks;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+public sealed class PaycheckProjectorTests
+{
+    private readonly PaycheckProjector projector = new();
+
+    [Theory]
+    [InlineData(2026, 8, 31)]
+    [InlineData(2026, 9, 1)]
+    [InlineData(2026, 9, 5)]
+    public void Weekly_returns_current_slot_before_and_inside_its_inclusive_window(int year, int month, int day)
+    {
+        var amount = new FixedConfirmedPaycheckAmount(1000m);
+        var pattern = new ConfirmedPaycheckPattern(
+            new WeeklyPaycheckSchedule(new(2026, 9, 4)), 3, 1, amount);
+
+        var result = projector.Project(pattern, new(year, month, day));
+
+        Assert.Equal(PaycheckProjector.AlgorithmVersion, result.AlgorithmVersion);
+        Assert.Equal(new DateOnly(2026, 9, 4), result.Anchor);
+        Assert.Equal(new DateOnly(2026, 9, 1), result.EarliestExpectedDate);
+        Assert.Equal(new DateOnly(2026, 9, 5), result.LatestExpectedDate);
+        Assert.Same(amount, result.Amount);
+    }
+
+    [Fact]
+    public void Weekly_advances_on_first_day_after_window_closes_and_never_precedes_reference()
+    {
+        var pattern = Pattern(new WeeklyPaycheckSchedule(new(2026, 9, 4)), before: 3, after: 1);
+
+        Assert.Equal(new DateOnly(2026, 9, 4), projector.Project(pattern, new(2020, 1, 1)).Anchor);
+        Assert.Equal(new DateOnly(2026, 9, 11), projector.Project(pattern, new(2026, 9, 6)).Anchor);
+    }
+
+    [Fact]
+    public void Latest_confirmed_slot_is_skipped_even_while_its_window_is_open()
+    {
+        var pattern = new ConfirmedPaycheckPattern(
+            new BiweeklyPaycheckSchedule(new(2026, 8, 28)),
+            3,
+            3,
+            new FixedConfirmedPaycheckAmount(1000m),
+            new DateOnly(2026, 8, 28));
+
+        var result = projector.Project(pattern, new(2026, 8, 27));
+
+        Assert.Equal(new DateOnly(2026, 9, 11), result.Anchor);
+    }
+
+    [Fact]
+    public void Biweekly_preserves_phase_across_year_boundary()
+    {
+        var pattern = Pattern(new BiweeklyPaycheckSchedule(new(2025, 12, 26)));
+
+        Assert.Equal(new DateOnly(2026, 1, 9), projector.Project(pattern, new(2025, 12, 27)).Anchor);
+    }
+
+    [Fact]
+    public void Monthly_day_anchor_clamps_through_leap_and_nonleap_february()
+    {
+        var pattern = Pattern(new MonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(30)));
+
+        Assert.Equal(new DateOnly(2024, 2, 29), projector.Project(pattern, new(2024, 2, 1)).Anchor);
+        Assert.Equal(new DateOnly(2025, 2, 28), projector.Project(pattern, new(2025, 2, 1)).Anchor);
+    }
+
+    [Fact]
+    public void Month_end_can_return_previous_month_slot_while_its_window_is_open()
+    {
+        var pattern = Pattern(new MonthlyPaycheckSchedule(PaycheckMonthAnchor.MonthEnd), after: 3);
+
+        var result = projector.Project(pattern, new(2026, 3, 2));
+
+        Assert.Equal(new DateOnly(2026, 2, 28), result.Anchor);
+        Assert.Equal(new DateOnly(2026, 3, 3), result.LatestExpectedDate);
+    }
+
+    [Fact]
+    public void Semimonthly_moves_within_and_across_months_without_interval_approximation()
+    {
+        var pattern = Pattern(new SemimonthlyPaycheckSchedule(
+            PaycheckMonthAnchor.DayOfMonth(15), PaycheckMonthAnchor.MonthEnd));
+
+        Assert.Equal(new DateOnly(2026, 1, 31), projector.Project(pattern, new(2026, 1, 16)).Anchor);
+        Assert.Equal(new DateOnly(2026, 2, 15), projector.Project(pattern, new(2026, 2, 1)).Anchor);
+    }
+
+    [Fact]
+    public void Confirmed_range_is_passed_through_unchanged()
+    {
+        var amount = new RangeConfirmedPaycheckAmount(900m, 1100m);
+        var pattern = new ConfirmedPaycheckPattern(
+            new MonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(10)), 0, 0, amount);
+
+        Assert.Same(amount, projector.Project(pattern, new(2026, 9, 1)).Amount);
+    }
+
+    [Fact]
+    public void Invalid_schedule_window_amount_and_latest_slot_shapes_are_rejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => PaycheckMonthAnchor.DayOfMonth(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new FixedConfirmedPaycheckAmount(0m));
+        Assert.Throws<ArgumentException>(() => new RangeConfirmedPaycheckAmount(1000m, 1000m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfirmedPaycheckPattern(
+            new WeeklyPaycheckSchedule(new(2026, 9, 4)), 4, 0, new FixedConfirmedPaycheckAmount(1000m)));
+        Assert.Throws<ArgumentException>(() => new ConfirmedPaycheckPattern(
+            new WeeklyPaycheckSchedule(new(2026, 9, 4)),
+            0,
+            0,
+            new FixedConfirmedPaycheckAmount(1000m),
+            new DateOnly(2026, 9, 5)));
+    }
+
+    private static ConfirmedPaycheckPattern Pattern(
+        PaycheckSchedule schedule,
+        int before = 0,
+        int after = 0) => new(schedule, before, after, new FixedConfirmedPaycheckAmount(1000m));
+}

--- a/backend/Models/AccountInflow.cs
+++ b/backend/Models/AccountInflow.cs
@@ -1,8 +1,6 @@
-using System.Text.RegularExpressions;
-
 namespace BudgetPlanner.Models;
 
-public partial class AccountInflow
+public class AccountInflow
 {
     public int Id { get; set; }
     public string OwnerId { get; set; } = "";
@@ -17,7 +15,8 @@ public partial class AccountInflow
         var trimmedDescription = description.Trim();
         var materiallyChanged = Amount != amount
             || Date != date
-            || NormalizeDescriptionIdentity(Description) != NormalizeDescriptionIdentity(trimmedDescription);
+            || AccountInflowIdentity.NormalizeDescription(Description)
+                != AccountInflowIdentity.NormalizeDescription(trimmedDescription);
 
         Description = trimmedDescription;
         Amount = amount;
@@ -29,10 +28,4 @@ public partial class AccountInflow
 
         return materiallyChanged;
     }
-
-    private static string NormalizeDescriptionIdentity(string? value) =>
-        WhitespaceRegex().Replace((value ?? "").Trim(), " ").ToLowerInvariant();
-
-    [GeneratedRegex(@"\s+")]
-    private static partial Regex WhitespaceRegex();
 }

--- a/backend/Models/AccountInflowIdentity.cs
+++ b/backend/Models/AccountInflowIdentity.cs
@@ -1,0 +1,12 @@
+using System.Text.RegularExpressions;
+
+namespace BudgetPlanner.Models;
+
+public static partial class AccountInflowIdentity
+{
+    public static string NormalizeDescription(string? value) =>
+        WhitespaceRegex().Replace((value ?? "").Trim(), " ").ToLowerInvariant();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/backend/Paychecks/PaycheckCandidateDetector.cs
+++ b/backend/Paychecks/PaycheckCandidateDetector.cs
@@ -1,0 +1,362 @@
+using System.Buffers.Binary;
+using System.Collections.ObjectModel;
+using System.Security.Cryptography;
+using System.Text;
+using BudgetPlanner.Models;
+
+namespace BudgetPlanner.Paychecks;
+
+public sealed class PaycheckCandidateDetector
+{
+    public const string AlgorithmVersion = "paycheck-candidate-v1";
+    private static readonly byte[] FingerprintDomain = "ordo.paycheck-candidate.v1\0"u8.ToArray();
+
+    public IReadOnlyList<PaycheckCandidate> Detect(IEnumerable<AccountInflow> inflows, DateOnly evaluatedOn)
+    {
+        ArgumentNullException.ThrowIfNull(inflows);
+
+        var horizonStart = new DateOnly(evaluatedOn.Year, evaluatedOn.Month, 1).AddMonths(-17);
+        var horizonRows = inflows
+            .Where(inflow => inflow is null || inflow.Date >= horizonStart && inflow.Date <= evaluatedOn)
+            .ToArray();
+        if (horizonRows.Any(inflow => inflow is null)) return [];
+
+        var owners = horizonRows.Select(inflow => inflow.OwnerId).Distinct(StringComparer.Ordinal).ToArray();
+        if (owners.Length > 1 || owners.Any(string.IsNullOrWhiteSpace)) return [];
+
+        var duplicateIds = horizonRows
+            .GroupBy(inflow => inflow.Id)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToHashSet();
+
+        var groups = horizonRows
+            .GroupBy(inflow => AccountInflowIdentity.NormalizeDescription(inflow.Description))
+            .OrderBy(group => group.Key, StringComparer.Ordinal);
+
+        var candidates = new List<PaycheckCandidate>();
+        foreach (var group in groups)
+        {
+            var evidence = group.OrderBy(inflow => inflow.Date).ThenBy(inflow => inflow.Id).ToArray();
+            if (string.IsNullOrWhiteSpace(group.Key) || evidence.Any(inflow => !IsValid(inflow, duplicateIds)))
+                continue;
+
+            var candidate = DetectIdentity(group.Key, evidence, horizonStart, evaluatedOn);
+            if (candidate is not null) candidates.Add(candidate);
+        }
+
+        return new ReadOnlyCollection<PaycheckCandidate>(candidates);
+    }
+
+    private static bool IsValid(AccountInflow inflow, IReadOnlySet<int> duplicateIds) =>
+        inflow.Id > 0
+        && !duplicateIds.Contains(inflow.Id)
+        && inflow.PaycheckEvidenceRevision != Guid.Empty
+        && !string.IsNullOrWhiteSpace(inflow.Description)
+        && inflow.Description.Length <= 500
+        && PaycheckContractRules.IsValidAmount(inflow.Amount);
+
+    private static PaycheckCandidate? DetectIdentity(
+        string identity,
+        IReadOnlyList<AccountInflow> evidence,
+        DateOnly horizonStart,
+        DateOnly evaluatedOn)
+    {
+        var generationStart = new DateOnly(horizonStart.Year, horizonStart.Month, 1).AddMonths(-1);
+        var generationEnd = new DateOnly(evaluatedOn.Year, evaluatedOn.Month, 1).AddMonths(2).AddDays(-1);
+        var fits = new List<CandidateFit>();
+
+        foreach (var hypothesis in EnumerateHypotheses(generationStart, generationEnd))
+            fits.AddRange(FitRuns(hypothesis, evidence));
+
+        if (fits.Count == 0) return null;
+        var latestDate = fits.Max(fit => fit.FinalEvidenceDate);
+        var finalists = fits.Where(fit => fit.FinalEvidenceDate == latestDate).ToArray();
+        var greatestCount = finalists.Max(fit => fit.Evidence.Count);
+        finalists = finalists.Where(fit => fit.Evidence.Count == greatestCount).ToArray();
+        var smallestOffset = finalists.Min(fit => fit.TotalAbsoluteOffset);
+        finalists = finalists.Where(fit => fit.TotalAbsoluteOffset == smallestOffset).ToArray();
+        finalists = finalists
+            .GroupBy(CanonicalFitKey, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToArray();
+        if (finalists.Length != 1) return null;
+
+        var selected = finalists[0];
+        var amounts = selected.Evidence.Select(value => value.Inflow.Amount).Order().ToArray();
+        ObservedPaycheckAmountSummary amount = amounts[0] == amounts[^1]
+            ? new FixedObservedPaycheckAmount(amounts[0])
+            : new VariableObservedPaycheckAmount(amounts[0], amounts[(amounts.Length - 1) / 2], amounts[^1]);
+        var snapshots = selected.Evidence
+            .OrderBy(value => value.Inflow.Date)
+            .ThenBy(value => value.Inflow.Id)
+            .Select(value => new PaycheckCandidateEvidence(
+                value.Inflow.Id,
+                value.Inflow.PaycheckEvidenceRevision,
+                value.Inflow.Description,
+                value.Inflow.Date,
+                value.Inflow.Amount,
+                value.Anchor,
+                value.Offset))
+            .ToArray();
+        var fingerprint = Fingerprint(
+            selected.Schedule,
+            selected.WindowBeforeDays,
+            selected.WindowAfterDays,
+            identity,
+            snapshots);
+        return new PaycheckCandidate(
+            AlgorithmVersion,
+            identity,
+            selected.Schedule,
+            selected.WindowBeforeDays,
+            selected.WindowAfterDays,
+            amount,
+            fingerprint,
+            snapshots);
+    }
+
+    private static IEnumerable<ScheduleHypothesis> EnumerateHypotheses(DateOnly start, DateOnly end)
+    {
+        for (var phase = 0; phase < 7; phase++)
+        {
+            var reference = FirstDayWithPhase(start, phase, 7);
+            var schedule = new WeeklyPaycheckSchedule(reference);
+            yield return new(schedule, PaycheckScheduleEngine.GenerateAnchors(schedule, start, end));
+        }
+
+        for (var phase = 0; phase < 14; phase++)
+        {
+            var reference = FirstDayWithPhase(start, phase, 14);
+            var schedule = new BiweeklyPaycheckSchedule(reference);
+            yield return new(schedule, PaycheckScheduleEngine.GenerateAnchors(schedule, start, end));
+        }
+
+        foreach (var anchor in PaycheckScheduleEngine.CanonicalMonthAnchors)
+        {
+            var schedule = new MonthlyPaycheckSchedule(anchor);
+            yield return new(schedule, PaycheckScheduleEngine.GenerateAnchors(schedule, start, end));
+        }
+
+        foreach (var first in PaycheckScheduleEngine.CanonicalMonthAnchors)
+        {
+            foreach (var second in PaycheckScheduleEngine.CanonicalMonthAnchors)
+            {
+                if (!PaycheckScheduleEngine.IsValidSemimonthlyPair(first, second)) continue;
+                var schedule = new SemimonthlyPaycheckSchedule(first, second);
+                yield return new(schedule, PaycheckScheduleEngine.GenerateAnchors(schedule, start, end));
+            }
+        }
+    }
+
+    private static DateOnly FirstDayWithPhase(DateOnly start, int phase, int interval)
+    {
+        var adjustment = Mod(phase - Mod(start.DayNumber, interval), interval);
+        return DateOnly.FromDayNumber(start.DayNumber + adjustment);
+    }
+
+    private static IEnumerable<CandidateFit> FitRuns(
+        ScheduleHypothesis hypothesis,
+        IReadOnlyList<AccountInflow> evidence)
+    {
+        var assignments = new int?[evidence.Count];
+        for (var evidenceIndex = 0; evidenceIndex < evidence.Count; evidenceIndex++)
+        {
+            var bestDistance = 4;
+            var bestAnchorIndex = -1;
+            var tied = false;
+            for (var anchorIndex = 0; anchorIndex < hypothesis.Anchors.Count; anchorIndex++)
+            {
+                var distance = Math.Abs(evidence[evidenceIndex].Date.DayNumber - hypothesis.Anchors[anchorIndex].DayNumber);
+                if (distance > 3) continue;
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    bestAnchorIndex = anchorIndex;
+                    tied = false;
+                }
+                else if (distance == bestDistance)
+                {
+                    tied = true;
+                }
+            }
+            if (bestAnchorIndex >= 0 && !tied) assignments[evidenceIndex] = bestAnchorIndex;
+        }
+
+        var assignedBySlot = assignments
+            .Select((slot, evidenceIndex) => (slot, evidenceIndex))
+            .Where(value => value.slot.HasValue)
+            .GroupBy(value => value.slot!.Value)
+            .ToDictionary(group => group.Key, group => group.Select(value => value.evidenceIndex).ToArray());
+
+        var run = new List<AssignedEvidence>();
+        var fits = new List<CandidateFit>();
+        for (var anchorIndex = 0; anchorIndex < hypothesis.Anchors.Count; anchorIndex++)
+        {
+            if (!assignedBySlot.TryGetValue(anchorIndex, out var slotEvidence) || slotEvidence.Length != 1)
+            {
+                AddFitIfQualifying(hypothesis.Schedule, run, fits);
+                run.Clear();
+                continue;
+            }
+
+            var evidenceIndex = slotEvidence[0];
+            if (run.Count > 0 && evidenceIndex != run[^1].EvidenceIndex + 1)
+            {
+                AddFitIfQualifying(hypothesis.Schedule, run, fits);
+                run.Clear();
+            }
+
+            var anchor = hypothesis.Anchors[anchorIndex];
+            run.Add(new(
+                evidenceIndex,
+                evidence[evidenceIndex],
+                anchor,
+                evidence[evidenceIndex].Date.DayNumber - anchor.DayNumber));
+        }
+        AddFitIfQualifying(hypothesis.Schedule, run, fits);
+        return fits;
+    }
+
+    private static void AddFitIfQualifying(
+        PaycheckSchedule hypothesisSchedule,
+        IReadOnlyList<AssignedEvidence> run,
+        ICollection<CandidateFit> fits)
+    {
+        var qualifies = hypothesisSchedule.Cadence switch
+        {
+            PaycheckCadence.Weekly => run.Count >= 6,
+            PaycheckCadence.Biweekly => run.Count >= 4
+                && run[^1].Anchor.DayNumber - run[0].Anchor.DayNumber >= 42,
+            PaycheckCadence.Monthly => run.Count >= 3,
+            PaycheckCadence.Semimonthly => run.Count >= 6
+                && run.Select(value => (value.Inflow.Date.Year, value.Inflow.Date.Month)).Distinct().Count() >= 3,
+            _ => false
+        };
+        if (!qualifies) return;
+
+        PaycheckSchedule schedule = hypothesisSchedule switch
+        {
+            WeeklyPaycheckSchedule => new WeeklyPaycheckSchedule(run[0].Anchor),
+            BiweeklyPaycheckSchedule => new BiweeklyPaycheckSchedule(run[0].Anchor),
+            _ => hypothesisSchedule
+        };
+        var offsets = run.Select(value => value.Offset).ToArray();
+        fits.Add(new(
+            schedule,
+            Math.Max(0, -offsets.Min()),
+            Math.Max(0, offsets.Max()),
+            new ReadOnlyCollection<AssignedEvidence>(run.ToArray()),
+            run.Max(value => value.Inflow.Date),
+            offsets.Sum(Math.Abs)));
+    }
+
+    private static string CanonicalFitKey(CandidateFit fit)
+    {
+        var schedule = fit.Schedule switch
+        {
+            WeeklyPaycheckSchedule weekly => $"w:{weekly.ReferenceAnchor.DayNumber}",
+            BiweeklyPaycheckSchedule biweekly => $"b:{biweekly.ReferenceAnchor.DayNumber}",
+            MonthlyPaycheckSchedule monthly => $"m:{AnchorKey(monthly.Anchor)}",
+            SemimonthlyPaycheckSchedule semimonthly => $"s:{AnchorKey(semimonthly.First)}:{AnchorKey(semimonthly.Second)}",
+            _ => throw new InvalidOperationException("Unsupported paycheck schedule.")
+        };
+        return $"{schedule}|{fit.WindowBeforeDays}|{fit.WindowAfterDays}|{string.Join(',', fit.Evidence.Select(value => value.Inflow.Id))}";
+    }
+
+    private static string AnchorKey(PaycheckMonthAnchor anchor) =>
+        $"{PaycheckScheduleEngine.AnchorKindCode(anchor)}:{PaycheckScheduleEngine.AnchorDayCode(anchor)}";
+
+    private static string Fingerprint(
+        PaycheckSchedule schedule,
+        int windowBeforeDays,
+        int windowAfterDays,
+        string identity,
+        IReadOnlyList<PaycheckCandidateEvidence> evidence)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(FingerprintDomain);
+        WriteString(stream, AlgorithmVersion);
+        stream.WriteByte(CadenceCode(schedule.Cadence));
+        WriteSchedule(stream, schedule);
+        WriteInt32(stream, windowBeforeDays);
+        WriteInt32(stream, windowAfterDays);
+        WriteString(stream, identity);
+        WriteInt32(stream, evidence.Count);
+        Span<byte> revision = stackalloc byte[16];
+        foreach (var item in evidence)
+        {
+            WriteInt32(stream, item.AccountInflowId);
+            item.PaycheckEvidenceRevision.TryWriteBytes(revision, bigEndian: true, out _);
+            stream.Write(revision);
+        }
+        return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
+    }
+
+    private static byte CadenceCode(PaycheckCadence cadence) => cadence switch
+    {
+        PaycheckCadence.Weekly => 1,
+        PaycheckCadence.Biweekly => 2,
+        PaycheckCadence.Semimonthly => 3,
+        PaycheckCadence.Monthly => 4,
+        _ => throw new InvalidOperationException("Unsupported paycheck cadence.")
+    };
+
+    private static void WriteSchedule(Stream stream, PaycheckSchedule schedule)
+    {
+        switch (schedule)
+        {
+            case WeeklyPaycheckSchedule weekly:
+                WriteInt32(stream, weekly.ReferenceAnchor.DayNumber);
+                break;
+            case BiweeklyPaycheckSchedule biweekly:
+                WriteInt32(stream, biweekly.ReferenceAnchor.DayNumber);
+                break;
+            case MonthlyPaycheckSchedule monthly:
+                WriteAnchor(stream, monthly.Anchor);
+                break;
+            case SemimonthlyPaycheckSchedule semimonthly:
+                WriteAnchor(stream, semimonthly.First);
+                WriteAnchor(stream, semimonthly.Second);
+                break;
+            default:
+                throw new InvalidOperationException("Unsupported paycheck schedule.");
+        }
+    }
+
+    private static void WriteAnchor(Stream stream, PaycheckMonthAnchor anchor)
+    {
+        WriteInt32(stream, PaycheckScheduleEngine.AnchorKindCode(anchor));
+        WriteInt32(stream, PaycheckScheduleEngine.AnchorDayCode(anchor));
+    }
+
+    private static void WriteString(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteInt32(stream, bytes.Length);
+        stream.Write(bytes);
+    }
+
+    private static void WriteInt32(Stream stream, int value)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+        stream.Write(bytes);
+    }
+
+    private static int Mod(int value, int divisor) => ((value % divisor) + divisor) % divisor;
+
+    private sealed record ScheduleHypothesis(PaycheckSchedule Schedule, IReadOnlyList<DateOnly> Anchors);
+    private sealed record AssignedEvidence(
+        int EvidenceIndex,
+        AccountInflow Inflow,
+        DateOnly Anchor,
+        int Offset);
+    private sealed record CandidateFit(
+        PaycheckSchedule Schedule,
+        int WindowBeforeDays,
+        int WindowAfterDays,
+        IReadOnlyList<AssignedEvidence> Evidence,
+        DateOnly FinalEvidenceDate,
+        int TotalAbsoluteOffset);
+}

--- a/backend/Paychecks/PaycheckProjector.cs
+++ b/backend/Paychecks/PaycheckProjector.cs
@@ -1,0 +1,26 @@
+namespace BudgetPlanner.Paychecks;
+
+public sealed class PaycheckProjector
+{
+    public const string AlgorithmVersion = "paycheck-projector-v1";
+
+    public PaycheckProjection Project(ConfirmedPaycheckPattern pattern, DateOnly evaluatedOn)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        var targetDayNumber = evaluatedOn.DayNumber - pattern.WindowAfterDays;
+        if (pattern.LatestConfirmedSlotAnchor is { } latest)
+            targetDayNumber = Math.Max(targetDayNumber, latest.DayNumber + 1);
+        var anchor = PaycheckScheduleEngine.FirstAnchorOnOrAfter(
+            pattern.Schedule,
+            DateOnly.FromDayNumber(targetDayNumber));
+
+        return new PaycheckProjection(
+            AlgorithmVersion,
+            evaluatedOn,
+            anchor,
+            anchor.AddDays(-pattern.WindowBeforeDays),
+            anchor.AddDays(pattern.WindowAfterDays),
+            pattern.Amount);
+    }
+}

--- a/backend/Paychecks/PaycheckSchedule.cs
+++ b/backend/Paychecks/PaycheckSchedule.cs
@@ -1,0 +1,453 @@
+using System.Collections.ObjectModel;
+using BudgetPlanner.Models;
+
+namespace BudgetPlanner.Paychecks;
+
+public enum PaycheckCadence
+{
+    Weekly,
+    Biweekly,
+    Semimonthly,
+    Monthly
+}
+
+public enum PaycheckMonthAnchorKind
+{
+    DayOfMonth,
+    MonthEnd
+}
+
+public sealed record PaycheckMonthAnchor
+{
+    private PaycheckMonthAnchor(PaycheckMonthAnchorKind kind, int? day)
+    {
+        Kind = kind;
+        Day = day;
+    }
+
+    public PaycheckMonthAnchorKind Kind { get; }
+    public int? Day { get; }
+
+    public static PaycheckMonthAnchor DayOfMonth(int day)
+    {
+        if (day is < 1 or > 31)
+            throw new ArgumentOutOfRangeException(nameof(day), "A month anchor day must be between 1 and 31.");
+
+        return day == 31 ? MonthEnd : new(PaycheckMonthAnchorKind.DayOfMonth, day);
+    }
+
+    public static PaycheckMonthAnchor MonthEnd { get; } = new(PaycheckMonthAnchorKind.MonthEnd, null);
+}
+
+public abstract record PaycheckSchedule
+{
+    protected PaycheckSchedule(PaycheckCadence cadence) => Cadence = cadence;
+
+    public PaycheckCadence Cadence { get; }
+}
+
+public sealed record WeeklyPaycheckSchedule : PaycheckSchedule
+{
+    public WeeklyPaycheckSchedule(DateOnly referenceAnchor) : base(PaycheckCadence.Weekly) =>
+        ReferenceAnchor = referenceAnchor;
+
+    public DateOnly ReferenceAnchor { get; }
+}
+
+public sealed record BiweeklyPaycheckSchedule : PaycheckSchedule
+{
+    public BiweeklyPaycheckSchedule(DateOnly referenceAnchor) : base(PaycheckCadence.Biweekly) =>
+        ReferenceAnchor = referenceAnchor;
+
+    public DateOnly ReferenceAnchor { get; }
+}
+
+public sealed record MonthlyPaycheckSchedule : PaycheckSchedule
+{
+    public MonthlyPaycheckSchedule(PaycheckMonthAnchor anchor) : base(PaycheckCadence.Monthly)
+    {
+        ArgumentNullException.ThrowIfNull(anchor);
+        Anchor = anchor;
+    }
+
+    public PaycheckMonthAnchor Anchor { get; }
+}
+
+public sealed record SemimonthlyPaycheckSchedule : PaycheckSchedule
+{
+    public SemimonthlyPaycheckSchedule(PaycheckMonthAnchor first, PaycheckMonthAnchor second)
+        : base(PaycheckCadence.Semimonthly)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        if (!PaycheckScheduleEngine.IsValidSemimonthlyPair(first, second))
+            throw new ArgumentException("Semimonthly anchors must be canonical, ordered, distinct, and always at least seven days apart.");
+
+        First = first;
+        Second = second;
+    }
+
+    public PaycheckMonthAnchor First { get; }
+    public PaycheckMonthAnchor Second { get; }
+}
+
+public sealed record PaycheckCandidateEvidence
+{
+    public PaycheckCandidateEvidence(
+        int accountInflowId,
+        Guid paycheckEvidenceRevision,
+        string description,
+        DateOnly postedDate,
+        decimal amount,
+        DateOnly slotAnchor,
+        int timingOffsetDays)
+    {
+        if (accountInflowId <= 0) throw new ArgumentOutOfRangeException(nameof(accountInflowId));
+        if (paycheckEvidenceRevision == Guid.Empty) throw new ArgumentException("Evidence revision is required.", nameof(paycheckEvidenceRevision));
+        if (string.IsNullOrWhiteSpace(description) || description.Length > 500)
+            throw new ArgumentException("A stored description between 1 and 500 characters is required.", nameof(description));
+        PaycheckContractRules.RequireAmount(amount, nameof(amount));
+        if (timingOffsetDays is < -3 or > 3 || postedDate.DayNumber - slotAnchor.DayNumber != timingOffsetDays)
+            throw new ArgumentOutOfRangeException(nameof(timingOffsetDays));
+
+        AccountInflowId = accountInflowId;
+        PaycheckEvidenceRevision = paycheckEvidenceRevision;
+        Description = description;
+        PostedDate = postedDate;
+        Amount = amount;
+        SlotAnchor = slotAnchor;
+        TimingOffsetDays = timingOffsetDays;
+    }
+
+    public int AccountInflowId { get; }
+    public Guid PaycheckEvidenceRevision { get; }
+    public string Description { get; }
+    public DateOnly PostedDate { get; }
+    public decimal Amount { get; }
+    public DateOnly SlotAnchor { get; }
+    public int TimingOffsetDays { get; }
+}
+
+public abstract record ObservedPaycheckAmountSummary;
+
+public sealed record FixedObservedPaycheckAmount : ObservedPaycheckAmountSummary
+{
+    public FixedObservedPaycheckAmount(decimal amount)
+    {
+        PaycheckContractRules.RequireAmount(amount, nameof(amount));
+        Amount = amount;
+    }
+
+    public decimal Amount { get; }
+}
+
+public sealed record VariableObservedPaycheckAmount : ObservedPaycheckAmountSummary
+{
+    public VariableObservedPaycheckAmount(decimal minimum, decimal lowerMedian, decimal maximum)
+    {
+        PaycheckContractRules.RequireAmount(minimum, nameof(minimum));
+        PaycheckContractRules.RequireAmount(lowerMedian, nameof(lowerMedian));
+        PaycheckContractRules.RequireAmount(maximum, nameof(maximum));
+        if (minimum >= maximum || lowerMedian < minimum || lowerMedian > maximum)
+            throw new ArgumentException("A variable amount requires minimum < maximum and a median within that range.");
+
+        Minimum = minimum;
+        LowerMedian = lowerMedian;
+        Maximum = maximum;
+    }
+
+    public decimal Minimum { get; }
+    public decimal LowerMedian { get; }
+    public decimal Maximum { get; }
+}
+
+public sealed record PaycheckCandidate
+{
+    public PaycheckCandidate(
+        string algorithmVersion,
+        string normalizedDescriptionIdentity,
+        PaycheckSchedule schedule,
+        int windowBeforeDays,
+        int windowAfterDays,
+        ObservedPaycheckAmountSummary observedAmount,
+        string evidenceFingerprint,
+        IEnumerable<PaycheckCandidateEvidence> evidence)
+    {
+        if (string.IsNullOrWhiteSpace(algorithmVersion)) throw new ArgumentException("Algorithm version is required.", nameof(algorithmVersion));
+        if (string.IsNullOrWhiteSpace(normalizedDescriptionIdentity)
+            || normalizedDescriptionIdentity != AccountInflowIdentity.NormalizeDescription(normalizedDescriptionIdentity))
+            throw new ArgumentException("A normalized description identity is required.", nameof(normalizedDescriptionIdentity));
+        ArgumentNullException.ThrowIfNull(schedule);
+        PaycheckContractRules.RequireWindow(windowBeforeDays, nameof(windowBeforeDays));
+        PaycheckContractRules.RequireWindow(windowAfterDays, nameof(windowAfterDays));
+        ArgumentNullException.ThrowIfNull(observedAmount);
+        if (string.IsNullOrEmpty(evidenceFingerprint)
+            || evidenceFingerprint.Length != 64
+            || evidenceFingerprint.Any(character => character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f')))
+            throw new ArgumentException("The evidence fingerprint must be lowercase SHA-256 hex.", nameof(evidenceFingerprint));
+        ArgumentNullException.ThrowIfNull(evidence);
+        var snapshot = evidence.ToArray();
+        if (snapshot.Length == 0) throw new ArgumentException("Candidate evidence is required.", nameof(evidence));
+
+        AlgorithmVersion = algorithmVersion;
+        NormalizedDescriptionIdentity = normalizedDescriptionIdentity;
+        Schedule = schedule;
+        WindowBeforeDays = windowBeforeDays;
+        WindowAfterDays = windowAfterDays;
+        ObservedAmount = observedAmount;
+        EvidenceFingerprint = evidenceFingerprint;
+        Evidence = Array.AsReadOnly(snapshot);
+    }
+
+    public string AlgorithmVersion { get; }
+    public string NormalizedDescriptionIdentity { get; }
+    public PaycheckSchedule Schedule { get; }
+    public int WindowBeforeDays { get; }
+    public int WindowAfterDays { get; }
+    public ObservedPaycheckAmountSummary ObservedAmount { get; }
+    public string EvidenceFingerprint { get; }
+    public IReadOnlyList<PaycheckCandidateEvidence> Evidence { get; }
+}
+
+public abstract record ConfirmedPaycheckAmount;
+
+public sealed record FixedConfirmedPaycheckAmount : ConfirmedPaycheckAmount
+{
+    public FixedConfirmedPaycheckAmount(decimal amount)
+    {
+        PaycheckContractRules.RequireAmount(amount, nameof(amount));
+        Amount = amount;
+    }
+
+    public decimal Amount { get; }
+}
+
+public sealed record RangeConfirmedPaycheckAmount : ConfirmedPaycheckAmount
+{
+    public RangeConfirmedPaycheckAmount(decimal minimum, decimal maximum)
+    {
+        PaycheckContractRules.RequireAmount(minimum, nameof(minimum));
+        PaycheckContractRules.RequireAmount(maximum, nameof(maximum));
+        if (minimum >= maximum) throw new ArgumentException("A range requires minimum < maximum.");
+        Minimum = minimum;
+        Maximum = maximum;
+    }
+
+    public decimal Minimum { get; }
+    public decimal Maximum { get; }
+}
+
+public sealed record ConfirmedPaycheckPattern
+{
+    public ConfirmedPaycheckPattern(
+        PaycheckSchedule schedule,
+        int windowBeforeDays,
+        int windowAfterDays,
+        ConfirmedPaycheckAmount amount,
+        DateOnly? latestConfirmedSlotAnchor = null)
+    {
+        ArgumentNullException.ThrowIfNull(schedule);
+        PaycheckContractRules.RequireWindow(windowBeforeDays, nameof(windowBeforeDays));
+        PaycheckContractRules.RequireWindow(windowAfterDays, nameof(windowAfterDays));
+        ArgumentNullException.ThrowIfNull(amount);
+        if (latestConfirmedSlotAnchor is { } latest && !PaycheckScheduleEngine.IsAnchor(schedule, latest))
+            throw new ArgumentException("The latest confirmed slot must be an anchor of the schedule.", nameof(latestConfirmedSlotAnchor));
+
+        Schedule = schedule;
+        WindowBeforeDays = windowBeforeDays;
+        WindowAfterDays = windowAfterDays;
+        Amount = amount;
+        LatestConfirmedSlotAnchor = latestConfirmedSlotAnchor;
+    }
+
+    public PaycheckSchedule Schedule { get; }
+    public int WindowBeforeDays { get; }
+    public int WindowAfterDays { get; }
+    public ConfirmedPaycheckAmount Amount { get; }
+    public DateOnly? LatestConfirmedSlotAnchor { get; }
+}
+
+public sealed record PaycheckProjection(
+    string AlgorithmVersion,
+    DateOnly EvaluatedOn,
+    DateOnly Anchor,
+    DateOnly EarliestExpectedDate,
+    DateOnly LatestExpectedDate,
+    ConfirmedPaycheckAmount Amount);
+
+internal static class PaycheckContractRules
+{
+    internal const decimal MaximumAmount = 9999999999999999.99m;
+
+    internal static void RequireAmount(decimal amount, string parameterName)
+    {
+        if (amount <= 0m || amount > MaximumAmount || decimal.Round(amount, 2) != amount)
+            throw new ArgumentOutOfRangeException(parameterName, "Amounts must be positive, representable numeric(18,2) values.");
+    }
+
+    internal static bool IsValidAmount(decimal amount) =>
+        amount > 0m && amount <= MaximumAmount && decimal.Round(amount, 2) == amount;
+
+    internal static void RequireWindow(int value, string parameterName)
+    {
+        if (value is < 0 or > 3)
+            throw new ArgumentOutOfRangeException(parameterName, "Paycheck windows must be between zero and three days.");
+    }
+}
+
+internal static class PaycheckScheduleEngine
+{
+    private static readonly IReadOnlyList<PaycheckMonthAnchor> MonthAnchors =
+        new ReadOnlyCollection<PaycheckMonthAnchor>(
+            Enumerable.Range(1, 30).Select(PaycheckMonthAnchor.DayOfMonth)
+                .Append(PaycheckMonthAnchor.MonthEnd)
+                .ToArray());
+
+    private static readonly HashSet<(int First, int Second)> ValidSemimonthlyPairs = BuildValidSemimonthlyPairs();
+
+    internal static IReadOnlyList<PaycheckMonthAnchor> CanonicalMonthAnchors => MonthAnchors;
+
+    internal static bool IsValidSemimonthlyPair(PaycheckMonthAnchor first, PaycheckMonthAnchor second) =>
+        AnchorRank(first) < AnchorRank(second)
+        && ValidSemimonthlyPairs.Contains((AnchorRank(first), AnchorRank(second)));
+
+    internal static DateOnly CalendarAnchor(int year, int month, PaycheckMonthAnchor anchor)
+    {
+        var day = anchor.Kind == PaycheckMonthAnchorKind.MonthEnd
+            ? DateTime.DaysInMonth(year, month)
+            : Math.Min(anchor.Day!.Value, DateTime.DaysInMonth(year, month));
+        return new DateOnly(year, month, day);
+    }
+
+    internal static IReadOnlyList<DateOnly> GenerateAnchors(PaycheckSchedule schedule, DateOnly start, DateOnly end)
+    {
+        if (end < start) return [];
+
+        return schedule switch
+        {
+            WeeklyPaycheckSchedule weekly => GenerateIntervalAnchors(weekly.ReferenceAnchor, 7, start, end),
+            BiweeklyPaycheckSchedule biweekly => GenerateIntervalAnchors(biweekly.ReferenceAnchor, 14, start, end),
+            MonthlyPaycheckSchedule monthly => GenerateCalendarAnchors([monthly.Anchor], start, end),
+            SemimonthlyPaycheckSchedule semimonthly => GenerateCalendarAnchors([semimonthly.First, semimonthly.Second], start, end),
+            _ => throw new ArgumentException("Unsupported paycheck schedule.", nameof(schedule))
+        };
+    }
+
+    internal static bool IsAnchor(PaycheckSchedule schedule, DateOnly date) => schedule switch
+    {
+        WeeklyPaycheckSchedule weekly => Mod(date.DayNumber - weekly.ReferenceAnchor.DayNumber, 7) == 0,
+        BiweeklyPaycheckSchedule biweekly => Mod(date.DayNumber - biweekly.ReferenceAnchor.DayNumber, 14) == 0,
+        MonthlyPaycheckSchedule monthly => CalendarAnchor(date.Year, date.Month, monthly.Anchor) == date,
+        SemimonthlyPaycheckSchedule semimonthly =>
+            CalendarAnchor(date.Year, date.Month, semimonthly.First) == date
+            || CalendarAnchor(date.Year, date.Month, semimonthly.Second) == date,
+        _ => false
+    };
+
+    internal static DateOnly FirstAnchorOnOrAfter(PaycheckSchedule schedule, DateOnly target) => schedule switch
+    {
+        WeeklyPaycheckSchedule weekly => FirstIntervalAnchorOnOrAfter(weekly.ReferenceAnchor, 7, target),
+        BiweeklyPaycheckSchedule biweekly => FirstIntervalAnchorOnOrAfter(biweekly.ReferenceAnchor, 14, target),
+        MonthlyPaycheckSchedule monthly => FirstCalendarAnchorOnOrAfter([monthly.Anchor], target),
+        SemimonthlyPaycheckSchedule semimonthly => FirstCalendarAnchorOnOrAfter([semimonthly.First, semimonthly.Second], target),
+        _ => throw new ArgumentException("Unsupported paycheck schedule.", nameof(schedule))
+    };
+
+    internal static int AnchorKindCode(PaycheckMonthAnchor anchor) =>
+        anchor.Kind == PaycheckMonthAnchorKind.DayOfMonth ? 1 : 2;
+
+    internal static int AnchorDayCode(PaycheckMonthAnchor anchor) => anchor.Day ?? 0;
+
+    private static IReadOnlyList<DateOnly> GenerateIntervalAnchors(
+        DateOnly reference,
+        int intervalDays,
+        DateOnly start,
+        DateOnly end)
+    {
+        var first = FirstPhaseAnchorOnOrAfter(reference, intervalDays, start);
+        var anchors = new List<DateOnly>();
+        for (var dayNumber = first.DayNumber; dayNumber <= end.DayNumber; dayNumber += intervalDays)
+            anchors.Add(DateOnly.FromDayNumber(dayNumber));
+        return anchors;
+    }
+
+    private static DateOnly FirstPhaseAnchorOnOrAfter(DateOnly reference, int intervalDays, DateOnly target)
+    {
+        var adjustment = Mod(reference.DayNumber - target.DayNumber, intervalDays);
+        return DateOnly.FromDayNumber(target.DayNumber + adjustment);
+    }
+
+    private static DateOnly FirstIntervalAnchorOnOrAfter(DateOnly reference, int intervalDays, DateOnly target)
+    {
+        if (target <= reference) return reference;
+        return FirstPhaseAnchorOnOrAfter(reference, intervalDays, target);
+    }
+
+    private static IReadOnlyList<DateOnly> GenerateCalendarAnchors(
+        IReadOnlyList<PaycheckMonthAnchor> anchors,
+        DateOnly start,
+        DateOnly end)
+    {
+        var results = new List<DateOnly>();
+        var month = new DateOnly(start.Year, start.Month, 1);
+        var finalMonth = new DateOnly(end.Year, end.Month, 1);
+        while (month <= finalMonth)
+        {
+            foreach (var anchor in anchors)
+            {
+                var date = CalendarAnchor(month.Year, month.Month, anchor);
+                if (date >= start && date <= end) results.Add(date);
+            }
+            month = month.AddMonths(1);
+        }
+        results.Sort();
+        return results;
+    }
+
+    private static DateOnly FirstCalendarAnchorOnOrAfter(
+        IReadOnlyList<PaycheckMonthAnchor> anchors,
+        DateOnly target)
+    {
+        var month = new DateOnly(target.Year, target.Month, 1);
+        while (true)
+        {
+            foreach (var anchor in anchors)
+            {
+                var date = CalendarAnchor(month.Year, month.Month, anchor);
+                if (date >= target) return date;
+            }
+            month = month.AddMonths(1);
+        }
+    }
+
+    private static HashSet<(int First, int Second)> BuildValidSemimonthlyPairs()
+    {
+        var valid = new HashSet<(int, int)>();
+        foreach (var first in MonthAnchors)
+        {
+            foreach (var second in MonthAnchors)
+            {
+                if (AnchorRank(first) >= AnchorRank(second)) continue;
+                var pairIsValid = true;
+                for (var year = 2000; year < 2400 && pairIsValid; year++)
+                {
+                    for (var month = 1; month <= 12 && pairIsValid; month++)
+                    {
+                        var firstDate = CalendarAnchor(year, month, first);
+                        var secondDate = CalendarAnchor(year, month, second);
+                        var nextMonth = new DateOnly(year, month, 1).AddMonths(1);
+                        var nextFirstDate = CalendarAnchor(nextMonth.Year, nextMonth.Month, first);
+                        pairIsValid = secondDate.DayNumber - firstDate.DayNumber >= 7
+                            && nextFirstDate.DayNumber - secondDate.DayNumber >= 7;
+                    }
+                }
+                if (pairIsValid) valid.Add((AnchorRank(first), AnchorRank(second)));
+            }
+        }
+        return valid;
+    }
+
+    private static int AnchorRank(PaycheckMonthAnchor anchor) => anchor.Day ?? 31;
+
+    private static int Mod(int value, int divisor) => ((value % divisor) + divisor) % divisor;
+}


### PR DESCRIPTION
## Summary

- add the pure, versioned paycheck-candidate-v1 detector with the approved 18-calendar-month horizon, cadence hypotheses, nearest-slot assignment, ambiguity barriers, maximal-run ranking, amount summaries, and deterministic V1 fingerprint
- add paycheck-specific immutable schedules/contracts and a shared calendar engine with canonical month end, Gregorian clamping, and 400-year semimonthly separation validation
- add the pure paycheck-projector-v1 projector for confirmed patterns and inclusive expected windows
- share canonical AccountInflow description normalization with UpdateEvidence
- add exhaustive synthetic detector, projector, fingerprint, ordering, validation, and characterization tests

Closes #110

## Risk

HIGH — this defines recurring-income recognition and future-pay timing semantics. Implementation is limited to the owner-approved Stage 2 pure domain/test plan.

## Important implementation details

- weekly and biweekly remain fixed-day interval schedules with preserved reference phase
- monthly and semimonthly use canonical clamped calendar anchors; day 31 canonicalizes to month end
- ambiguous observations, duplicate slot assignments, cadence ties, schedule ties, and evidence-assignment ties fail closed
- selection order is newest qualifying maximal run, then greatest evidence count, then smallest total absolute offset
- fingerprints use explicit big-endian fields, stable cadence/anchor codes, RFC-4122 network-order UUID bytes, and lowercase SHA-256 hex; a golden vector locks V1
- detector results snapshot evidence and do not expose owner/navigation state

## Verification

Passed locally:

- focused Stage 2 and AccountInflow tests: 45 passed
- backend Release build: 0 warnings, 0 errors
- changed-file dotnet whitespace verification
- git diff --cached --check
- branch merge base matches origin/main at 69bce21f3ab3b5910c7283396a826191dbff93d6

Local full-suite gap:

- ./scripts/verify.sh backend built successfully and passed 346 of 347 tests on two runs, but the pre-existing Generated_boundary_pdfs_flow_through_extractor_before_row_limit_enforcement PDF-worker test timed out under full-suite load; that exact test passed when run alone
- a supplemental run excluding that boundary case encountered two other pre-existing PDF-worker timing failures under suite load; no paycheck or AccountInflow test failed
- independent Backend CI is required before review-ready status

## Scope boundaries

- no EF mapping, persistence model, schema, or migration changes
- no service, controller, endpoint, API, importer runtime, or Program registration
- no paycheck profile, dismissal, occurrence, lifecycle, or change-detection persistence
- no frontend/UI, flags, dependencies, deployment, production access, or data operations

## Impact

- Migration impact: none
- API impact: none
- Dependency impact: none
- Production operation: none authorized or performed