### PR TITLE
Add account inflow APIs and credit import confirmation

### DIFF
--- a/backend.Tests/Financial/FinancialApiTestApplication.cs
+++ b/backend.Tests/Financial/FinancialApiTestApplication.cs
@@ -136,6 +136,26 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
         return expense;
     }
 
+    public async Task<AccountInflow> SeedInflowAsync(
+        string ownerId,
+        string description = "seeded inflow",
+        decimal amount = 123.45m,
+        DateOnly? date = null)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var inflow = new AccountInflow
+        {
+            OwnerId = ownerId,
+            Description = description,
+            Amount = amount,
+            Date = date ?? new DateOnly(2026, 9, 1)
+        };
+        context.AccountInflows.Add(inflow);
+        await context.SaveChangesAsync();
+        return inflow;
+    }
+
     public async Task<BudgetLimit> SeedBudgetLimitAsync(
         string userId,
         string category = "food",
@@ -161,6 +181,14 @@ internal abstract class FinancialApiTestApplicationBase : WebApplicationFactory<
         using var scope = Services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
         return await context.Expenses.AsNoTracking().SingleOrDefaultAsync(expense => expense.Id == id);
+    }
+
+    public async Task<AccountInflow?> FindInflowAsync(int id)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        return await context.AccountInflows.AsNoTracking()
+            .SingleOrDefaultAsync(value => value.Id == id);
     }
 
     public async Task<int> CountExpensesAsync()

--- a/backend.Tests/Financial/InflowsApiTests.cs
+++ b/backend.Tests/Financial/InflowsApiTests.cs
@@ -1,0 +1,262 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+public sealed class InflowsApiTests
+{
+    [Fact]
+    public async Task Unauthenticated_request_is_rejected()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+
+        using var response = await client.GetAsync("/api/inflows");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_assigns_authenticated_owner_trims_description_and_returns_explicit_dto()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("inflow-other@example.com");
+
+        using var response = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "  Synthetic   Deposit  ",
+            amount = 2450.25m,
+            date = "2026-09-03",
+            ownerId = other.Id
+        });
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("Synthetic   Deposit", body.GetProperty("description").GetString());
+        Assert.Equal(2450.25m, body.GetProperty("amount").GetDecimal());
+        Assert.Equal("2026-09-03", body.GetProperty("date").GetString());
+        Assert.False(body.TryGetProperty("ownerId", out _));
+        Assert.False(body.TryGetProperty("owner", out _));
+        Assert.False(body.TryGetProperty("paycheckEvidenceRevision", out _));
+        Assert.Equal(
+            $"/api/inflows/{body.GetProperty("id").GetInt32()}",
+            response.Headers.Location?.AbsolutePath);
+
+        var persisted = await app.FindInflowAsync(body.GetProperty("id").GetInt32());
+        Assert.NotNull(persisted);
+        Assert.Equal(owner.Id, persisted.OwnerId);
+        Assert.NotEqual(Guid.Empty, persisted.PaycheckEvidenceRevision);
+    }
+
+    [Fact]
+    public async Task List_is_owner_scoped_and_deterministically_orders_date_then_id_descending()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-list-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("inflow-list-other@example.com");
+        var older = await app.SeedInflowAsync(owner.Id, "older", date: new(2026, 8, 31));
+        var firstLatest = await app.SeedInflowAsync(owner.Id, "latest first", date: new(2026, 9, 2));
+        var secondLatest = await app.SeedInflowAsync(owner.Id, "latest second", date: new(2026, 9, 2));
+        await app.SeedInflowAsync(other.Id, "FOREIGN PRIVATE", date: new(2026, 9, 3));
+
+        using var response = await owner.Client.GetAsync("/api/inflows");
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            [secondLatest.Id, firstLatest.Id, older.Id],
+            body.EnumerateArray().Select(value => value.GetProperty("id").GetInt32()));
+        Assert.DoesNotContain("FOREIGN PRIVATE", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Item_read_returns_owned_record_and_bare_not_found_for_missing_or_foreign()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-read-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("inflow-read-other@example.com");
+        var owned = await app.SeedInflowAsync(owner.Id, "owned");
+        var foreign = await app.SeedInflowAsync(other.Id, "FOREIGN PRIVATE");
+
+        using var found = await owner.Client.GetAsync($"/api/inflows/{owned.Id}");
+        using var hidden = await owner.Client.GetAsync($"/api/inflows/{foreign.Id}");
+        using var missing = await owner.Client.GetAsync("/api/inflows/2147483647");
+
+        Assert.Equal(HttpStatusCode.OK, found.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, hidden.StatusCode);
+        Assert.Empty(await hidden.Content.ReadAsStringAsync());
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+        Assert.Empty(await missing.Content.ReadAsStringAsync());
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("123.456")]
+    [InlineData("10000000000000000")]
+    public async Task Create_rejects_invalid_amounts(string amountText)
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync($"inflow-amount-{Guid.NewGuid()}@example.com");
+
+        using var response = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "amount edge",
+            amount = decimal.Parse(amountText, System.Globalization.CultureInfo.InvariantCulture),
+            date = "2026-09-03"
+        });
+
+        await AssertValidationErrorAsync(response, "amount");
+    }
+
+    [Fact]
+    public async Task Create_accepts_numeric_18_2_maximum_and_rejects_missing_or_timestamp_date()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-date-owner@example.com");
+
+        using var accepted = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "maximum",
+            amount = 9999999999999999.99m,
+            date = "2026-09-03"
+        });
+        using var missing = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "missing date",
+            amount = 1m
+        });
+        using var timestamp = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "timestamp date",
+            amount = 1m,
+            date = "2026-09-03T00:00:00Z"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, accepted.StatusCode);
+        await AssertValidationErrorAsync(missing, "date");
+        Assert.Equal(HttpStatusCode.BadRequest, timestamp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_validates_description_after_outer_trim_and_allows_manual_duplicates()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-description-owner@example.com");
+        var boundary = new string('D', 500);
+
+        using var accepted = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = $"  {boundary}  ", amount = 1m, date = "2026-09-03"
+        });
+        using var duplicate = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = $"  {boundary}  ", amount = 1m, date = "2026-09-03"
+        });
+        using var blank = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "   ", amount = 1m, date = "2026-09-03"
+        });
+        using var tooLong = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = new string('x', 501), amount = 1m, date = "2026-09-03"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, accepted.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, duplicate.StatusCode);
+        await AssertValidationErrorAsync(blank, "description");
+        await AssertValidationErrorAsync(tooLong, "description");
+    }
+
+    [Fact]
+    public async Task Update_uses_evidence_semantics_for_equivalent_and_material_edits()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-update-owner@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, "Weekly   Payroll", 100m, new(2026, 9, 1));
+        var originalRevision = inflow.PaycheckEvidenceRevision;
+
+        using var formatting = await owner.Client.PutAsJsonAsync($"/api/inflows/{inflow.Id}", new
+        {
+            id = inflow.Id,
+            description = "  weekly payroll  ",
+            amount = 100m,
+            date = "2026-09-01"
+        });
+        var afterFormatting = await app.FindInflowAsync(inflow.Id);
+
+        Assert.Equal(HttpStatusCode.NoContent, formatting.StatusCode);
+        Assert.NotNull(afterFormatting);
+        Assert.Equal("weekly payroll", afterFormatting.Description);
+        Assert.Equal(originalRevision, afterFormatting.PaycheckEvidenceRevision);
+
+        using var material = await owner.Client.PutAsJsonAsync($"/api/inflows/{inflow.Id}", new
+        {
+            id = inflow.Id,
+            description = "different payroll",
+            amount = 101m,
+            date = "2026-09-02"
+        });
+        var afterMaterial = await app.FindInflowAsync(inflow.Id);
+
+        Assert.Equal(HttpStatusCode.NoContent, material.StatusCode);
+        Assert.NotNull(afterMaterial);
+        Assert.NotEqual(originalRevision, afterMaterial.PaycheckEvidenceRevision);
+    }
+
+    [Fact]
+    public async Task Update_rejects_id_mismatch_and_hides_foreign_before_validation()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-write-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("inflow-write-other@example.com");
+        var foreign = await app.SeedInflowAsync(other.Id, "protected");
+
+        using var mismatch = await owner.Client.PutAsJsonAsync("/api/inflows/1", new
+        {
+            id = 2, description = "mismatch", amount = 1m, date = "2026-09-03"
+        });
+        using var hidden = await owner.Client.PutAsJsonAsync($"/api/inflows/{foreign.Id}", new
+        {
+            id = foreign.Id, description = "   ", amount = -1m, date = (string?)null
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, mismatch.StatusCode);
+        Assert.Equal("Inflow ID mismatch", await mismatch.Content.ReadAsStringAsync());
+        Assert.Equal(HttpStatusCode.NotFound, hidden.StatusCode);
+        Assert.Empty(await hidden.Content.ReadAsStringAsync());
+        Assert.Equal("protected", (await app.FindInflowAsync(foreign.Id))?.Description);
+    }
+
+    [Fact]
+    public async Task Delete_removes_owned_record_and_hides_foreign_or_missing()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-delete-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("inflow-delete-other@example.com");
+        var owned = await app.SeedInflowAsync(owner.Id, "delete me");
+        var foreign = await app.SeedInflowAsync(other.Id, "protected");
+
+        using var deleted = await owner.Client.DeleteAsync($"/api/inflows/{owned.Id}");
+        using var hidden = await owner.Client.DeleteAsync($"/api/inflows/{foreign.Id}");
+        using var missing = await owner.Client.DeleteAsync("/api/inflows/2147483647");
+
+        Assert.Equal(HttpStatusCode.NoContent, deleted.StatusCode);
+        Assert.Null(await app.FindInflowAsync(owned.Id));
+        Assert.Equal(HttpStatusCode.NotFound, hidden.StatusCode);
+        Assert.Empty(await hidden.Content.ReadAsStringAsync());
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+        Assert.NotNull(await app.FindInflowAsync(foreign.Id));
+    }
+
+    private static async Task AssertValidationErrorAsync(HttpResponseMessage response, string field)
+    {
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.True(body.GetProperty("errors").TryGetProperty(field, out _));
+    }
+}

--- a/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
+++ b/backend.Tests/Financial/PostgreSqlFinancialApiTests.cs
@@ -1421,6 +1421,60 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Mixed_confirmation_inflow_failure_rolls_back_both_target_types_and_preview_changes()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-mixed-confirm-rollback@example.com");
+        var preview = await CreatePreviewAsync(
+            owner.Client,
+            SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        await SelectCreditForInflowAsync(owner.Client, preview);
+
+        using (var setupScope = app.Services.CreateScope())
+        {
+            var setupContext = setupScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await setupContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE FUNCTION reject_import_inflow_provenance() RETURNS trigger
+                LANGUAGE plpgsql AS $function$
+                BEGIN
+                    RAISE EXCEPTION 'intentional disposable-test inflow provenance rejection';
+                END;
+                $function$;
+
+                CREATE TRIGGER reject_import_inflow_provenance_insert
+                BEFORE INSERT ON "ImportInflowProvenances"
+                FOR EACH ROW EXECUTE FUNCTION reject_import_inflow_provenance();
+                """);
+        }
+
+        using var response = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("confirmation_failed", error.GetProperty("code").GetString());
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batch = await context.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Include(value => value.Provenance)
+            .Include(value => value.InflowProvenance)
+            .SingleAsync(value => value.Id == batchId);
+        Assert.Equal(ImportPreviewLifecycle.Open, batch.Lifecycle);
+        Assert.Null(batch.ConfirmedAt);
+        Assert.Equal(13, batch.Rows.Count);
+        Assert.Equal(11, batch.Rows.Count(value => value.SelectedForImport));
+        Assert.Empty(batch.Provenance);
+        Assert.Empty(batch.InflowProvenance);
+        Assert.False(await context.Expenses.AnyAsync());
+        Assert.False(await context.AccountInflows.AnyAsync());
+    }
+
+    [PostgreSqlFact]
     public async Task Concurrent_confirmations_serialize_to_confirmed_and_already_confirmed()
     {
         await using var app = new PostgreSqlImportPreviewTestApplication();
@@ -1429,6 +1483,7 @@ public sealed class PostgreSqlFinancialApiTests
             owner.Client,
             SunflowerFixtureCorpus.CreateRepresentativePdf());
         var batchId = preview.GetProperty("batchId").GetGuid();
+        await SelectCreditForInflowAsync(owner.Client, preview);
 
         using var lockScope = app.Services.CreateScope();
         var lockContext = lockScope.ServiceProvider.GetRequiredService<BudgetContext>();
@@ -1459,6 +1514,8 @@ public sealed class PostgreSqlFinancialApiTests
             }.Order());
         Assert.Equal(10, firstBody.GetProperty("importedExpenseCount").GetInt32());
         Assert.Equal(10, secondBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, firstBody.GetProperty("importedInflowCount").GetInt32());
+        Assert.Equal(1, secondBody.GetProperty("importedInflowCount").GetInt32());
         Assert.Equal(
             firstBody.GetProperty("confirmedAt").GetDateTime(),
             secondBody.GetProperty("confirmedAt").GetDateTime());
@@ -1466,6 +1523,7 @@ public sealed class PostgreSqlFinancialApiTests
         using var assertScope = app.Services.CreateScope();
         var context = assertScope.ServiceProvider.GetRequiredService<BudgetContext>();
         Assert.Equal(10, await context.Expenses.CountAsync(value => value.UserId == owner.Id));
+        Assert.Equal(1, await context.AccountInflows.CountAsync(value => value.OwnerId == owner.Id));
         Assert.Equal(10, await context.ImportExpenseProvenances.CountAsync(
             value => value.BatchId == batchId));
         Assert.Equal(10, await context.ImportExpenseProvenances
@@ -1473,6 +1531,8 @@ public sealed class PostgreSqlFinancialApiTests
             .Select(value => value.ExpenseId)
             .Distinct()
             .CountAsync());
+        Assert.Equal(1, await context.ImportInflowProvenances.CountAsync(
+            value => value.BatchId == batchId));
     }
 
     [PostgreSqlFact]
@@ -1819,6 +1879,67 @@ public sealed class PostgreSqlFinancialApiTests
     }
 
     [PostgreSqlFact]
+    public async Task Inflow_delete_nulls_owner_consistent_provenance_and_preserves_replay_counts_and_document_identity()
+    {
+        await using var app = new PostgreSqlImportPreviewTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("postgres-inflow-provenance-delete@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var preview = await CreatePreviewAsync(owner.Client, pdf);
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        await SelectCreditForInflowAsync(owner.Client, preview);
+
+        using var confirmation = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var confirmationBody = await confirmation.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.OK, confirmation.StatusCode);
+        Assert.Equal(10, confirmationBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, confirmationBody.GetProperty("importedInflowCount").GetInt32());
+
+        int inflowId;
+        int sourceRowOrdinal;
+        using (var readScope = app.Services.CreateScope())
+        {
+            var context = readScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var provenance = await context.ImportInflowProvenances.AsNoTracking()
+                .SingleAsync(value => value.BatchId == batchId);
+            inflowId = Assert.IsType<int>(provenance.AccountInflowId);
+            sourceRowOrdinal = provenance.SourceRowOrdinal;
+            Assert.Equal(owner.Id, provenance.OwnerId);
+            Assert.Equal(owner.Id, provenance.AccountInflowOwnerId);
+        }
+
+        using var delete = await owner.Client.DeleteAsync($"/api/inflows/{inflowId}");
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+        using (var assertScope = app.Services.CreateScope())
+        {
+            var context = assertScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var provenance = await context.ImportInflowProvenances.AsNoTracking()
+                .SingleAsync(value => value.BatchId == batchId
+                    && value.SourceRowOrdinal == sourceRowOrdinal);
+            Assert.Equal(owner.Id, provenance.OwnerId);
+            Assert.Null(provenance.AccountInflowId);
+            Assert.Null(provenance.AccountInflowOwnerId);
+        }
+
+        using var replay = await owner.Client.PostAsync(
+            $"/api/import-previews/{batchId}/confirm",
+            content: null);
+        var replayBody = await replay.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.OK, replay.StatusCode);
+        Assert.Equal("already_confirmed", replayBody.GetProperty("status").GetString());
+        Assert.Equal(10, replayBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, replayBody.GetProperty("importedInflowCount").GetInt32());
+
+        using var upload = CreatePdfUpload(pdf);
+        using var reupload = await owner.Client.PostAsync("/api/import-previews", upload);
+        var error = await reupload.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.Conflict, reupload.StatusCode);
+        Assert.Equal("already_imported", error.GetProperty("code").GetString());
+    }
+
+    [PostgreSqlFact]
     public async Task Budget_create_read_upsert_and_delete_use_relational_month_query()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
@@ -1874,6 +1995,26 @@ public sealed class PostgreSqlFinancialApiTests
             response.StatusCode == HttpStatusCode.Created,
             $"Expected preview creation, received {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         return body;
+    }
+
+    private static async Task SelectCreditForInflowAsync(
+        HttpClient client,
+        JsonElement preview,
+        string sourceDescription = "DEMO PAYROLL CREDIT")
+    {
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var row = preview.GetProperty("rows").EnumerateArray().Single(value =>
+            value.GetProperty("sourceDescription").GetString() == sourceDescription);
+        using var response = await client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{row.GetProperty("rowId").GetGuid()}",
+            new
+            {
+                editableExpenseDescription = (string?)null,
+                category = (string?)null,
+                selectedForImport = false,
+                selectedForInflow = true
+            });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     private static DateOnly[] RecentCommitmentDates()

--- a/backend.Tests/Import/ImportPreviewApiTests.cs
+++ b/backend.Tests/Import/ImportPreviewApiTests.cs
@@ -243,6 +243,230 @@ public sealed class ImportPreviewApiTests
     }
 
     [Fact]
+    public async Task Credit_preview_uses_separate_default_off_selection_and_owner_scoped_exact_duplicate_warning()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-inflow-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("preview-inflow-other@example.com");
+        var firstMatch = await app.SeedInflowAsync(
+            owner.Id,
+            "  demo   payroll credit ",
+            2450m,
+            new DateOnly(2026, 2, 3));
+        var secondMatch = await app.SeedInflowAsync(
+            owner.Id,
+            "DEMO PAYROLL CREDIT",
+            2450m,
+            new DateOnly(2026, 2, 3));
+        await app.SeedInflowAsync(owner.Id, "DEMO PAYROLL CREDIT", 2451m, new DateOnly(2026, 2, 3));
+        await app.SeedInflowAsync(other.Id, "DEMO REIMBURSEMENT CREDIT", 18.25m, new DateOnly(2026, 2, 3));
+
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var payroll = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO PAYROLL CREDIT");
+        var reimbursement = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO REIMBURSEMENT CREDIT");
+        var debit = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "STREAMCO SUBSCRIPTION");
+        var ambiguous = rows.Single(row => row.GetProperty("classification").GetString() == "needs_review");
+
+        Assert.False(payroll.GetProperty("isEligible").GetBoolean());
+        Assert.True(payroll.GetProperty("isInflowEligible").GetBoolean());
+        Assert.False(payroll.GetProperty("selectedForImport").GetBoolean());
+        Assert.False(payroll.GetProperty("selectedForInflow").GetBoolean());
+        Assert.False(payroll.GetProperty("isPossibleDuplicate").GetBoolean());
+        Assert.Empty(payroll.GetProperty("duplicateExpenseIds").EnumerateArray());
+        Assert.True(payroll.GetProperty("isPossibleInflowDuplicate").GetBoolean());
+        Assert.Equal(
+            new[] { firstMatch.Id, secondMatch.Id }.Order(),
+            payroll.GetProperty("duplicateInflowIds").EnumerateArray()
+                .Select(value => value.GetInt32()));
+        Assert.Contains("possible_inflow_duplicate", payroll.GetProperty("warnings").EnumerateArray()
+            .Select(value => value.GetString()));
+
+        Assert.True(reimbursement.GetProperty("isInflowEligible").GetBoolean());
+        Assert.False(reimbursement.GetProperty("isPossibleInflowDuplicate").GetBoolean());
+        Assert.Empty(reimbursement.GetProperty("duplicateInflowIds").EnumerateArray());
+        Assert.True(debit.GetProperty("isEligible").GetBoolean());
+        Assert.False(debit.GetProperty("isInflowEligible").GetBoolean());
+        Assert.False(debit.GetProperty("selectedForInflow").GetBoolean());
+        Assert.Empty(debit.GetProperty("duplicateInflowIds").EnumerateArray());
+        Assert.False(ambiguous.GetProperty("isInflowEligible").GetBoolean());
+        Assert.False(ambiguous.GetProperty("selectedForInflow").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Credit_and_debit_selection_are_mutually_exclusive_and_credit_selection_resumes()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-inflow-selection@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var credit = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO PAYROLL CREDIT");
+        var debit = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "STREAMCO SUBSCRIPTION");
+
+        using var wrongCredit = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{credit.GetProperty("rowId").GetGuid()}",
+            new { selectedForImport = true, selectedForInflow = false });
+        using var both = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{credit.GetProperty("rowId").GetGuid()}",
+            new { selectedForImport = true, selectedForInflow = true });
+        using var wrongDebit = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{debit.GetProperty("rowId").GetGuid()}",
+            new
+            {
+                editableExpenseDescription = debit.GetProperty("editableExpenseDescription").GetString(),
+                category = debit.GetProperty("category").GetString(),
+                selectedForImport = false,
+                selectedForInflow = true
+            });
+        using var selected = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{credit.GetProperty("rowId").GetGuid()}",
+            new
+            {
+                editableExpenseDescription = "ignored private edit",
+                category = "ignored",
+                selectedForImport = false,
+                selectedForInflow = true
+            });
+        var selectedBody = await selected.Content.ReadFromJsonAsync<JsonElement>();
+        var resumed = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/import-previews/{batchId}");
+        var resumedCredit = resumed.GetProperty("rows").EnumerateArray()
+            .Single(row => row.GetProperty("rowId").GetGuid() == credit.GetProperty("rowId").GetGuid());
+
+        Assert.Equal(HttpStatusCode.BadRequest, wrongCredit.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, both.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, wrongDebit.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, selected.StatusCode);
+        Assert.True(selectedBody.GetProperty("selectedForInflow").GetBoolean());
+        Assert.False(selectedBody.GetProperty("selectedForImport").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, selectedBody.GetProperty("editableExpenseDescription").ValueKind);
+        Assert.Equal(JsonValueKind.Null, selectedBody.GetProperty("category").ValueKind);
+        Assert.True(resumedCredit.GetProperty("selectedForInflow").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Confirmation_persists_selected_credit_only_and_replays_stable_separate_counts()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-inflow-confirm@example.com");
+        var pdf = SunflowerFixtureCorpus.CreateRepresentativePdf();
+        var preview = await UploadPreviewAsync(owner, pdf);
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var credit = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO PAYROLL CREDIT");
+        await SelectOnlyAsync(owner, batchId, rows, selectedRowId: null);
+        await SelectInflowAsync(owner, batchId, credit, selected: true);
+
+        using var first = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        using var retry = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var retryBody = await retry.Content.ReadFromJsonAsync<JsonElement>();
+        var inflows = await owner.Client.GetFromJsonAsync<JsonElement>("/api/inflows");
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal("confirmed", firstBody.GetProperty("status").GetString());
+        Assert.Equal(0, firstBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, firstBody.GetProperty("importedInflowCount").GetInt32());
+        Assert.Equal("already_confirmed", retryBody.GetProperty("status").GetString());
+        Assert.Equal(0, retryBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, retryBody.GetProperty("importedInflowCount").GetInt32());
+        Assert.Equal(firstBody.GetProperty("confirmedAt").GetDateTime(), retryBody.GetProperty("confirmedAt").GetDateTime());
+        var inflow = Assert.Single(inflows.EnumerateArray());
+        Assert.Equal("DEMO PAYROLL CREDIT", inflow.GetProperty("description").GetString());
+        Assert.Equal(2450m, inflow.GetProperty("amount").GetDecimal());
+        Assert.Equal("2026-02-03", inflow.GetProperty("date").GetString());
+        Assert.Equal(0, await app.CountExpensesAsync());
+
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var batch = await context.ImportPreviewBatches.AsNoTracking()
+            .Include(value => value.Rows)
+            .Include(value => value.Provenance)
+            .Include(value => value.InflowProvenance)
+            .SingleAsync(value => value.Id == batchId);
+        Assert.Empty(batch.Rows);
+        Assert.Empty(batch.Provenance);
+        var provenance = Assert.Single(batch.InflowProvenance);
+        Assert.Equal(owner.Id, provenance.OwnerId);
+        Assert.Equal(owner.Id, provenance.AccountInflowOwnerId);
+        Assert.Equal(credit.GetProperty("sourceRowOrdinal").GetInt32(), provenance.SourceRowOrdinal);
+        Assert.NotNull(provenance.AccountInflowId);
+    }
+
+    [Fact]
+    public async Task Mixed_confirmation_persists_selected_debits_and_only_explicitly_selected_credit()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-inflow-mixed@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var payroll = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO PAYROLL CREDIT");
+        var reimbursement = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO REIMBURSEMENT CREDIT");
+        await SelectInflowAsync(owner, batchId, payroll, selected: true);
+
+        using var response = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var inflows = await owner.Client.GetFromJsonAsync<JsonElement>("/api/inflows");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(10, body.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, body.GetProperty("importedInflowCount").GetInt32());
+        Assert.Equal(10, await app.CountExpensesAsync());
+        var inflow = Assert.Single(inflows.EnumerateArray());
+        Assert.Equal(payroll.GetProperty("sourceDescription").GetString(), inflow.GetProperty("description").GetString());
+        Assert.NotEqual(reimbursement.GetProperty("sourceDescription").GetString(), inflow.GetProperty("description").GetString());
+    }
+
+    [Fact]
+    public async Task Newly_discovered_inflow_duplicate_requires_review_before_explicit_reselection()
+    {
+        await using var app = new SyntheticExtractionFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("preview-inflow-new-duplicate@example.com");
+        var preview = await UploadPreviewAsync(owner, SunflowerFixtureCorpus.CreateRepresentativePdf());
+        var batchId = preview.GetProperty("batchId").GetGuid();
+        var rows = preview.GetProperty("rows").EnumerateArray().ToList();
+        var credit = rows.Single(row => row.GetProperty("sourceDescription").GetString() == "DEMO PAYROLL CREDIT");
+        var rowId = credit.GetProperty("rowId").GetGuid();
+        await SelectOnlyAsync(owner, batchId, rows, selectedRowId: null);
+        await SelectInflowAsync(owner, batchId, credit, selected: true);
+        var match = await app.SeedInflowAsync(
+            owner.Id,
+            " demo   payroll credit ",
+            2450m,
+            new DateOnly(2026, 2, 3));
+
+        using var first = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var firstText = await first.Content.ReadAsStringAsync();
+        using var firstDocument = JsonDocument.Parse(firstText);
+        var firstBody = firstDocument.RootElement;
+
+        Assert.Equal(HttpStatusCode.Conflict, first.StatusCode);
+        Assert.Equal("duplicate_review_required", firstBody.GetProperty("code").GetString());
+        AssertSafeRowError(firstBody, rowId, "possible_inflow_duplicate");
+        Assert.DoesNotContain("DEMO PAYROLL CREDIT", firstText);
+
+        var refreshed = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/import-previews/{batchId}");
+        var refreshedCredit = refreshed.GetProperty("rows").EnumerateArray()
+            .Single(row => row.GetProperty("rowId").GetGuid() == rowId);
+        Assert.True(refreshedCredit.GetProperty("isPossibleInflowDuplicate").GetBoolean());
+        Assert.False(refreshedCredit.GetProperty("selectedForInflow").GetBoolean());
+        Assert.Equal(
+            new[] { match.Id },
+            refreshedCredit.GetProperty("duplicateInflowIds").EnumerateArray().Select(value => value.GetInt32()));
+
+        await SelectInflowAsync(owner, batchId, refreshedCredit, selected: true);
+        using var second = await owner.Client.PostAsync($"/api/import-previews/{batchId}/confirm", null);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal(0, secondBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(1, secondBody.GetProperty("importedInflowCount").GetInt32());
+        var inflows = await owner.Client.GetFromJsonAsync<JsonElement>("/api/inflows");
+        Assert.Equal(2, inflows.GetArrayLength());
+    }
+
+    [Fact]
     public async Task Confirmation_uses_only_server_owned_selected_fields_and_is_retry_safe()
     {
         await using var app = new SyntheticExtractionFinancialApiTestApplication();
@@ -276,6 +500,7 @@ public sealed class ImportPreviewApiTests
         Assert.Equal(batchId, firstBody.GetProperty("batchId").GetGuid());
         Assert.Equal("confirmed", firstBody.GetProperty("status").GetString());
         Assert.Equal(1, firstBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(0, firstBody.GetProperty("importedInflowCount").GetInt32());
         Assert.Equal(0, confirmedAt.Ticks % TimeSpan.TicksPerMicrosecond);
         var expenses = await owner.Client.GetFromJsonAsync<JsonElement>("/api/expenses");
         var expense = Assert.Single(expenses.EnumerateArray());
@@ -292,6 +517,7 @@ public sealed class ImportPreviewApiTests
         Assert.Equal("already_confirmed", retryBody.GetProperty("status").GetString());
         Assert.Equal(confirmedAt, retryBody.GetProperty("confirmedAt").GetDateTime());
         Assert.Equal(1, retryBody.GetProperty("importedExpenseCount").GetInt32());
+        Assert.Equal(0, retryBody.GetProperty("importedInflowCount").GetInt32());
         Assert.Equal(1, await app.CountExpensesAsync());
 
         using (var scope = app.Services.CreateScope())
@@ -954,6 +1180,24 @@ public sealed class ImportPreviewApiTests
                 });
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
+    }
+
+    private static async Task SelectInflowAsync(
+        TestUser owner,
+        Guid batchId,
+        JsonElement row,
+        bool selected)
+    {
+        var response = await owner.Client.PatchAsJsonAsync(
+            $"/api/import-previews/{batchId}/rows/{row.GetProperty("rowId").GetGuid()}",
+            new
+            {
+                editableExpenseDescription = (string?)null,
+                category = (string?)null,
+                selectedForImport = false,
+                selectedForInflow = selected
+            });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     private static void AssertSafeRowError(JsonElement error, Guid rowId, string code)

--- a/backend/Contracts/ImportPreviews/ImportPreviewContracts.cs
+++ b/backend/Contracts/ImportPreviews/ImportPreviewContracts.cs
@@ -15,7 +15,8 @@ public sealed record ImportConfirmationResponse(
     Guid BatchId,
     string Status,
     DateTime ConfirmedAt,
-    int ImportedExpenseCount);
+    int ImportedExpenseCount,
+    int ImportedInflowCount);
 
 public sealed record ImportPreviewResponse(
     Guid BatchId,
@@ -35,15 +36,20 @@ public sealed record ImportPreviewRowResponse(
     string SourceSection,
     string Classification,
     bool IsEligible,
+    bool IsInflowEligible,
     IReadOnlyList<string> Errors,
     IReadOnlyList<string> Warnings,
     bool IsPossibleDuplicate,
     IReadOnlyList<int> DuplicateExpenseIds,
+    bool IsPossibleInflowDuplicate,
+    IReadOnlyList<int> DuplicateInflowIds,
     string? EditableExpenseDescription,
     string? Category,
-    bool SelectedForImport);
+    bool SelectedForImport,
+    bool SelectedForInflow);
 
 public sealed record UpdateImportPreviewRowRequest(
     string? EditableExpenseDescription,
     string? Category,
-    bool SelectedForImport);
+    bool SelectedForImport,
+    bool SelectedForInflow);

--- a/backend/Contracts/Inflows/CreateInflowRequest.cs
+++ b/backend/Contracts/Inflows/CreateInflowRequest.cs
@@ -1,0 +1,6 @@
+namespace BudgetPlanner.Contracts.Inflows;
+
+public sealed record CreateInflowRequest(
+    string? Description,
+    decimal Amount,
+    DateOnly? Date);

--- a/backend/Contracts/Inflows/InflowResponse.cs
+++ b/backend/Contracts/Inflows/InflowResponse.cs
@@ -1,0 +1,7 @@
+namespace BudgetPlanner.Contracts.Inflows;
+
+public sealed record InflowResponse(
+    int Id,
+    string Description,
+    decimal Amount,
+    DateOnly Date);

--- a/backend/Contracts/Inflows/UpdateInflowRequest.cs
+++ b/backend/Contracts/Inflows/UpdateInflowRequest.cs
@@ -1,0 +1,7 @@
+namespace BudgetPlanner.Contracts.Inflows;
+
+public sealed record UpdateInflowRequest(
+    int Id,
+    string? Description,
+    decimal Amount,
+    DateOnly? Date);

--- a/backend/Controllers/InflowsController.cs
+++ b/backend/Controllers/InflowsController.cs
@@ -1,0 +1,158 @@
+using System.Security.Claims;
+using BudgetPlanner.Contracts.Inflows;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace BudgetPlanner.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/inflows")]
+public sealed class InflowsController(BudgetContext context) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<InflowResponse>>> GetAll(
+        CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+
+        var inflows = await context.AccountInflows.AsNoTracking()
+            .Where(value => value.OwnerId == userId)
+            .OrderByDescending(value => value.Date)
+            .ThenByDescending(value => value.Id)
+            .ToListAsync(cancellationToken);
+
+        return inflows.Select(ToResponse).ToList();
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> Get(
+        int id,
+        CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+
+        var inflow = await context.AccountInflows.AsNoTracking()
+            .SingleOrDefaultAsync(
+                value => value.Id == id && value.OwnerId == userId,
+                cancellationToken);
+        return inflow is null ? EmptyNotFound() : Ok(ToResponse(inflow));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<InflowResponse>> Create(
+        CreateInflowRequest request,
+        CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+
+        if (!TryValidateAndNormalize(
+                request.Description,
+                request.Amount,
+                request.Date,
+                out var description))
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var inflow = new AccountInflow
+        {
+            OwnerId = userId,
+            Description = description,
+            Amount = request.Amount,
+            Date = request.Date!.Value
+        };
+        context.AccountInflows.Add(inflow);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(Get), new { id = inflow.Id }, ToResponse(inflow));
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(
+        int id,
+        UpdateInflowRequest request,
+        CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+        if (id != request.Id) return BadRequest("Inflow ID mismatch");
+
+        var inflow = await context.AccountInflows.SingleOrDefaultAsync(
+            value => value.Id == id && value.OwnerId == userId,
+            cancellationToken);
+        if (inflow is null) return EmptyNotFound();
+
+        if (!TryValidateAndNormalize(
+                request.Description,
+                request.Amount,
+                request.Date,
+                out var description))
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        inflow.UpdateEvidence(description, request.Amount, request.Date!.Value);
+        await context.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> Delete(int id, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return Unauthorized();
+
+        var inflow = await context.AccountInflows.SingleOrDefaultAsync(
+            value => value.Id == id && value.OwnerId == userId,
+            cancellationToken);
+        if (inflow is null) return EmptyNotFound();
+
+        context.AccountInflows.Remove(inflow);
+        await context.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private bool TryValidateAndNormalize(
+        string? description,
+        decimal amount,
+        DateOnly? date,
+        out string normalizedDescription)
+    {
+        normalizedDescription = AccountInflowInputRules.NormalizeDescription(description);
+        foreach (var error in AccountInflowInputRules.Validate(amount, date, normalizedDescription))
+        {
+            var (field, message) = error switch
+            {
+                "date_required" => ("date", "Date is required."),
+                "amount_must_be_positive" => ("amount", "Amount must be greater than zero."),
+                "amount_out_of_range" => ("amount", "Amount exceeds the supported monetary range."),
+                "amount_precision_invalid" => ("amount", "Amount must have at most two decimal places."),
+                "description_required" => ("description", "Description is required."),
+                "description_too_long" => ("description", "Description must be 500 characters or fewer."),
+                _ => ("request", "The inflow is invalid.")
+            };
+            ModelState.AddModelError(field, message);
+        }
+
+        return ModelState.IsValid;
+    }
+
+    private static InflowResponse ToResponse(AccountInflow inflow) => new(
+        inflow.Id,
+        inflow.Description,
+        inflow.Amount,
+        inflow.Date);
+
+    private IActionResult EmptyNotFound()
+    {
+        Response.StatusCode = StatusCodes.Status404NotFound;
+        return new EmptyResult();
+    }
+}

--- a/backend/Import/ImportPreviewService.cs
+++ b/backend/Import/ImportPreviewService.cs
@@ -168,10 +168,15 @@ public sealed class ImportPreviewService(
             Lifecycle = ImportPreviewLifecycle.Open
         };
 
-        var eligibleRows = parsed.Rows.Where(IsPotentiallyEligible).ToList();
-        var dates = eligibleRows.Where(row => row.PostedDate.HasValue).Select(row => row.PostedDate!.Value).Distinct().ToList();
+        var eligibleRows = parsed.Rows.Where(row =>
+            IsPotentiallyExpenseEligible(row) || IsPotentiallyInflowEligible(row)).ToList();
+        var dates = eligibleRows.Where(row => row.PostedDate.HasValue)
+            .Select(row => row.PostedDate!.Value).Distinct().ToList();
         var expenses = await context.Expenses.AsNoTracking()
             .Where(expense => expense.UserId == userId && dates.Contains(expense.Date))
+            .ToListAsync(cancellationToken);
+        var inflows = await context.AccountInflows.AsNoTracking()
+            .Where(inflow => inflow.OwnerId == userId && dates.Contains(inflow.Date))
             .ToListAsync(cancellationToken);
 
         foreach (var source in parsed.Rows.OrderBy(row => row.SourceRowOrdinal))
@@ -181,22 +186,45 @@ public sealed class ImportPreviewService(
             var errors = source.Errors.ToList();
             if (source.SourceDescription.Length > 500)
                 errors.Add("source_description_too_long");
-            var eligible = IsPotentiallyEligible(source);
-            if (eligible)
+            var expenseEligible = IsPotentiallyExpenseEligible(source);
+            var inflowEligible = IsPotentiallyInflowEligible(source);
+            if (expenseEligible)
                 errors.AddRange(ExpenseInputRules.Validate(source.Amount, source.PostedDate, description, category));
-            eligible = eligible && errors.Count == 0;
+            if (inflowEligible)
+                errors.AddRange(AccountInflowInputRules.Validate(
+                    source.Amount,
+                    source.PostedDate,
+                    source.SourceDescription));
+            errors = errors.Distinct().ToList();
+            expenseEligible = expenseEligible && errors.Count == 0;
+            inflowEligible = inflowEligible && errors.Count == 0;
 
-            var duplicateIds = eligible
+            var expenseDuplicateIds = expenseEligible
                 ? expenses.Where(expense => expense.Date == source.PostedDate
                     && expense.Amount == source.Amount
                     && ExpenseInputRules.NormalizeDescriptionForComparison(expense.Description)
                         == ExpenseInputRules.NormalizeDescriptionForComparison(description))
-                    .Select(expense => expense.Id).ToList()
+                    .Select(expense => expense.Id).Distinct().OrderBy(value => value).ToList()
                 : [];
+            var inflowDuplicateIds = inflowEligible
+                ? inflows.Where(inflow => inflow.Date == source.PostedDate
+                    && inflow.Amount == source.Amount
+                    && AccountInflowIdentity.NormalizeDescription(inflow.Description)
+                        == AccountInflowIdentity.NormalizeDescription(source.SourceDescription))
+                    .Select(inflow => inflow.Id).Distinct().OrderBy(value => value).ToList()
+                : [];
+            var duplicateIds = expenseEligible ? expenseDuplicateIds : inflowDuplicateIds;
 
             var warnings = source.Warnings.ToList();
-            if (duplicateIds.Count > 0 && !warnings.Contains("possible_duplicate"))
-                warnings.Add("possible_duplicate");
+            var duplicateWarning = expenseEligible
+                ? "possible_duplicate"
+                : inflowEligible ? "possible_inflow_duplicate" : null;
+            if (duplicateIds.Count > 0
+                && duplicateWarning is not null
+                && !warnings.Contains(duplicateWarning))
+            {
+                warnings.Add(duplicateWarning);
+            }
 
             batch.Rows.Add(new ImportPreviewRow
             {
@@ -211,14 +239,14 @@ public sealed class ImportPreviewService(
                 SourceSection = source.SourceSection,
                 SourcePageNumber = source.Provenance.SourcePageNumber,
                 Classification = source.Classification,
-                IsEligible = eligible,
-                ValidationErrorCodes = JsonSerializer.Serialize(errors.Distinct()),
+                IsEligible = expenseEligible,
+                ValidationErrorCodes = JsonSerializer.Serialize(errors),
                 WarningCodes = JsonSerializer.Serialize(warnings.Distinct()),
                 IsPossibleDuplicate = duplicateIds.Count > 0,
                 DuplicateExpenseIds = JsonSerializer.Serialize(duplicateIds),
-                EditableExpenseDescription = eligible ? description : null,
-                Category = eligible ? category : null,
-                SelectedForImport = eligible && duplicateIds.Count == 0
+                EditableExpenseDescription = expenseEligible ? description : null,
+                Category = expenseEligible ? category : null,
+                SelectedForImport = expenseEligible && duplicateIds.Count == 0
             });
         }
 
@@ -259,6 +287,7 @@ public sealed class ImportPreviewService(
             var batch = await context.ImportPreviewBatches
                 .Include(value => value.Rows)
                 .Include(value => value.Provenance)
+                .Include(value => value.InflowProvenance)
                 .SingleOrDefaultAsync(
                     value => value.OwnerId == userId && value.Id == batchId,
                     cancellationToken);
@@ -267,7 +296,11 @@ public sealed class ImportPreviewService(
 
             if (batch.Lifecycle == ImportPreviewLifecycle.Confirmed)
             {
-                return ConfirmationSucceeded(batch, "already_confirmed", batch.Provenance.Count);
+                return ConfirmationSucceeded(
+                    batch,
+                    "already_confirmed",
+                    batch.Provenance.Count,
+                    batch.InflowProvenance.Count);
             }
 
             if (batch.SourceType != SunflowerStatementParser.SourceType
@@ -294,7 +327,7 @@ public sealed class ImportPreviewService(
                 return ConfirmationFailed("preview_not_found", "The preview is unavailable.");
             }
 
-            if (batch.Provenance.Count > 0)
+            if (batch.Provenance.Count > 0 || batch.InflowProvenance.Count > 0)
             {
                 return ConfirmationFailed("confirmation_conflict", "The preview cannot be confirmed safely.");
             }
@@ -314,20 +347,32 @@ public sealed class ImportPreviewService(
             var currentExpenses = await context.Expenses.AsNoTracking()
                 .Where(value => value.UserId == userId && selectedDates.Contains(value.Date))
                 .ToListAsync(cancellationToken);
+            var currentInflows = await context.AccountInflows.AsNoTracking()
+                .Where(value => value.OwnerId == userId && selectedDates.Contains(value.Date))
+                .ToListAsync(cancellationToken);
 
             var newlyWarnedRows = new List<ImportConfirmationRowError>();
             foreach (var row in selectedRows)
             {
-                var duplicateIds = FindPossibleDuplicateExpenseIds(row, currentExpenses);
+                var isExpenseTarget = IsExpenseTarget(row);
+                var isInflowTarget = IsInflowTarget(row);
+                var duplicateIds = isExpenseTarget
+                    ? FindPossibleDuplicateExpenseIds(row, currentExpenses)
+                    : isInflowTarget
+                        ? FindPossibleDuplicateInflowIds(row, currentInflows)
+                        : [];
                 if (row.IsPossibleDuplicate || duplicateIds.Count == 0) continue;
 
                 row.IsPossibleDuplicate = true;
                 row.DuplicateExpenseIds = JsonSerializer.Serialize(duplicateIds);
                 var warnings = DeserializeCodes(row.WarningCodes).ToList();
-                if (!warnings.Contains("possible_duplicate")) warnings.Add("possible_duplicate");
+                var warningCode = isInflowTarget
+                    ? "possible_inflow_duplicate"
+                    : "possible_duplicate";
+                if (!warnings.Contains(warningCode)) warnings.Add(warningCode);
                 row.WarningCodes = JsonSerializer.Serialize(warnings.Distinct());
                 row.SelectedForImport = false;
-                newlyWarnedRows.Add(new(row.Id, ["possible_duplicate"]));
+                newlyWarnedRows.Add(new(row.Id, [warningCode]));
             }
 
             if (newlyWarnedRows.Count > 0)
@@ -341,28 +386,44 @@ public sealed class ImportPreviewService(
             }
 
             var validationErrors = new List<ImportConfirmationRowError>();
-            var normalizedRows = new List<(ImportPreviewRow Row, string Description, string Category)>();
+            var normalizedExpenseRows = new List<(ImportPreviewRow Row, string Description, string Category)>();
+            var normalizedInflowRows = new List<(ImportPreviewRow Row, string Description)>();
             foreach (var row in selectedRows)
             {
-                var description = ExpenseInputRules.NormalizeDescription(row.EditableExpenseDescription);
-                var category = ExpenseInputRules.NormalizeCategory(row.Category);
                 var errors = new List<string>();
-                if (!row.IsEligible
-                    || row.Classification != ImportedRowClassification.ExpenseCandidate
-                    || row.Direction != ImportedTransactionDirection.Debit)
+                if (IsExpenseTarget(row))
+                {
+                    var description = ExpenseInputRules.NormalizeDescription(row.EditableExpenseDescription);
+                    var category = ExpenseInputRules.NormalizeCategory(row.Category);
+                    if (!IsExpenseEligible(row)) errors.Add("row_not_selectable");
+                    errors.AddRange(ExpenseInputRules.Validate(
+                        row.Amount,
+                        row.PostedDate,
+                        description,
+                        category));
+                    if (errors.Count == 0)
+                        normalizedExpenseRows.Add((row, description, category));
+                }
+                else if (IsInflowTarget(row))
+                {
+                    var description = AccountInflowInputRules.NormalizeDescription(row.SourceDescription);
+                    if (!IsInflowEligible(row)) errors.Add("row_not_selectable");
+                    errors.AddRange(AccountInflowInputRules.Validate(
+                        row.Amount,
+                        row.PostedDate,
+                        description));
+                    if (errors.Count == 0)
+                        normalizedInflowRows.Add((row, description));
+                }
+                else
                 {
                     errors.Add("row_not_selectable");
                 }
-                errors.AddRange(ExpenseInputRules.Validate(row.Amount, row.PostedDate, description, category));
 
                 var distinctErrors = errors.Distinct().ToList();
                 if (distinctErrors.Count > 0)
                 {
                     validationErrors.Add(new(row.Id, distinctErrors));
-                }
-                else
-                {
-                    normalizedRows.Add((row, description, category));
                 }
             }
 
@@ -374,7 +435,7 @@ public sealed class ImportPreviewService(
                     validationErrors);
             }
 
-            foreach (var normalized in normalizedRows)
+            foreach (var normalized in normalizedExpenseRows)
             {
                 var expense = new Expense
                 {
@@ -393,12 +454,36 @@ public sealed class ImportPreviewService(
                 });
             }
 
+            foreach (var normalized in normalizedInflowRows)
+            {
+                var inflow = new AccountInflow
+                {
+                    OwnerId = userId,
+                    Description = normalized.Description,
+                    Amount = normalized.Row.Amount!.Value,
+                    Date = normalized.Row.PostedDate!.Value
+                };
+                context.AccountInflows.Add(inflow);
+                batch.InflowProvenance.Add(new ImportInflowProvenance
+                {
+                    BatchId = batch.Id,
+                    OwnerId = userId,
+                    SourceRowOrdinal = normalized.Row.SourceRowOrdinal,
+                    AccountInflowOwnerId = userId,
+                    AccountInflow = inflow
+                });
+            }
+
             batch.Lifecycle = ImportPreviewLifecycle.Confirmed;
             batch.ConfirmedAt = TruncateToPostgreSqlTimestampPrecision(now);
             context.ImportPreviewRows.RemoveRange(batch.Rows);
             await context.SaveChangesAsync(cancellationToken);
             await CommitAsync(transaction, cancellationToken);
-            return ConfirmationSucceeded(batch, "confirmed", normalizedRows.Count);
+            return ConfirmationSucceeded(
+                batch,
+                "confirmed",
+                normalizedExpenseRows.Count,
+                normalizedInflowRows.Count);
         }
         catch (OperationCanceledException)
         {
@@ -459,10 +544,16 @@ public sealed class ImportPreviewService(
 
             var row = batch.Rows.SingleOrDefault(value => value.Id == rowId);
             if (row is null) return Failed("preview_not_found", "The preview is unavailable.");
-            if (!row.IsEligible && request.SelectedForImport)
+            var expenseEligible = IsExpenseEligible(row);
+            var inflowEligible = IsInflowEligible(row);
+            if ((request.SelectedForImport && request.SelectedForInflow)
+                || (request.SelectedForImport && !expenseEligible)
+                || (request.SelectedForInflow && !inflowEligible))
+            {
                 return Failed("row_not_selectable", "This row cannot be selected for import.");
+            }
 
-            if (row.IsEligible)
+            if (expenseEligible)
             {
                 var description = ExpenseInputRules.NormalizeDescription(request.EditableExpenseDescription);
                 var category = ExpenseInputRules.NormalizeCategory(request.Category);
@@ -471,6 +562,10 @@ public sealed class ImportPreviewService(
                 row.EditableExpenseDescription = description;
                 row.Category = category;
                 row.SelectedForImport = request.SelectedForImport;
+            }
+            else if (inflowEligible)
+            {
+                row.SelectedForImport = request.SelectedForInflow;
             }
             else
             {
@@ -555,6 +650,21 @@ public sealed class ImportPreviewService(
                 && expense.Amount == row.Amount.Value
                 && ExpenseInputRules.NormalizeDescriptionForComparison(expense.Description) == description)
             .Select(expense => expense.Id)
+            .Distinct()
+            .OrderBy(value => value)
+            .ToList();
+    }
+
+    private static List<int> FindPossibleDuplicateInflowIds(
+        ImportPreviewRow row,
+        IReadOnlyList<AccountInflow> inflows)
+    {
+        if (!row.PostedDate.HasValue || !row.Amount.HasValue) return [];
+        var description = AccountInflowIdentity.NormalizeDescription(row.SourceDescription);
+        return inflows.Where(inflow => inflow.Date == row.PostedDate.Value
+                && inflow.Amount == row.Amount.Value
+                && AccountInflowIdentity.NormalizeDescription(inflow.Description) == description)
+            .Select(inflow => inflow.Id)
             .Distinct()
             .OrderBy(value => value)
             .ToList();
@@ -742,9 +852,33 @@ public sealed class ImportPreviewService(
         await context.SaveChangesAsync(cancellationToken);
     }
 
-    private static bool IsPotentiallyEligible(NormalizedImportedRow row) =>
+    private static bool IsPotentiallyExpenseEligible(NormalizedImportedRow row) =>
         row.Classification == ImportedRowClassification.ExpenseCandidate
         && row.Direction == ImportedTransactionDirection.Debit;
+
+    private static bool IsPotentiallyInflowEligible(NormalizedImportedRow row) =>
+        row.Classification == ImportedRowClassification.NonExpense
+        && row.Direction == ImportedTransactionDirection.Credit;
+
+    private static bool IsExpenseTarget(ImportPreviewRow row) =>
+        row.Classification == ImportedRowClassification.ExpenseCandidate
+        && row.Direction == ImportedTransactionDirection.Debit;
+
+    private static bool IsInflowTarget(ImportPreviewRow row) =>
+        row.Classification == ImportedRowClassification.NonExpense
+        && row.Direction == ImportedTransactionDirection.Credit;
+
+    private static bool IsExpenseEligible(ImportPreviewRow row) =>
+        row.IsEligible && IsExpenseTarget(row);
+
+    private static bool IsInflowEligible(ImportPreviewRow row) =>
+        !row.IsEligible
+        && IsInflowTarget(row)
+        && DeserializeCodes(row.ValidationErrorCodes).Count == 0
+        && AccountInflowInputRules.Validate(
+            row.Amount,
+            row.PostedDate,
+            row.SourceDescription).Count == 0;
 
     private static ImportPreviewOperation MapExtractionFailure(PdfExtractionFailure failure) => failure.Code switch
     {
@@ -760,12 +894,14 @@ public sealed class ImportPreviewService(
     private static ImportConfirmationOperation ConfirmationSucceeded(
         ImportPreviewBatch batch,
         string status,
-        int importedExpenseCount) => new(
+        int importedExpenseCount,
+        int importedInflowCount) => new(
             new(
                 batch.Id,
                 status,
                 batch.ConfirmedAt ?? throw new InvalidOperationException("A confirmed batch requires a confirmation time."),
-                importedExpenseCount),
+                importedExpenseCount,
+                importedInflowCount),
             null);
 
     private static ImportConfirmationOperation ConfirmationFailed(
@@ -781,15 +917,25 @@ public sealed class ImportPreviewService(
 
     private static ImportPreviewResponse ToResponse(ImportPreviewBatch batch) => new(
         batch.Id, batch.SourceType, batch.ParserRuleVersion, batch.CreatedAt, batch.ExpiresAt,
-        batch.Rows.OrderBy(row => row.SourceRowOrdinal).Select(row => new ImportPreviewRowResponse(
-            row.Id, row.SourceRowOrdinal, row.PostedDate, row.Amount,
-            row.Direction.ToString().ToLowerInvariant(), row.SourceDescription, row.SourceSection,
-            ToSnakeCase(row.Classification), row.IsEligible,
-            JsonSerializer.Deserialize<string[]>(row.ValidationErrorCodes) ?? [],
-            JsonSerializer.Deserialize<string[]>(row.WarningCodes) ?? [],
-            row.IsPossibleDuplicate,
-            JsonSerializer.Deserialize<int[]>(row.DuplicateExpenseIds) ?? [],
-            row.EditableExpenseDescription, row.Category, row.SelectedForImport)).ToList());
+        batch.Rows.OrderBy(row => row.SourceRowOrdinal).Select(row =>
+        {
+            var expenseEligible = IsExpenseEligible(row);
+            var inflowEligible = IsInflowEligible(row);
+            var duplicateIds = JsonSerializer.Deserialize<int[]>(row.DuplicateExpenseIds) ?? [];
+            return new ImportPreviewRowResponse(
+                row.Id, row.SourceRowOrdinal, row.PostedDate, row.Amount,
+                row.Direction.ToString().ToLowerInvariant(), row.SourceDescription, row.SourceSection,
+                ToSnakeCase(row.Classification), expenseEligible, inflowEligible,
+                JsonSerializer.Deserialize<string[]>(row.ValidationErrorCodes) ?? [],
+                JsonSerializer.Deserialize<string[]>(row.WarningCodes) ?? [],
+                expenseEligible && row.IsPossibleDuplicate,
+                expenseEligible ? duplicateIds : [],
+                inflowEligible && row.IsPossibleDuplicate,
+                inflowEligible ? duplicateIds : [],
+                row.EditableExpenseDescription, row.Category,
+                expenseEligible && row.SelectedForImport,
+                inflowEligible && row.SelectedForImport);
+        }).ToList());
 
     private static string ToSnakeCase(ImportedRowClassification value) => value switch
     {

--- a/backend/Models/AccountInflowInputRules.cs
+++ b/backend/Models/AccountInflowInputRules.cs
@@ -1,0 +1,30 @@
+namespace BudgetPlanner.Models;
+
+public static class AccountInflowInputRules
+{
+    public const decimal MaximumAmount = 9999999999999999.99m;
+
+    public static string NormalizeDescription(string? value) => (value ?? "").Trim();
+
+    public static IReadOnlyList<string> Validate(
+        decimal? amount,
+        DateOnly? date,
+        string? description)
+    {
+        var errors = new List<string>();
+        if (date is null) errors.Add("date_required");
+        if (amount is null || amount <= 0m) errors.Add("amount_must_be_positive");
+        else
+        {
+            if (amount > MaximumAmount) errors.Add("amount_out_of_range");
+            if (decimal.Round(amount.Value, 2) != amount.Value)
+                errors.Add("amount_precision_invalid");
+        }
+
+        var normalizedDescription = NormalizeDescription(description);
+        if (normalizedDescription.Length == 0) errors.Add("description_required");
+        else if (normalizedDescription.Length > 500) errors.Add("description_too_long");
+
+        return errors;
+    }
+}

--- a/docs/financial-domain-invariants.md
+++ b/docs/financial-domain-invariants.md
@@ -37,6 +37,26 @@ If Ordo later tracks multiple accounts, this invariant must be
 revisited before cross-account transfers are represented so the product does
 not accidentally double-count the same movement across tracked accounts.
 
+## Account inflow invariant
+
+An `AccountInflow` is owner-scoped evidence that money increased the one
+tracked checking account. It is not an `Expense`, does not use a negative
+amount, and does not by itself classify the movement as income or a paycheck.
+Transfers, refunds, reimbursements, and other non-paycheck credits may therefore
+be retained as inflow evidence without acquiring income meaning.
+
+Its amount is strictly positive, uses at most two decimal places, and shares the
+application's `numeric(18,2)` monetary range. Its posted date is a calendar date
+using API `YYYY-MM-DD`, .NET `DateOnly`, and PostgreSQL `date`. Its description
+is required, outer-trimmed at the authoritative write boundary, limited to 500
+characters, and preserves meaningful case and internal text.
+
+Ownership comes only from authenticated identity. Manual inflows have no import
+provenance. A confidently directed imported credit becomes an `AccountInflow`
+only when the user explicitly selects it during statement review; that selection
+is false by default. Credits never become Expenses, and saving an imported
+credit does not call it income or a paycheck.
+
 ## Description invariant
 
 An expense description is required. At the authoritative write boundary it is

--- a/docs/import-pipeline.md
+++ b/docs/import-pipeline.md
@@ -21,10 +21,10 @@ The V1 pipeline is:
 1. **Parse** the supported Sunflower statement under the approved F1 threat-model limits.
 2. **Normalize** each supported source row into a bank-neutral imported-row representation.
 3. **Validate** required financial fields and supported formats.
-4. **Deduplicate** against exact import provenance and existing expense data.
+4. **Deduplicate** against exact import provenance and the applicable existing expense or account-inflow data.
 5. **Preview** every successfully parsed batch for authenticated-user review.
 6. **Confirm** only explicitly selected, valid rows after authoritative backend revalidation.
-7. **Persist** selected rows as ordinary expenses atomically and idempotently once all persistence prerequisites are satisfied.
+7. **Persist** selected debits as ordinary Expenses and explicitly selected credits as generic AccountInflows atomically and idempotently once all persistence prerequisites are satisfied.
 
 Format-specific parsing must remain separate from the core expense write boundary. Existing Transactions, Budgets, and Analytics continue to consume normal `Expense` records after a successful import; V1 does not introduce a parallel outflow model.
 
@@ -45,7 +45,7 @@ The conceptual V1 row includes:
 - category, defaulting to canonical `uncategorized` for eligible expenses;
 - validation errors and warnings;
 - duplicate status;
-- selected-for-import state; and
+- separate selected-for-expense-import and selected-for-inflow state; and
 - minimum provenance metadata required to identify source, parser/rule version, batch, and source row without retaining the original PDF.
 
 The normalized import model is intentionally broader than `Expense`. Credits and deposits may exist in preview without being representable as negative expenses.
@@ -56,7 +56,7 @@ V1 uses four classification states:
 
 - `expense_candidate` — a supported, valid debit/outflow from the tracked checking account and eligible for user selection;
 - `needs_review` — a transaction-like row was recognized, but the parser cannot confidently establish debit/credit direction or another required source fact; never auto-selected or persisted;
-- `non_expense` — a known credit or deposit that increases the tracked checking account balance and is excluded from expense persistence; and
+- `non_expense` — a known credit or deposit that increases the tracked checking account balance, is excluded from Expense persistence, and may be explicitly saved as generic account-inflow evidence when otherwise valid; and
 - `invalid` — cannot satisfy required date, amount, description, or supported-format rules.
 
 Classification rules must be explicit, testable, and versioned when a rule change can affect normalized output.
@@ -72,7 +72,7 @@ For the initial supported Sunflower statement format:
 - `needs_review` is reserved for source-parsing uncertainty such as a transaction-like row whose direction or required source facts cannot be established confidently, not for uncertainty about whether a valid debit is "true spending"; and
 - unsupported sections or rows are surfaced as unsupported/invalid according to parser confidence and are never silently persisted.
 
-No income model is introduced by V1. Credits and deposits may be visible in preview as excluded rows but are not persisted as expenses.
+No income model is introduced by V1. Credits and deposits are never persisted as Expenses. A valid confidently directed credit may be saved explicitly as an `AccountInflow`, which records only an observed increase to the tracked account and does not classify it as income or a paycheck.
 
 ## Validation
 
@@ -87,6 +87,8 @@ At minimum, eligible rows require:
 - ownership derived exclusively from the authenticated user.
 
 Frontend validation is user experience only. Confirmation must revalidate the selected rows on the backend; client preview state is never authoritative.
+
+An eligible AccountInflow uses the same positive amount/date/description limits without an Expense category. Its description is the outer-trimmed source description; normalized-description identity is used only for deterministic possible-duplicate warnings.
 
 ## Preview and review behavior
 
@@ -106,10 +108,10 @@ Default selection behavior:
 
 - `expense_candidate`: selected by default only when validation is clean and there is no duplicate warning;
 - `needs_review`: not selected until the source ambiguity is resolved into an eligible debit or an excluded credit/deposit;
-- `non_expense`: cannot be selected for expense import in V1; and
+- `non_expense`: cannot be selected for Expense import; a valid confidently directed credit has a separate **Save incoming deposit as inflow evidence** selection that is always false by default; and
 - `invalid`: cannot be selected for expense import.
 
-Rows with possible-duplicate warnings are not selected by default. The user must explicitly choose to import them.
+Rows with possible-duplicate warnings are not selected by default. The user must explicitly choose to import or save them.
 
 V1 does not auto-categorize merchants. Eligible expenses default to `uncategorized` unless the user chooses another valid category during review.
 
@@ -130,7 +132,7 @@ The digest is used only as an exact-document identity aid; it does not replace s
 For the same authenticated user, source type, and parser/rule version:
 
 - if an unexpired open preview exists for the same digest, reuse/return that batch rather than creating a second independent preview; and
-- if that statement was already confirmed, report it as already imported and do not create duplicate expenses by default.
+- if that statement was already confirmed, report it as already imported and do not create duplicate Expenses or AccountInflows.
 
 An open preview produced by an incompatible parser/rule version must not be
 resumed, mutated, or reused as current financial interpretation. A successful
@@ -149,7 +151,7 @@ A row already confirmed from the same source batch/provenance is blocked automat
 
 ### Possible duplicate
 
-A normalized row that resembles an existing expense or another relevant row by fields such as date, amount, and normalized/user-facing description is a **warning**, not an automatic rejection.
+A normalized row that resembles an existing target record is a **warning**, not an automatic rejection. AccountInflow warnings use the exact owner + posted date + amount + normalized-description identity key. Expense warning behavior is unchanged.
 
 Legitimate repeated outflows can have the same date, amount, and description. Therefore:
 
@@ -169,19 +171,19 @@ At confirmation time, the backend must:
 2. reject expired or invalid batch state;
 3. revalidate every selected row against authoritative financial rules;
 4. re-run the required duplicate/idempotency checks against current persisted state; and
-5. persist only the selected valid expense rows.
+5. persist only the selected valid debit and credit rows into their separate approved target models.
 
-A batch may be successfully confirmed only once. Retrying a confirmation request after success must return a stable already-confirmed/success result without creating additional expenses.
+A batch may be successfully confirmed only once. Retrying a confirmation request after success must return a stable already-confirmed/success result without creating additional Expenses or AccountInflows.
 
 Client-supplied row state cannot bypass backend classification, validation, ownership, duplicate, or idempotency rules.
 
 ## Atomic persistence
 
-Confirmation of the selected expense rows is atomic.
+Confirmation of all selected debit and credit rows is atomic.
 
-If any selected row fails authoritative validation, ownership, exact-duplicate/idempotency checks, or persistence, persist **none** of the selected rows and return safe per-row errors so the user can correct or unselect problematic rows and retry.
+If any selected row fails authoritative validation, ownership, exact-duplicate/idempotency checks, or persistence, persist **none** of either target type and return safe per-row errors so the user can correct or unselect problematic rows and retry.
 
-Rows that remain excluded as `needs_review`, `non_expense`, or `invalid` are not part of the persistence transaction and do not make confirmation fail merely because they remain excluded.
+Rows that remain unselected, `needs_review`, or `invalid` are not part of the persistence transaction and do not make confirmation fail merely because they remain excluded. An unselected `non_expense` credit remains preview-only.
 
 This prevents half-imported statements and makes retries predictable.
 
@@ -195,7 +197,7 @@ Retain only the minimum durable metadata needed for idempotency and auditability
 - parser/rule version;
 - document digest;
 - source section plus stable row ordinal/fingerprint;
-- link to the created Expense ID; and
+- link to the created Expense or AccountInflow ID through its distinct provenance table; and
 - confirmed timestamp/status.
 
 Do not retain the raw PDF.
@@ -214,7 +216,7 @@ The 24-hour retention applies only to normalized preview state needed for the un
 
 Implementation should use the simplest enforceable cleanup/expiry mechanism compatible with the current architecture. Do not introduce a background-job framework solely for preview cleanup.
 
-Confirmed minimal provenance may remain with the linked imported expenses unless a later approved deletion/export/privacy policy changes that decision.
+Confirmed minimal provenance may remain with linked imported Expenses and AccountInflows unless a later approved deletion/export/privacy policy changes that decision. Deleting a target may null its link without reopening confirmed document identity.
 
 ## Date-only persistence prerequisite
 

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
@@ -37,7 +37,7 @@ function issueTitle(code) {
   if (code === "duplicate_review_required") return "Review new duplicate warnings";
   if (code === "preview_expired") return "Preview expired";
   if (code === "preview_unavailable") return "Preview unavailable";
-  return "Expenses were not imported";
+  return "Statement was not confirmed";
 }
 
 function focusAfterRender(ref) {
@@ -195,14 +195,16 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
       editableExpenseDescription: draft.description.trim(),
       category: categoryFromDraft(draft),
       selectedForImport: row.selectedForImport,
+      selectedForInflow: false,
     }, true);
   }
 
-  async function updateSelection(row, selectedForImport) {
+  async function updateSelection(row, selected) {
     return runRowUpdate(row, {
-      editableExpenseDescription: row.editableExpenseDescription,
-      category: row.category,
-      selectedForImport,
+      editableExpenseDescription: row.isEligible ? row.editableExpenseDescription : null,
+      category: row.isEligible ? row.category : null,
+      selectedForImport: row.isEligible ? selected : false,
+      selectedForInflow: row.isInflowEligible ? selected : false,
     }, false);
   }
 
@@ -227,9 +229,9 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
 
     focusAfterRender(completionHeading);
     try {
-      await onImportConfirmed();
+      if (result.importedExpenseCount > 0) await onImportConfirmed();
     } catch {
-      setRefreshError("Expenses were imported, but Transactions could not be refreshed. Reload this page to see them.");
+      setRefreshError("The import succeeded, but Transactions could not be refreshed. Reload this page to see imported expenses.");
     }
   }
 
@@ -238,7 +240,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
     if (hasPendingRows) return "Wait for every row update to finish before confirming.";
     if (hasDirtyRows) return "Save every row with unsaved changes before confirming.";
     if (selectedCount === 0) return "Select at least one eligible row to import.";
-    return `${selectedCount} selected ${selectedCount === 1 ? "expense is" : "expenses are"} ready to import.`;
+    return `${selectedCount} selected ${selectedCount === 1 ? "row is" : "rows are"} ready to confirm.`;
   }
 
   function confirmationCodesFor(rowId) {
@@ -285,7 +287,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
 
       {!confirmation && (
         <div className="status-message status-message--info">
-          Review and save any edits before importing. Expenses are created only after confirmation.
+          Review and save any edits before confirming. Expenses and explicitly selected incoming deposits are created only after confirmation.
         </div>
       )}
 
@@ -296,9 +298,9 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
           </h3>
           <p>
             {confirmation.importedExpenseCount} {confirmation.importedExpenseCount === 1 ? "expense" : "expenses"}
-            {confirmation.status === "already_confirmed"
-              ? confirmation.importedExpenseCount === 1 ? " was already imported" : " were already imported"
-              : " imported"}
+            {" and "}
+            {confirmation.importedInflowCount} {confirmation.importedInflowCount === 1 ? "incoming deposit" : "incoming deposits"}
+            {confirmation.status === "already_confirmed" ? " were already saved" : " saved"}
             {` at ${formatConfirmationTime(confirmation.confirmedAt)}.`}
           </p>
         </div>
@@ -380,10 +382,10 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
                 onClick={handleConfirm}
               >
                 {confirming
-                  ? "Importing expenses…"
+                  ? "Confirming selected rows…"
                   : selectedCount > 0
-                    ? `Import ${selectedCount} selected ${selectedCount === 1 ? "expense" : "expenses"}`
-                    : "Import selected expenses"}
+                    ? `Confirm ${selectedCount} selected ${selectedCount === 1 ? "row" : "rows"}`
+                    : "Confirm selected rows"}
               </button>
             </div>
           </div>

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
@@ -13,12 +13,15 @@ const row = {
   sourceSection: 'electronic_transactions',
   classification: 'expense_candidate',
   isEligible: true,
+  isInflowEligible: false,
   errors: [],
   warnings: [],
   isPossibleDuplicate: false,
+  isPossibleInflowDuplicate: false,
   editableExpenseDescription: 'Coffee',
   category: 'food',
   selectedForImport: true,
+  selectedForInflow: false,
 }
 
 const preview = {
@@ -67,7 +70,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
     expect(within(card).getByLabelText('Expense description')).toHaveValue('Morning coffee')
     expect(within(table).getByRole('status')).toHaveTextContent('Unsaved changes')
     expect(screen.getByText('Save every row with unsaved changes before confirming.')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeDisabled()
     expect(state.confirm).not.toHaveBeenCalled()
   })
 
@@ -85,22 +88,23 @@ describe('ImportPreviewPanel confirmation safety', () => {
     await user.click(within(table).getByRole('button', { name: 'Save row' }))
 
     expect(within(table).getByRole('status')).toHaveTextContent('Saving…')
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeDisabled()
     expect(updateRow).toHaveBeenCalledWith('row-1', {
       editableExpenseDescription: 'Morning coffee',
       category: 'food',
       selectedForImport: true,
+      selectedForInflow: false,
     })
 
     await act(async () => {
       resolveUpdate({ ...row, editableExpenseDescription: 'Morning coffee' })
     })
     expect(within(table).getByRole('status')).toHaveTextContent('Saved')
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeEnabled()
 
     await user.type(description, ' again')
     expect(within(table).getByRole('status')).toHaveTextContent('Unsaved changes')
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeDisabled()
   })
 
   it('keeps a failed save draft visible and customer-readable', async () => {
@@ -116,7 +120,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
 
     expect(await within(table).findByRole('alert')).toHaveTextContent('Save failed. Changes remain unsaved.')
     expect(description).toHaveValue('Unsaved coffee')
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeDisabled()
   })
 
   it('tracks selection PATCH state before enabling confirmation', async () => {
@@ -130,7 +134,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
 
     expect(within(table).getByLabelText('Select for import')).toBeDisabled()
     expect(within(table).getByRole('status')).toHaveTextContent('Saving…')
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeDisabled()
 
     await act(async () => { resolveUpdate({ ...row, selectedForImport: false }) })
     expect(within(table).getByRole('status')).toHaveTextContent('Saved')
@@ -139,7 +143,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
   it('shows one accessible responsive confirmation action and clear zero-selection guidance', () => {
     render(<ImportPreviewPanel importState={importState({ selectedCount: 0 })} />)
 
-    const buttons = screen.getAllByRole('button', { name: 'Import selected expenses' })
+    const buttons = screen.getAllByRole('button', { name: 'Confirm selected rows' })
     expect(buttons).toHaveLength(1)
     expect(buttons[0]).toBeDisabled()
     expect(buttons[0]).toHaveAttribute('aria-describedby', 'import-confirmation-guidance')
@@ -153,7 +157,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
     const state = importState({ confirming: true })
     render(<ImportPreviewPanel importState={state} />)
 
-    const button = screen.getByRole('button', { name: 'Importing expenses…' })
+    const button = screen.getByRole('button', { name: 'Confirming selected rows…' })
     expect(button).toBeDisabled()
     expect(button).toHaveAttribute('aria-busy', 'true')
     expect(within(tableRegion()).getByLabelText('Select for import')).toBeDisabled()
@@ -166,12 +170,13 @@ describe('ImportPreviewPanel confirmation safety', () => {
       status: 'confirmed',
       confirmedAt: '2026-08-25T21:00:00Z',
       importedExpenseCount: 1,
+      importedInflowCount: 0,
     }
     const confirm = vi.fn().mockResolvedValue(confirmation)
     const onImportConfirmed = vi.fn().mockResolvedValue(undefined)
     render(<ImportPreviewPanel importState={importState({ confirm })} onImportConfirmed={onImportConfirmed} />)
 
-    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm 1 selected row' }))
 
     expect(confirm).toHaveBeenCalledOnce()
     expect(onImportConfirmed).toHaveBeenCalledOnce()
@@ -187,7 +192,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
       />,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm 1 selected row' }))
 
     expect(onImportConfirmed).not.toHaveBeenCalled()
   })
@@ -199,14 +204,15 @@ describe('ImportPreviewPanel confirmation safety', () => {
       status: 'already_confirmed',
       confirmedAt: '2026-08-25T21:00:00Z',
       importedExpenseCount: 1,
+      importedInflowCount: 0,
     }
     const state = importState({ confirm: vi.fn().mockResolvedValue(result) })
     const { rerender } = render(
       <ImportPreviewPanel importState={state} onImportConfirmed={vi.fn().mockRejectedValue(new Error('offline'))} />,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
-    expect(await screen.findByRole('alert')).toHaveTextContent('Expenses were imported, but Transactions could not be refreshed')
+    await user.click(screen.getByRole('button', { name: 'Confirm 1 selected row' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('The import succeeded, but Transactions could not be refreshed')
 
     rerender(<ImportPreviewPanel importState={importState({
       preview: null,
@@ -214,7 +220,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
       confirmation: result,
     })} />)
     expect(screen.getByRole('heading', { name: 'Statement already imported' })).toBeInTheDocument()
-    expect(screen.getByText(/1 expense was already imported/)).toBeInTheDocument()
+    expect(screen.getByText(/1 expense and 0 incoming deposits were already saved/)).toBeInTheDocument()
   })
 
   it('shows safe row-level duplicate guidance and blocks a stale review', () => {
@@ -229,7 +235,42 @@ describe('ImportPreviewPanel confirmation safety', () => {
 
     expect(screen.getByRole('heading', { name: 'Review new duplicate warnings' })).toBeInTheDocument()
     expect(within(tableRegion()).getByText(/New possible duplicate/)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Import 1 selected expense' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm 1 selected row' })).toBeDisabled()
     expect(screen.getByText(/Refresh this page to load the authoritative duplicate review/)).toBeInTheDocument()
+  })
+
+  it('offers a separate default-off incoming-deposit evidence control without expense fields', async () => {
+    const user = userEvent.setup()
+    const credit = {
+      ...row,
+      rowId: 'credit-1',
+      direction: 'credit',
+      classification: 'non_expense',
+      sourceDescription: 'SYNTHETIC DEPOSIT',
+      isEligible: false,
+      isInflowEligible: true,
+      editableExpenseDescription: null,
+      category: null,
+      selectedForImport: false,
+      selectedForInflow: false,
+    }
+    const updateRow = vi.fn().mockResolvedValue({ ...credit, selectedForInflow: true })
+    render(<ImportPreviewPanel importState={importState({
+      preview: { ...preview, rows: [credit] },
+      selectedCount: 0,
+      updateRow,
+    })} />)
+    const table = tableRegion()
+
+    expect(within(table).queryByLabelText('Expense description')).not.toBeInTheDocument()
+    expect(within(table).getByText(/does not classify it as income or a paycheck/)).toBeInTheDocument()
+    await user.click(within(table).getByLabelText('Save incoming deposit as inflow evidence'))
+
+    expect(updateRow).toHaveBeenCalledWith('credit-1', {
+      editableExpenseDescription: null,
+      category: null,
+      selectedForImport: false,
+      selectedForInflow: true,
+    })
   })
 })

--- a/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
@@ -3,20 +3,21 @@ import { displayText } from "../../../utils/text";
 
 const STATUS_LABELS = {
   expense_candidate: "Expense candidate",
-  non_expense: "Excluded credit",
+  non_expense: "Incoming deposit",
   needs_review: "Needs review",
   invalid: "Invalid row",
 };
 
 const CONFIRMATION_CODE_MESSAGES = {
   possible_duplicate: "New possible duplicate — review this row and explicitly select it again if it should be imported.",
-  row_not_selectable: "This row is not eligible to become an expense.",
+  possible_inflow_duplicate: "New possible incoming-deposit duplicate — review this row and explicitly select it again if it should be saved.",
+  row_not_selectable: "This row is not eligible for the requested import selection.",
   date_required: "A transaction date is required.",
   amount_must_be_positive: "The expense amount must be positive.",
   amount_out_of_range: "The expense amount is outside the supported range.",
   amount_precision_invalid: "The expense amount must use no more than two decimal places.",
-  description_required: "An expense description is required.",
-  description_too_long: "The expense description is too long.",
+  description_required: "A description is required.",
+  description_too_long: "The description is too long.",
   category_required: "An expense category is required.",
   category_too_long: "The expense category is too long.",
   category_reserved: "Choose a category other than Other.",
@@ -97,13 +98,19 @@ function RowStatus({ row, confirmationCodes }) {
       {row.isPossibleDuplicate && (
         <span className="import-warning">Possible duplicate — review before selecting</span>
       )}
+      {row.isPossibleInflowDuplicate && (
+        <span className="import-warning">Possible incoming-deposit duplicate — review before saving</span>
+      )}
       {row.errors.map((code) => <span className="import-error" key={code}>Issue: {code.replaceAll("_", " ")}</span>)}
-      {row.warnings.filter((code) => code !== "possible_duplicate").map((code) => (
+      {row.warnings.filter((code) =>
+        code !== "possible_duplicate" && code !== "possible_inflow_duplicate").map((code) => (
         <span className="import-warning" key={code}>Warning: {code.replaceAll("_", " ")}</span>
       ))}
       {confirmationCodes.map((code) => (
         <span
-          className={code === "possible_duplicate" ? "import-warning" : "import-error"}
+          className={code === "possible_duplicate" || code === "possible_inflow_duplicate"
+            ? "import-warning"
+            : "import-error"}
           key={`confirmation-${code}`}
         >
           {CONFIRMATION_CODE_MESSAGES[code]}
@@ -123,15 +130,22 @@ export default function ImportPreviewRow({
   onSelectionChange,
   presentation = "table",
 }) {
+  const isInflow = row.isInflowEligible;
+  const isSelectable = row.isEligible || isInflow;
+  const isSelected = row.isEligible ? row.selectedForImport : row.selectedForInflow;
   const selection = (
     <label className="import-selection">
       <input
         type="checkbox"
-        checked={row.selectedForImport}
-        disabled={!row.isEligible || disabled || draft.pending}
+        checked={Boolean(isSelected)}
+        disabled={!isSelectable || disabled || draft.pending}
         onChange={(event) => onSelectionChange(event.target.checked)}
       />
-      <span>{row.isEligible ? "Select for import" : "Not selectable"}</span>
+      <span>{row.isEligible
+        ? "Select for import"
+        : isInflow
+          ? "Save incoming deposit as inflow evidence"
+          : "Not selectable"}</span>
     </label>
   );
 
@@ -142,6 +156,9 @@ export default function ImportPreviewRow({
       <div><span className="import-field-label">Direction</span>{displayText(row.direction)}</div>
       <div><span className="import-field-label">Source</span>{row.sourceDescription || "Unavailable"}</div>
       <div><span className="import-field-label">Section</span>{displayText(row.sourceSection)}</div>
+      {isInflow && (
+        <div className="muted">Saving this deposit records account inflow evidence. It does not classify it as income or a paycheck.</div>
+      )}
     </>
   );
 

--- a/frontend/src/features/importPreview/hooks/useImportPreview.js
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.js
@@ -14,15 +14,15 @@ const SAFE_ERRORS = {
   processing_timed_out: "Statement processing timed out. Try the upload again.",
   processing_cancelled: "Statement processing was cancelled.",
   import_in_progress: "Another statement is already being processed.",
-  already_imported: "This statement was already imported. No duplicate expenses were created.",
+  already_imported: "This statement was already imported. No duplicate financial records were created.",
   row_not_selectable: "That row cannot be selected for import.",
-  row_validation_failed: "Check the description and category, then try again.",
+  row_validation_failed: "Check the row details, then try again.",
 };
 
 const CONFIRMATION_MESSAGES = {
-  no_rows_selected: "Select at least one eligible row before importing expenses.",
+  no_rows_selected: "Select at least one eligible row before confirming.",
   duplicate_review_required: "New possible duplicates were found. Review the affected rows and explicitly select any row you still want to import.",
-  confirmation_validation_failed: "One or more selected rows need attention before expenses can be imported.",
+  confirmation_validation_failed: "One or more selected rows need attention before the import can be confirmed.",
   confirmation_conflict: "The statement could not be confirmed because its import state changed. Review the preview and try again.",
   confirmation_failed: "The statement could not be confirmed safely. Nothing is being reported as imported; you can try again.",
   preview_expired: "This preview expired. Re-upload the statement to create a new review.",
@@ -31,6 +31,7 @@ const CONFIRMATION_MESSAGES = {
 
 const SAFE_CONFIRMATION_ROW_CODES = new Set([
   "possible_duplicate",
+  "possible_inflow_duplicate",
   "row_not_selectable",
   "date_required",
   "amount_must_be_positive",
@@ -80,7 +81,9 @@ function isConfirmationResponse(value, batchId) {
     && (value.status === "confirmed" || value.status === "already_confirmed")
     && typeof value.confirmedAt === "string"
     && Number.isInteger(value.importedExpenseCount)
-    && value.importedExpenseCount >= 0;
+    && value.importedExpenseCount >= 0
+    && Number.isInteger(value.importedInflowCount)
+    && value.importedInflowCount >= 0;
 }
 
 function batchIdFromLocation() {
@@ -216,7 +219,8 @@ export function useImportPreview() {
       }));
       setConfirmationIssue((current) => {
         if (!current) return null;
-        if (current.code === "no_rows_selected" && payload.selectedForImport) return null;
+        if (current.code === "no_rows_selected"
+          && (payload.selectedForImport || payload.selectedForInflow)) return null;
         if (!current.rows.some((row) => row.rowId === rowId)) return current;
         return {
           ...current,
@@ -284,7 +288,9 @@ export function useImportPreview() {
     forgetBatch();
   }, []);
 
-  const selectedCount = preview?.rows.filter((row) => row.isEligible && row.selectedForImport).length ?? 0;
+  const selectedCount = preview?.rows.filter((row) =>
+    (row.isEligible && row.selectedForImport)
+    || (row.isInflowEligible && row.selectedForInflow)).length ?? 0;
 
   return {
     preview,

--- a/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
+++ b/frontend/src/features/importPreview/hooks/useImportPreview.test.jsx
@@ -12,7 +12,8 @@ const preview = {
   sourceType: 'sunflower_pdf',
   expiresAt: '2026-08-21T12:00:00Z',
   rows: [{
-    rowId: 'row-1', isEligible: true, selectedForImport: false,
+    rowId: 'row-1', isEligible: true, isInflowEligible: false,
+    selectedForImport: false, selectedForInflow: false,
     editableExpenseDescription: 'Coffee', category: 'food',
   }],
 }
@@ -22,6 +23,7 @@ const confirmed = {
   status: 'confirmed',
   confirmedAt: '2026-08-25T21:00:00Z',
   importedExpenseCount: 1,
+  importedInflowCount: 0,
 }
 
 describe('useImportPreview', () => {
@@ -69,7 +71,7 @@ describe('useImportPreview', () => {
     await act(() => result.current.selectSource('sunflower_pdf'))
     await act(() => result.current.upload(new File(['pdf'], 'statement.pdf')))
 
-    expect(result.current.error).toBe('This statement was already imported. No duplicate expenses were created.')
+    expect(result.current.error).toBe('This statement was already imported. No duplicate financial records were created.')
     expect(result.current.error).not.toContain('private server detail')
   })
 
@@ -99,6 +101,22 @@ describe('useImportPreview', () => {
     expect(result.current.preview).toEqual(preview)
     expect(result.current.error).toBe('That row cannot be selected for import.')
     expect(result.current.error).not.toContain('internal detail')
+  })
+
+  it('counts explicitly selected eligible incoming deposits independently of expense selection', async () => {
+    window.history.replaceState({}, '', `/transactions?importBatch=${preview.batchId}`)
+    const creditPreview = {
+      ...preview,
+      rows: [{
+        ...preview.rows[0], isEligible: false, isInflowEligible: true,
+        selectedForImport: false, selectedForInflow: true,
+      }],
+    }
+    importPreviewApi.getById.mockResolvedValue({ status: 200, data: creditPreview })
+    const { result } = renderHook(() => useImportPreview())
+
+    await waitFor(() => expect(result.current.preview).toEqual(creditPreview))
+    expect(result.current.selectedCount).toBe(1)
   })
 
   it('requires explicit source selection before looking for an open preview', async () => {

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -227,7 +227,7 @@ describe('existing expense workflows', () => {
     await user.upload(screen.getByLabelText('Sunflower statement PDF'), file)
 
     expect(upload).toHaveBeenCalledWith(file)
-    expect(screen.getByText(/Expenses are created only after confirmation/)).toBeInTheDocument()
+    expect(screen.getByText(/Expenses and explicitly selected incoming deposits are created only after confirmation/)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /confirm|import expenses/i })).not.toBeInTheDocument()
   })
 
@@ -268,6 +268,7 @@ describe('existing expense workflows', () => {
       status,
       confirmedAt: '2026-08-25T21:00:00Z',
       importedExpenseCount: 1,
+      importedInflowCount: 0,
     }
     const confirm = vi.fn().mockResolvedValue(result)
     useExpenses.mockReturnValue({ ...baseExpensesHook, refresh })
@@ -280,7 +281,7 @@ describe('existing expense workflows', () => {
     })
     render(<TransactionsPage />)
 
-    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm 1 selected row' }))
 
     expect(confirm).toHaveBeenCalledOnce()
     expect(refresh).toHaveBeenCalledOnce()
@@ -294,6 +295,7 @@ describe('existing expense workflows', () => {
       status: 'confirmed',
       confirmedAt: '2026-08-25T21:00:00Z',
       importedExpenseCount: 1,
+      importedInflowCount: 0,
     })
     useExpenses.mockReturnValue({ ...baseExpensesHook, refresh })
     useImportPreview.mockReturnValue({
@@ -305,11 +307,11 @@ describe('existing expense workflows', () => {
     })
     render(<TransactionsPage />)
 
-    await user.click(screen.getByRole('button', { name: 'Import 1 selected expense' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm 1 selected row' }))
 
     expect(refresh).toHaveBeenCalledOnce()
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Expenses were imported, but Transactions could not be refreshed'
+      'The import succeeded, but Transactions could not be refreshed'
     )
   })
 
@@ -358,7 +360,8 @@ describe('existing expense workflows', () => {
       editableExpenseDescription: 'Morning coffee',
       category: 'food',
       selectedForImport: false,
+      selectedForInflow: false,
     })
-    expect(screen.getByRole('button', { name: 'Import selected expenses' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm selected rows' })).toBeDisabled()
   })
 })


### PR DESCRIPTION
## Summary

- add authenticated, owner-scoped CRUD contracts and endpoints for existing `AccountInflow` records
- expose credit-row inflow eligibility, explicit default-off selection, and deterministic owner-scoped duplicate warnings in statement previews
- confirm selected debit expenses and credit inflows atomically with separate provenance and stable replay counts
- update the import UI and financial/import invariants for generic incoming-deposit evidence

Closes #112

## Risk classification

HIGH — financial persistence and business-rule semantics. This implements only the explicitly approved no-migration Stage 3 plan.

## Important implementation details

- credit rows remain distinct from expenses and are never labeled as income or paychecks
- inflow selection is explicit and false by default; debit and inflow selection fields are mutually exclusive
- duplicate warnings use authenticated owner + posted date + amount + normalized description and return deterministically ordered inflow IDs
- confirmation rechecks duplicates and validation, then writes expenses, inflows, and their separate provenance records in one transaction
- already-confirmed retries return separate stable expense and inflow counts

## Verification

- `./scripts/verify.sh frontend` — passed (169 tests, lint, production build)
- `./scripts/verify.sh backend` — passed (365 tests)
- `./scripts/verify.sh postgresql` against disposable local PostgreSQL 16 — passed (migration chain 1/1; integration 31/31)
- `git diff --check` — passed
- Git pack verification and connectivity check — passed after recoverable local repository repair

## Scope boundaries and impact

- no EF Core migration, schema, mapping, or model-snapshot changes
- no dependency changes
- no statement parser/classification changes
- API impact: adds `/api/inflows` CRUD endpoints and extends import preview/update/confirmation payloads with inflow-specific fields and counts
- no deployment, production access, production database operation, or merge performed
