### PR TITLE
Add confirmed paycheck profiles and lifecycle APIs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,6 +72,18 @@ only confirmed commitments, occurrence links, and dismissals are persisted.
 The approved V1 semantics and explicit non-goals are defined in
 [`docs/commitment-intelligence.md`](docs/commitment-intelligence.md).
 
+`backend/Paychecks/` contains the pure, versioned paycheck candidate detector and
+projector plus the owner-scoped profile application service. The authenticated
+`/api/paycheck-candidates` and `/api/paychecks` APIs separate generic inflow
+evidence from explicit user-confirmed paycheck meaning. Profiles, confirmation
+occurrences, and exact-fingerprint dismissals are persisted; candidate and
+projection results remain derived. Confirmation uses a serializable transaction,
+ordered inflow locks, owner-consistent foreign keys, and exclusive evidence
+assignment. The profile schedule is immutable, while accepted amounts, windows,
+display name, and lifecycle are explicitly editable. No Paychecks frontend or
+paycheck change detection is included. See the paycheck section of
+[`docs/financial-domain-invariants.md`](docs/financial-domain-invariants.md).
+
 ### Authentication and ownership boundaries
 
 ASP.NET Core Identity manages users, JWT bearer authentication establishes the
@@ -88,8 +100,9 @@ not implemented yet.
 ### Persistence and migrations
 
 PostgreSQL is the application persistence provider. The database stores
-Identity data, expenses, budget limits, commitment decisions and links, and the
-ASP.NET Core Data Protection key ring. Normal application startup does not
+Identity data, expenses, budget limits, commitment decisions and links, account
+inflows and their import provenance, paycheck profiles/evidence/dismissals, and
+the ASP.NET Core Data Protection key ring. Normal application startup does not
 apply migrations. Production migrations remain a separate, deliberate,
 human-authorized operation described in [`README.md`](README.md).
 

--- a/backend.Tests/Financial/PaychecksApiTests.cs
+++ b/backend.Tests/Financial/PaychecksApiTests.cs
@@ -1,0 +1,736 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using BudgetPlanner.Paychecks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+public sealed class PaychecksApiTests
+{
+    private static readonly DateOnly EvaluatedOn = new(2026, 9, 10);
+
+    [Fact]
+    public async Task Every_read_and_mutation_requires_authentication()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var client = app.CreateTestClient();
+        var id = Guid.NewGuid();
+        foreach (var (method, path) in new[]
+        {
+            (HttpMethod.Get, "/api/paycheck-candidates"),
+            (HttpMethod.Post, "/api/paycheck-candidates/dismiss"),
+            (HttpMethod.Post, "/api/paycheck-candidates/reconsider"),
+            (HttpMethod.Post, "/api/paycheck-candidates/confirm"),
+            (HttpMethod.Get, "/api/paychecks"),
+            (HttpMethod.Post, "/api/paychecks"),
+            (HttpMethod.Get, $"/api/paychecks/{id}"),
+            (HttpMethod.Put, $"/api/paychecks/{id}"),
+            (HttpMethod.Patch, $"/api/paychecks/{id}/lifecycle")
+        })
+        {
+            using var request = new HttpRequestMessage(method, path) { Content = JsonContent.Create(new { }) };
+            using var response = await client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Candidates_match_the_pure_detector_exactly_with_owned_sources_and_ordinal_order()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-evidence@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-evidence-other@example.com");
+        var zulu = await SeedMonthlyAsync(app, owner.Id, "  Zulu   Deposit  ");
+        var alpha = await SeedMonthlyAsync(app, owner.Id, "alpha deposit", variable: true);
+        await SeedMonthlyAsync(app, other.Id, "FOREIGN PRIVATE", variable: true);
+        await SeedImportedAsync(app, owner.Id, zulu[0]);
+        // The nonrelational fixture permits corrupt provenance: it must never establish an owned source.
+        await SeedImportedAsync(app, other.Id, zulu[1]);
+        await app.SeedInflowAsync(owner.Id, "future only", 100m, EvaluatedOn.AddDays(1));
+
+        var response = await CandidatesAsync(owner.Client);
+        Assert.Equal("2026-09-10", response.GetProperty("evaluatedOn").GetString());
+        Assert.Empty(response.GetProperty("dismissedCandidates").EnumerateArray());
+        var candidates = response.GetProperty("candidates").EnumerateArray().ToArray();
+        Assert.Equal(new[] { "alpha deposit", "zulu deposit" }, candidates.Select(c => c.GetProperty("normalizedDescriptionIdentity").GetString()));
+        var expected = new PaycheckCandidateDetector().Detect(zulu.Concat(alpha), EvaluatedOn);
+        foreach (var (actual, domain) in candidates.Zip(expected))
+        {
+            AssertKeys(actual, "algorithmVersion", "coveredFrom", "coveredTo", "evidence", "fingerprint", "normalizedDescriptionIdentity", "observedAmount", "occurrenceCount", "schedule", "windowAfterDays", "windowBeforeDays");
+            Assert.Equal(domain.EvidenceFingerprint, actual.GetProperty("fingerprint").GetString());
+            Assert.Equal(domain.AlgorithmVersion, actual.GetProperty("algorithmVersion").GetString());
+            Assert.Equal(3, actual.GetProperty("occurrenceCount").GetInt32());
+            Assert.Equal("2026-07-10", actual.GetProperty("coveredFrom").GetString());
+            Assert.Equal("2026-09-10", actual.GetProperty("coveredTo").GetString());
+            Assert.True(JsonNode.DeepEquals(JsonSerializer.SerializeToNode(Schedule(domain.Schedule)), JsonNode.Parse(actual.GetProperty("schedule").GetRawText())));
+            Assert.Equal(domain.WindowBeforeDays, actual.GetProperty("windowBeforeDays").GetInt32());
+            Assert.Equal(domain.WindowAfterDays, actual.GetProperty("windowAfterDays").GetInt32());
+            foreach (var (evidence, snapshot) in actual.GetProperty("evidence").EnumerateArray().Zip(domain.Evidence))
+            {
+                AssertKeys(evidence, "accountInflowId", "amount", "description", "postedDate", "slotAnchor", "source", "timingOffsetDays");
+                Assert.Equal(snapshot.AccountInflowId, evidence.GetProperty("accountInflowId").GetInt32());
+                Assert.Equal(snapshot.Amount, evidence.GetProperty("amount").GetDecimal());
+                Assert.Equal(snapshot.Description, evidence.GetProperty("description").GetString());
+                Assert.Equal(snapshot.PostedDate.ToString("yyyy-MM-dd"), evidence.GetProperty("postedDate").GetString());
+                Assert.Equal(snapshot.SlotAnchor.ToString("yyyy-MM-dd"), evidence.GetProperty("slotAnchor").GetString());
+                Assert.Equal(snapshot.TimingOffsetDays, evidence.GetProperty("timingOffsetDays").GetInt32());
+                Assert.Equal(snapshot.AccountInflowId == zulu[0].Id ? "imported" : "manual", evidence.GetProperty("source").GetString());
+            }
+        }
+        var observed = candidates[0].GetProperty("observedAmount");
+        Assert.Equal("variable", observed.GetProperty("mode").GetString());
+        Assert.Equal(1000m, observed.GetProperty("minimumAmount").GetDecimal());
+        Assert.Equal(1100m, observed.GetProperty("lowerMedianAmount").GetDecimal());
+        Assert.Equal(1200m, observed.GetProperty("maximumAmount").GetDecimal());
+        Assert.DoesNotContain("FOREIGN", response.ToString());
+        Assert.DoesNotContain("revision", response.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ownerId", response.ToString());
+        Assert.Equal(response.GetRawText(), (await CandidatesAsync(owner.Client)).GetRawText());
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+    }
+
+    [Fact]
+    public async Task Dismissal_is_exact_idempotent_owner_scoped_and_retained_when_evidence_changes()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-dismiss@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-dismiss-other@example.com");
+        var rows = await SeedMonthlyAsync(app, owner.Id);
+        var candidate = await CandidateAsync(owner.Client);
+        var decision = Decision(candidate);
+        await AssertErrorAsync(await other.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision), HttpStatusCode.Conflict, "candidate_changed");
+        for (var i = 0; i < 2; i++)
+            Assert.Equal(HttpStatusCode.NoContent, (await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision)).StatusCode);
+        Assert.Equal(1, await CountAsync(app, db => db.PaycheckCandidateDismissals.CountAsync()));
+        var dismissed = await CandidatesAsync(owner.Client);
+        Assert.Empty(dismissed.GetProperty("candidates").EnumerateArray());
+        Assert.Equal(candidate.GetRawText(), Assert.Single(dismissed.GetProperty("dismissedCandidates").EnumerateArray()).GetRawText());
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(candidate)), HttpStatusCode.Conflict, "candidate_dismissed");
+        Assert.Equal(HttpStatusCode.NoContent, (await other.Client.PostAsJsonAsync("/api/paycheck-candidates/reconsider", decision)).StatusCode);
+        Assert.Equal(1, await CountAsync(app, db => db.PaycheckCandidateDismissals.CountAsync()));
+
+        await EditInflowAsync(owner.Client, rows[0], amount: 1010m);
+        var changed = await CandidateAsync(owner.Client);
+        Assert.NotEqual(candidate.GetProperty("fingerprint").GetString(), changed.GetProperty("fingerprint").GetString());
+        Assert.Empty((await CandidatesAsync(owner.Client)).GetProperty("dismissedCandidates").EnumerateArray());
+        Assert.Equal(1, await CountAsync(app, db => db.PaycheckCandidateDismissals.CountAsync()));
+        // Existing exact decisions remain idempotent even when they no longer describe a current candidate.
+        Assert.Equal(HttpStatusCode.NoContent, (await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision)).StatusCode);
+        for (var i = 0; i < 2; i++)
+            Assert.Equal(HttpStatusCode.NoContent, (await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/reconsider", decision)).StatusCode);
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckCandidateDismissals.CountAsync()));
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision), HttpStatusCode.Conflict, "candidate_changed");
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task Confirmation_persists_explicit_amount_windows_and_exact_occurrences(bool variable, bool range)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-confirm@example.com");
+        var rows = await SeedMonthlyAsync(app, owner.Id, variable: variable);
+        var candidate = await CandidateAsync(owner.Client);
+        var request = Confirmation(candidate, range ? RangeAmount(900m, 1500m) : FixedAmount(1350m));
+        request["accountInflowIds"] = new JsonArray(int.MaxValue);
+        request["evidence"] = new JsonArray(JsonSerializer.SerializeToNode(new { accountInflowId = int.MaxValue }));
+        using var response = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(body.GetProperty("alreadyConfirmed").GetBoolean());
+        var profile = body.GetProperty("paycheck");
+        var id = profile.GetProperty("id").GetGuid();
+        Assert.Equal("Synthetic employer", profile.GetProperty("displayName").GetString());
+        Assert.Equal("active", profile.GetProperty("lifecycle").GetString());
+        Assert.Equal("candidate", profile.GetProperty("source").GetString());
+        Assert.Equal(candidate.GetProperty("schedule").GetRawText(), profile.GetProperty("schedule").GetRawText());
+        Assert.Equal(candidate.GetProperty("fingerprint").GetString(), profile.GetProperty("origin").GetProperty("fingerprint").GetString());
+        Assert.Equal(3, profile.GetProperty("windowBeforeDays").GetInt32());
+        Assert.Equal(2, profile.GetProperty("windowAfterDays").GetInt32());
+        Assert.Equal(range ? "range" : "fixed", profile.GetProperty("amount").GetProperty("mode").GetString());
+        Assert.Equal(range ? 900m : 1350m, profile.GetProperty("amount").GetProperty(range ? "minimumAmount" : "fixedAmount").GetDecimal());
+        if (range) Assert.Equal(1500m, profile.GetProperty("amount").GetProperty("maximumAmount").GetDecimal());
+        Assert.Equal("2026-10-10", profile.GetProperty("nextProjection").GetProperty("anchor").GetString());
+        Assert.All(profile.GetProperty("evidence").EnumerateArray(), e => Assert.False(e.GetProperty("editedSinceConfirmation").GetBoolean()));
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var saved = await db.PaycheckProfiles.AsNoTracking().SingleAsync();
+        Assert.Equal(owner.Id, saved.OwnerId);
+        Assert.Equal(Convert.FromHexString(candidate.GetProperty("fingerprint").GetString()!), saved.OriginEvidenceFingerprint);
+        var occurrences = await db.PaycheckOccurrences.AsNoTracking().OrderBy(e => e.AccountInflowId).ToArrayAsync();
+        Assert.Equal(rows.Select(r => r.Id), occurrences.Select(e => e.AccountInflowId));
+        foreach (var (row, occurrence) in rows.Zip(occurrences))
+        {
+            Assert.Equal(id, occurrence.PaycheckProfileId);
+            Assert.Equal(owner.Id, occurrence.OwnerId);
+            Assert.Equal(row.PaycheckEvidenceRevision, occurrence.EvidenceRevisionAtAssignment);
+            Assert.Equal(row.Date, occurrence.SlotAnchor);
+            Assert.Equal(0, occurrence.TimingOffsetDays);
+            Assert.Equal(PaycheckOccurrenceKind.ConfirmationEvidence, occurrence.Kind);
+        }
+        Assert.Empty((await CandidatesAsync(owner.Client)).GetProperty("candidates").EnumerateArray());
+        using var retry = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request);
+        Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+        var retryBody = await retry.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(retryBody.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Equal(id, retryBody.GetProperty("paycheck").GetProperty("id").GetGuid());
+        Assert.Equal(1, await db.PaycheckProfiles.CountAsync());
+    }
+
+    [Fact]
+    public async Task Variable_candidate_requires_range_and_confirmation_rejects_stale_or_foreign_tuples()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-stale@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-stale-other@example.com");
+        var rows = await SeedMonthlyAsync(app, owner.Id, variable: true);
+        var empty = await CandidatesAsync(other.Client);
+        Assert.Empty(empty.GetProperty("candidates").EnumerateArray());
+        Assert.Empty(empty.GetProperty("dismissedCandidates").EnumerateArray());
+        var candidate = await CandidateAsync(owner.Client);
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(candidate)), HttpStatusCode.BadRequest);
+        var request = Confirmation(candidate, RangeAmount(900m, 1400m));
+        await AssertErrorAsync(await other.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request), HttpStatusCode.Conflict, "candidate_changed");
+        var mismatched = Confirmation(candidate, RangeAmount(900m, 1400m));
+        mismatched["schedule"] = JsonSerializer.SerializeToNode(Schedule(new MonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(11))));
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", mismatched), HttpStatusCode.BadRequest, "candidate_schedule_mismatch");
+        await EditInflowAsync(owner.Client, rows[0], amount: 1001m);
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request), HttpStatusCode.Conflict, "candidate_changed");
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckOccurrences.CountAsync()));
+    }
+
+    [Fact]
+    public async Task Manual_creation_has_no_origin_or_evidence_and_ignores_client_ownership_and_link_injection()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-manual@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-manual-other@example.com");
+        var foreign = await app.SeedInflowAsync(other.Id, "FOREIGN PRIVATE");
+        var request = Manual();
+        request["ownerId"] = other.Id;
+        request["accountInflowIds"] = new JsonArray(foreign.Id);
+        request["evidence"] = new JsonArray(JsonSerializer.SerializeToNode(new { accountInflowId = foreign.Id }));
+        using var response = await owner.Client.PostAsJsonAsync("/api/paychecks", request);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var profile = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var id = profile.GetProperty("id").GetGuid();
+        Assert.Equal($"/api/paychecks/{id}", response.Headers.Location?.AbsolutePath ?? response.Headers.Location?.OriginalString);
+        Assert.Equal("Synthetic employer", profile.GetProperty("displayName").GetString());
+        Assert.Equal("manual", profile.GetProperty("source").GetString());
+        Assert.Equal(JsonValueKind.Null, profile.GetProperty("origin").ValueKind);
+        Assert.Empty(profile.GetProperty("evidence").EnumerateArray());
+        Assert.Equal("2026-09-10", profile.GetProperty("nextProjection").GetProperty("anchor").GetString());
+        Assert.DoesNotContain("owner", profile.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("change", profile.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.Empty((await other.Client.GetFromJsonAsync<JsonElement>("/api/paychecks")).GetProperty("paychecks").EnumerateArray());
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckOccurrences.CountAsync()));
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidSchedules))]
+    public async Task Manual_profiles_map_all_schedule_types_to_the_unchanged_projector(PaycheckSchedule schedule)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-schedules@example.com");
+        var request = Manual(schedule: schedule, amount: RangeAmount(1.01m, 9999999999999999.99m));
+        using var response = await owner.Client.PostAsJsonAsync("/api/paychecks", request);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var profile = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var actual = profile.GetProperty("nextProjection");
+        var expected = new PaycheckProjector().Project(new ConfirmedPaycheckPattern(schedule, 3, 2, new RangeConfirmedPaycheckAmount(1.01m, 9999999999999999.99m)), EvaluatedOn);
+        Assert.Equal(PaycheckProjector.AlgorithmVersion, actual.GetProperty("algorithmVersion").GetString());
+        Assert.Equal(EvaluatedOn.ToString("yyyy-MM-dd"), actual.GetProperty("evaluatedOn").GetString());
+        Assert.Equal(expected.Anchor.ToString("yyyy-MM-dd"), actual.GetProperty("anchor").GetString());
+        Assert.Equal(expected.EarliestExpectedDate.ToString("yyyy-MM-dd"), actual.GetProperty("earliestExpectedDate").GetString());
+        Assert.Equal(expected.LatestExpectedDate.ToString("yyyy-MM-dd"), actual.GetProperty("latestExpectedDate").GetString());
+        Assert.Equal(profile.GetProperty("amount").GetRawText(), actual.GetProperty("amount").GetRawText());
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidManualRequests))]
+    public async Task Manual_validation_fails_closed_without_persisting(string path, string invalidJson)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-invalid@example.com");
+        var request = Manual();
+        SetPath(request, path, JsonNode.Parse(invalidJson));
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paychecks", request), HttpStatusCode.BadRequest);
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+    }
+
+    [Theory]
+    [InlineData("displayName")]
+    [InlineData("schedule")]
+    [InlineData("windowBeforeDays")]
+    [InlineData("windowAfterDays")]
+    [InlineData("amount")]
+    public async Task Manual_creation_requires_explicit_complete_profile_fields(string omitted)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-missing@example.com");
+        var request = Manual();
+        request.Remove(omitted);
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paychecks", request), HttpStatusCode.BadRequest);
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+    }
+
+    [Theory]
+    [InlineData("algorithmVersion", "null")]
+    [InlineData("algorithmVersion", "\"   \"")]
+    [InlineData("fingerprint", "null")]
+    [InlineData("fingerprint", "\"not-a-fingerprint\"")]
+    [InlineData("fingerprint", "\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"")]
+    [InlineData("cadence", "\"annual\"")]
+    public async Task Decision_validation_rejects_malformed_exact_tuple(string field, string value)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-decision-invalid@example.com");
+        var request = JsonSerializer.SerializeToNode(new { algorithmVersion = PaycheckCandidateDetector.AlgorithmVersion, cadence = "monthly", fingerprint = new string('a', 64) })!.AsObject();
+        request[field] = JsonNode.Parse(value);
+        foreach (var action in new[] { "dismiss", "reconsider" })
+            await AssertErrorAsync(await owner.Client.PostAsJsonAsync($"/api/paycheck-candidates/{action}", request), HttpStatusCode.BadRequest);
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckCandidateDismissals.CountAsync()));
+    }
+
+    [Fact]
+    public async Task Missing_and_foreign_item_operations_return_identical_empty_not_found()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-isolation@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-isolation-other@example.com");
+        var foreign = await CreateManualAsync(other.Client, "FOREIGN PRIVATE");
+        foreach (var id in new[] { foreign.GetProperty("id").GetGuid(), Guid.NewGuid() })
+        {
+            foreach (var response in new[]
+            {
+                await owner.Client.GetAsync($"/api/paychecks/{id}"),
+                await owner.Client.PutAsJsonAsync($"/api/paychecks/{id}", Update()),
+                await owner.Client.PatchAsJsonAsync($"/api/paychecks/{id}/lifecycle", new { lifecycle = "ended" })
+            })
+            {
+                using (response)
+                {
+                    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                    Assert.Empty(await response.Content.ReadAsStringAsync());
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Updates_preserve_schedule_and_lifecycle_is_explicit_reversible_and_ordered()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-lifecycle@example.com");
+        var zulu = await CreateManualAsync(owner.Client, "zulu");
+        var alpha = await CreateManualAsync(owner.Client, "Alpha");
+        var duplicateAlpha = await CreateManualAsync(owner.Client, "Alpha");
+        var ended = await CreateManualAsync(owner.Client, "A ended");
+        var zuluId = zulu.GetProperty("id").GetGuid();
+        var alphaId = alpha.GetProperty("id").GetGuid();
+        var duplicateAlphaId = duplicateAlpha.GetProperty("id").GetGuid();
+        var endedId = ended.GetProperty("id").GetGuid();
+        await SetLifecycleAsync(owner.Client, endedId, "ended");
+        await SetLifecycleAsync(owner.Client, zuluId, "paused");
+        var list = await owner.Client.GetFromJsonAsync<JsonElement>("/api/paychecks");
+        Assert.Equal("2026-09-10", list.GetProperty("evaluatedOn").GetString());
+        Assert.Equal(new[] { alphaId, duplicateAlphaId }.Order().Concat(new[] { zuluId, endedId }), list.GetProperty("paychecks").EnumerateArray().Select(p => p.GetProperty("id").GetGuid()));
+        foreach (var state in new[] { "active", "ended", "paused", "active", "active" })
+        {
+            var profile = await SetLifecycleAsync(owner.Client, zuluId, state);
+            Assert.Equal(state, profile.GetProperty("lifecycle").GetString());
+            Assert.Equal(state == "active" ? JsonValueKind.Object : JsonValueKind.Null, profile.GetProperty("nextProjection").ValueKind);
+        }
+        var update = Update();
+        update["schedule"] = JsonSerializer.SerializeToNode(Schedule(new WeeklyPaycheckSchedule(EvaluatedOn)));
+        update["lifecycle"] = "ended";
+        for (var i = 0; i < 2; i++)
+        {
+            using var response = await owner.Client.PutAsJsonAsync($"/api/paychecks/{zuluId}", update);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<JsonElement>();
+            Assert.Equal(zulu.GetProperty("schedule").GetRawText(), result.GetProperty("schedule").GetRawText());
+            Assert.Equal("Updated employer", result.GetProperty("displayName").GetString());
+            Assert.Equal("active", result.GetProperty("lifecycle").GetString());
+            Assert.Equal("range", result.GetProperty("amount").GetProperty("mode").GetString());
+        }
+        await AssertErrorAsync(await owner.Client.PatchAsJsonAsync($"/api/paychecks/{zuluId}/lifecycle", new { lifecycle = "deleted" }), HttpStatusCode.BadRequest);
+        using var deletion = await owner.Client.DeleteAsync($"/api/paychecks/{zuluId}");
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, deletion.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await owner.Client.GetAsync($"/api/paychecks/{zuluId}")).StatusCode);
+    }
+
+    [Theory]
+    [InlineData("displayName", "\"  \"")]
+    [InlineData("windowAfterDays", "4")]
+    [InlineData("amount.maximumAmount", "800")]
+    public async Task Invalid_updates_leave_the_existing_profile_unchanged(string path, string invalidJson)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-invalid-update@example.com");
+        var original = await CreateManualAsync(owner.Client, "Original");
+        var id = original.GetProperty("id").GetGuid();
+        var update = Update();
+        SetPath(update, path, JsonNode.Parse(invalidJson));
+        await AssertErrorAsync(await owner.Client.PutAsJsonAsync($"/api/paychecks/{id}", update), HttpStatusCode.BadRequest);
+        var current = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        Assert.Equal(original.GetRawText(), current.GetRawText());
+    }
+
+    [Theory]
+    [InlineData("weekly")]
+    [InlineData("biweekly")]
+    public async Task Creation_rejects_projection_date_overflow_without_persisting_a_profile(string cadence)
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-overflow-create@example.com");
+        var request = ExtremeReferenceProfile(cadence);
+        request["windowAfterDays"] = 1;
+
+        await AssertErrorAsync(await owner.Client.PostAsJsonAsync("/api/paychecks", request), HttpStatusCode.BadRequest, "schedule_invalid");
+
+        Assert.Equal(0, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+        Assert.Empty((await owner.Client.GetFromJsonAsync<JsonElement>("/api/paychecks")).GetProperty("paychecks").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Update_rejects_projection_date_overflow_without_changing_the_profile()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-overflow-update@example.com");
+        using var creation = await owner.Client.PostAsJsonAsync("/api/paychecks", ExtremeReferenceProfile("weekly"));
+        Assert.Equal(HttpStatusCode.Created, creation.StatusCode);
+        var original = await creation.Content.ReadFromJsonAsync<JsonElement>();
+        var id = original.GetProperty("id").GetGuid();
+        Assert.Equal("9999-12-31", original.GetProperty("nextProjection").GetProperty("latestExpectedDate").GetString());
+        app.Clock.UtcNow = app.Clock.UtcNow.AddMinutes(1);
+        var update = Update();
+        update["windowAfterDays"] = 1;
+
+        await AssertErrorAsync(await owner.Client.PutAsJsonAsync($"/api/paychecks/{id}", update), HttpStatusCode.BadRequest, "schedule_invalid");
+
+        var current = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        Assert.Equal(original.GetProperty("displayName").GetString(), current.GetProperty("displayName").GetString());
+        Assert.Equal(original.GetProperty("amount").GetRawText(), current.GetProperty("amount").GetRawText());
+        Assert.Equal(original.GetProperty("updatedAt").GetString(), current.GetProperty("updatedAt").GetString());
+        Assert.Equal(0, current.GetProperty("windowAfterDays").GetInt32());
+        Assert.Equal("active", current.GetProperty("lifecycle").GetString());
+    }
+
+    [Fact]
+    public async Task Reactivation_rejects_projection_date_overflow_and_keeps_the_profile_paused()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-overflow-lifecycle@example.com");
+        using var creation = await owner.Client.PostAsJsonAsync("/api/paychecks", ExtremeReferenceProfile("biweekly"));
+        Assert.Equal(HttpStatusCode.Created, creation.StatusCode);
+        var id = (await creation.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetGuid();
+        await SetLifecycleAsync(owner.Client, id, "paused");
+        var update = Update();
+        update["windowAfterDays"] = 1;
+        using var updated = await owner.Client.PutAsJsonAsync($"/api/paychecks/{id}", update);
+        Assert.Equal(HttpStatusCode.OK, updated.StatusCode);
+        var paused = await updated.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(JsonValueKind.Null, paused.GetProperty("nextProjection").ValueKind);
+        app.Clock.UtcNow = app.Clock.UtcNow.AddMinutes(1);
+
+        await AssertErrorAsync(await owner.Client.PatchAsJsonAsync($"/api/paychecks/{id}/lifecycle", new { lifecycle = "active" }), HttpStatusCode.BadRequest, "schedule_invalid");
+
+        var current = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        Assert.Equal(paused.GetRawText(), current.GetRawText());
+        Assert.Equal("paused", current.GetProperty("lifecycle").GetString());
+    }
+
+    private static JsonObject ExtremeReferenceProfile(string cadence)
+    {
+        var request = Manual(schedule: cadence == "weekly"
+            ? new WeeklyPaycheckSchedule(DateOnly.MaxValue)
+            : new BiweeklyPaycheckSchedule(DateOnly.MaxValue));
+        request["windowAfterDays"] = 0;
+        return request;
+    }
+
+    [Fact]
+    public async Task Evidence_edits_keep_assignment_and_retry_identity_while_showing_current_data_only()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-edited@example.com");
+        var rows = await SeedMonthlyAsync(app, owner.Id);
+        var candidate = await CandidateAsync(owner.Client);
+        var request = Confirmation(candidate);
+        using var confirmation = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request);
+        confirmation.EnsureSuccessStatusCode();
+        var profile = (await confirmation.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("paycheck");
+        var id = profile.GetProperty("id").GetGuid();
+        await EditInflowAsync(owner.Client, rows[0], 1510m, "Revised description");
+        var current = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        var evidence = current.GetProperty("evidence").EnumerateArray().ToArray();
+        Assert.Equal(3, evidence.Length);
+        Assert.True(evidence[0].GetProperty("editedSinceConfirmation").GetBoolean());
+        Assert.Equal(1510m, evidence[0].GetProperty("amount").GetDecimal());
+        Assert.Equal("Revised description", evidence[0].GetProperty("description").GetString());
+        Assert.All(evidence.Skip(1), e => Assert.False(e.GetProperty("editedSinceConfirmation").GetBoolean()));
+        Assert.DoesNotContain("revision", current.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(profile.GetProperty("amount").GetRawText(), current.GetProperty("amount").GetRawText());
+        Assert.Equal(profile.GetProperty("schedule").GetRawText(), current.GetProperty("schedule").GetRawText());
+        await SetLifecycleAsync(owner.Client, id, "ended");
+        Assert.Empty((await CandidatesAsync(owner.Client)).GetProperty("candidates").EnumerateArray());
+        Assert.Equal(3, await CountAsync(app, db => db.PaycheckOccurrences.CountAsync()));
+        await owner.Client.PutAsJsonAsync($"/api/paychecks/{id}", Update());
+        using var retry = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request);
+        Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+        var retryBody = await retry.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(retryBody.GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Equal("Updated employer", retryBody.GetProperty("paycheck").GetProperty("displayName").GetString());
+        Assert.Equal("ended", retryBody.GetProperty("paycheck").GetProperty("lifecycle").GetString());
+    }
+
+    [Fact]
+    public async Task Deleted_evidence_recomputes_latest_slot_keeps_profile_and_preserves_confirmation_retry()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-deleted@example.com");
+        var rows = await SeedMonthlyAsync(app, owner.Id);
+        var request = Confirmation(await CandidateAsync(owner.Client));
+        using var confirmation = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request);
+        confirmation.EnsureSuccessStatusCode();
+        var profile = (await confirmation.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("paycheck");
+        var id = profile.GetProperty("id").GetGuid();
+        Assert.Equal("2026-10-10", profile.GetProperty("nextProjection").GetProperty("anchor").GetString());
+        // InMemory does not execute database cascades for untracked dependents. Load the relationship
+        // in the deletion context to exercise EF cascade behavior; PostgreSQL tests prove the API cascade.
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await db.PaycheckOccurrences.LoadAsync();
+            var latestInflowId = rows[^1].Id;
+            db.AccountInflows.Remove(await db.AccountInflows.SingleAsync(i => i.Id == latestInflowId));
+            await db.SaveChangesAsync();
+        }
+        var afterLatestDelete = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        Assert.Equal(2, afterLatestDelete.GetProperty("evidence").GetArrayLength());
+        Assert.Equal("2026-09-10", afterLatestDelete.GetProperty("nextProjection").GetProperty("anchor").GetString());
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await db.PaycheckOccurrences.LoadAsync();
+            db.AccountInflows.RemoveRange(await db.AccountInflows.ToArrayAsync());
+            await db.SaveChangesAsync();
+        }
+        var empty = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        Assert.Equal("active", empty.GetProperty("lifecycle").GetString());
+        Assert.Empty(empty.GetProperty("evidence").EnumerateArray());
+        Assert.Equal("2026-09-10", empty.GetProperty("nextProjection").GetProperty("anchor").GetString());
+        Assert.Equal(profile.GetProperty("amount").GetRawText(), empty.GetProperty("amount").GetRawText());
+        using var retry = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request);
+        Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+        Assert.True((await retry.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("alreadyConfirmed").GetBoolean());
+        Assert.Equal(1, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+    }
+
+    [Fact]
+    public async Task Later_disjoint_evidence_can_surface_without_automatically_linking_to_an_ended_profile()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-disjoint@example.com");
+        var firstRows = await SeedMonthlyAsync(app, owner.Id);
+        using var confirmation = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(await CandidateAsync(owner.Client)));
+        confirmation.EnsureSuccessStatusCode();
+        var id = (await confirmation.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("paycheck").GetProperty("id").GetGuid();
+        await SetLifecycleAsync(owner.Client, id, "ended");
+        app.Clock.UtcNow = new DateTimeOffset(2026, 12, 10, 12, 0, 0, TimeSpan.Zero);
+        var laterRows = new List<AccountInflow>();
+        foreach (var month in new[] { 10, 11, 12 })
+            laterRows.Add(await app.SeedInflowAsync(owner.Id, "Synthetic deposit", 1000m, new(2026, month, 10)));
+        var later = await CandidateAsync(owner.Client);
+        Assert.Equal(laterRows.Select(r => r.Id), later.GetProperty("evidence").EnumerateArray().Select(e => e.GetProperty("accountInflowId").GetInt32()));
+        var old = await owner.Client.GetFromJsonAsync<JsonElement>($"/api/paychecks/{id}");
+        Assert.Equal(firstRows.Select(r => r.Id), old.GetProperty("evidence").EnumerateArray().Select(e => e.GetProperty("accountInflowId").GetInt32()));
+        Assert.Equal(1, await CountAsync(app, db => db.PaycheckProfiles.CountAsync()));
+    }
+
+    public static IEnumerable<object[]> ValidSchedules()
+    {
+        yield return [new WeeklyPaycheckSchedule(new(2026, 9, 4))];
+        yield return [new BiweeklyPaycheckSchedule(new(2026, 8, 28))];
+        yield return [new MonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(30))];
+        yield return [new MonthlyPaycheckSchedule(PaycheckMonthAnchor.MonthEnd)];
+        yield return [new SemimonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(15), PaycheckMonthAnchor.MonthEnd)];
+        yield return [new SemimonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(5), PaycheckMonthAnchor.DayOfMonth(20))];
+    }
+
+    public static IEnumerable<object[]> InvalidManualRequests()
+    {
+        foreach (var (path, value) in new (string, string)[]
+        {
+            ("displayName", "null"), ("displayName", "\"   \""), ("displayName", JsonSerializer.Serialize(new string('x', 501))),
+            ("schedule", "null"), ("schedule.cadence", "null"), ("schedule.cadence", "\"annual\""),
+            ("schedule.referenceAnchorDate", "\"2026-09-10\""), ("schedule.firstMonthAnchor", "null"),
+            ("schedule.firstMonthAnchor.kind", "null"), ("schedule.firstMonthAnchor.kind", "\"weekday\""),
+            ("schedule.firstMonthAnchor.day", "null"), ("schedule.firstMonthAnchor.day", "0"), ("schedule.firstMonthAnchor.day", "31"),
+            ("schedule.firstMonthAnchor", "{\"kind\":\"month_end\",\"day\":30}"),
+            ("schedule.secondMonthAnchor", "{\"kind\":\"month_end\",\"day\":null}"),
+            ("windowBeforeDays", "-1"), ("windowBeforeDays", "4"), ("windowBeforeDays", "null"),
+            ("windowAfterDays", "-1"), ("windowAfterDays", "4"), ("windowAfterDays", "null"),
+            ("amount", "null"), ("amount.mode", "null"), ("amount.mode", "\"variable\""),
+            ("amount.fixedAmount", "null"), ("amount.fixedAmount", "0"), ("amount.fixedAmount", "-1"),
+            ("amount.fixedAmount", "1.001"), ("amount.fixedAmount", "10000000000000000"),
+            ("amount.minimumAmount", "1"), ("amount.maximumAmount", "2000"),
+            ("amount", "{\"mode\":\"range\",\"fixedAmount\":1,\"minimumAmount\":1,\"maximumAmount\":2}"),
+            ("amount", "{\"mode\":\"range\",\"minimumAmount\":1}"),
+            ("amount", "{\"mode\":\"range\",\"maximumAmount\":2}"),
+            ("amount", "{\"mode\":\"range\",\"minimumAmount\":2,\"maximumAmount\":2}"),
+            ("amount", "{\"mode\":\"range\",\"minimumAmount\":3,\"maximumAmount\":2}"),
+            ("amount", "{\"mode\":\"range\",\"minimumAmount\":0,\"maximumAmount\":2}"),
+            ("amount", "{\"mode\":\"range\",\"minimumAmount\":1.001,\"maximumAmount\":2}"),
+            ("amount", "{\"mode\":\"range\",\"minimumAmount\":1,\"maximumAmount\":2.001}")
+        }) yield return [path, value];
+        foreach (var cadence in new[] { "weekly", "biweekly" })
+        {
+            yield return ["schedule", JsonSerializer.Serialize(new { cadence, referenceAnchorDate = (string?)null, firstMonthAnchor = (object?)null, secondMonthAnchor = (object?)null })];
+            yield return ["schedule", JsonSerializer.Serialize(new { cadence, referenceAnchorDate = "2026-09-10", firstMonthAnchor = new { kind = "day_of_month", day = 10 }, secondMonthAnchor = (object?)null })];
+            yield return ["schedule", JsonSerializer.Serialize(new { cadence, referenceAnchorDate = "2026-09-10", firstMonthAnchor = (object?)null, secondMonthAnchor = new { kind = "month_end", day = (int?)null } })];
+        }
+        foreach (var (first, second) in new[] { (15, 15), (20, 10), (25, 31), (1, 30), (1, 7), (0, 15), (15, 32) })
+            yield return ["schedule", JsonSerializer.Serialize(new { cadence = "semimonthly", referenceAnchorDate = (string?)null, firstMonthAnchor = Anchor(first), secondMonthAnchor = Anchor(second) })];
+        yield return ["schedule", "{\"cadence\":\"semimonthly\",\"firstMonthAnchor\":{\"kind\":\"day_of_month\",\"day\":15}}"];
+        yield return ["schedule", "{\"cadence\":\"semimonthly\",\"secondMonthAnchor\":{\"kind\":\"month_end\",\"day\":null}}"];
+        yield return ["schedule", "{\"cadence\":\"semimonthly\",\"referenceAnchorDate\":\"2026-09-10\",\"firstMonthAnchor\":{\"kind\":\"day_of_month\",\"day\":15},\"secondMonthAnchor\":{\"kind\":\"month_end\",\"day\":null}}"];
+    }
+
+    private static object Anchor(int day) => new { kind = day == 31 ? "month_end" : "day_of_month", day = day == 31 ? (int?)null : day };
+
+    private static object Schedule(PaycheckSchedule schedule) => new
+    {
+        cadence = schedule.Cadence.ToString().ToLowerInvariant(),
+        referenceAnchorDate = schedule switch { WeeklyPaycheckSchedule w => w.ReferenceAnchor.ToString("yyyy-MM-dd"), BiweeklyPaycheckSchedule b => b.ReferenceAnchor.ToString("yyyy-MM-dd"), _ => null },
+        firstMonthAnchor = schedule switch { MonthlyPaycheckSchedule m => MonthAnchor(m.Anchor), SemimonthlyPaycheckSchedule s => MonthAnchor(s.First), _ => null },
+        secondMonthAnchor = schedule is SemimonthlyPaycheckSchedule semi ? MonthAnchor(semi.Second) : null
+    };
+
+    private static object MonthAnchor(PaycheckMonthAnchor anchor) => new { kind = anchor.Kind == PaycheckMonthAnchorKind.MonthEnd ? "month_end" : "day_of_month", day = anchor.Day };
+    private static object FixedAmount(decimal value = 1000m) => new { mode = "fixed", fixedAmount = (decimal?)value, minimumAmount = (decimal?)null, maximumAmount = (decimal?)null };
+    private static object RangeAmount(decimal minimum, decimal maximum) => new { mode = "range", fixedAmount = (decimal?)null, minimumAmount = (decimal?)minimum, maximumAmount = (decimal?)maximum };
+
+    private static JsonObject Manual(string name = "  Synthetic employer  ", PaycheckSchedule? schedule = null, object? amount = null) => JsonSerializer.SerializeToNode(new
+    {
+        displayName = name,
+        schedule = Schedule(schedule ?? new MonthlyPaycheckSchedule(PaycheckMonthAnchor.DayOfMonth(10))),
+        windowBeforeDays = 3, windowAfterDays = 2, amount = amount ?? FixedAmount()
+    })!.AsObject();
+
+    private static JsonObject Update() => JsonSerializer.SerializeToNode(new { displayName = "  Updated employer  ", windowBeforeDays = 1, windowAfterDays = 0, amount = RangeAmount(800m, 1600m) })!.AsObject();
+
+    private static JsonObject Confirmation(JsonElement candidate, object? amount = null)
+    {
+        var request = Manual(amount: amount);
+        request["algorithmVersion"] = candidate.GetProperty("algorithmVersion").GetString();
+        request["fingerprint"] = candidate.GetProperty("fingerprint").GetString();
+        request["schedule"] = JsonNode.Parse(candidate.GetProperty("schedule").GetRawText());
+        return request;
+    }
+
+    private static object Decision(JsonElement candidate) => new { algorithmVersion = candidate.GetProperty("algorithmVersion").GetString(), cadence = candidate.GetProperty("schedule").GetProperty("cadence").GetString(), fingerprint = candidate.GetProperty("fingerprint").GetString() };
+    private static async Task<JsonElement> CandidatesAsync(HttpClient client) => await client.GetFromJsonAsync<JsonElement>("/api/paycheck-candidates");
+    private static async Task<JsonElement> CandidateAsync(HttpClient client) => Assert.Single((await CandidatesAsync(client)).GetProperty("candidates").EnumerateArray());
+
+    private static async Task<List<AccountInflow>> SeedMonthlyAsync(FinancialApiTestApplicationBase app, string ownerId, string description = "Synthetic deposit", bool variable = false)
+    {
+        var rows = new List<AccountInflow>();
+        foreach (var month in new[] { 7, 8, 9 })
+            rows.Add(await app.SeedInflowAsync(ownerId, description, variable ? 1000m + (month - 7) * 100m : 1000m, new(2026, month, 10)));
+        return rows;
+    }
+
+    private static async Task EditInflowAsync(HttpClient client, AccountInflow row, decimal amount, string? description = null)
+    {
+        using var response = await client.PutAsJsonAsync($"/api/inflows/{row.Id}", new { id = row.Id, description = description ?? row.Description, amount, date = row.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) });
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private static async Task<JsonElement> CreateManualAsync(HttpClient client, string name)
+    {
+        using var response = await client.PostAsJsonAsync("/api/paychecks", Manual(name));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await response.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<JsonElement> SetLifecycleAsync(HttpClient client, Guid id, string lifecycle)
+    {
+        using var response = await client.PatchAsJsonAsync($"/api/paychecks/{id}/lifecycle", new { lifecycle });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return await response.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task AssertErrorAsync(HttpResponseMessage response, HttpStatusCode status, string? code = null)
+    {
+        using (response)
+        {
+            Assert.Equal(status, response.StatusCode);
+            var problem = await response.Content.ReadFromJsonAsync<JsonElement>();
+            var actualCode = problem.GetProperty("code").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(actualCode));
+            if (code is not null) Assert.Equal(code, actualCode);
+            Assert.DoesNotContain("FOREIGN", problem.GetRawText());
+        }
+    }
+
+    private static void AssertKeys(JsonElement value, params string[] expected) => Assert.Equal(expected.Order(StringComparer.Ordinal), value.EnumerateObject().Select(p => p.Name).Order(StringComparer.Ordinal));
+
+    private static void SetPath(JsonObject target, string path, JsonNode? value)
+    {
+        var parts = path.Split('.');
+        JsonNode node = target;
+        foreach (var part in parts[..^1]) node = node[part]!;
+        node[parts[^1]] = value;
+    }
+
+    private static async Task<int> CountAsync(FinancialApiTestApplicationBase app, Func<BudgetContext, Task<int>> query)
+    {
+        using var scope = app.Services.CreateScope();
+        return await query(scope.ServiceProvider.GetRequiredService<BudgetContext>());
+    }
+
+    private static async Task SeedImportedAsync(FinancialApiTestApplicationBase app, string provenanceOwnerId, AccountInflow inflow)
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var now = new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc);
+        db.ImportPreviewBatches.Add(new ImportPreviewBatch
+        {
+            Id = Guid.NewGuid(), OwnerId = provenanceOwnerId, SourceType = "sunflower_pdf", ParserRuleVersion = "paycheck-tests-v1",
+            DocumentDigest = Guid.NewGuid().ToByteArray().Concat(Guid.NewGuid().ToByteArray()).ToArray(),
+            CreatedAt = now.AddHours(-1), ExpiresAt = now.AddHours(1), ConfirmedAt = now, Lifecycle = ImportPreviewLifecycle.Confirmed,
+            InflowProvenance = [new ImportInflowProvenance { OwnerId = provenanceOwnerId, AccountInflowId = inflow.Id, AccountInflowOwnerId = inflow.OwnerId, SourceRowOrdinal = 1 }]
+        });
+        await db.SaveChangesAsync();
+    }
+}
+
+internal sealed class PaycheckTestApplication : FinancialApiTestApplication
+{
+    public PaycheckTestClock Clock { get; } = new();
+
+    protected override void ConfigureAdditionalServices(IServiceCollection services)
+    {
+        services.RemoveAll<TimeProvider>();
+        services.AddSingleton<TimeProvider>(Clock);
+    }
+}
+
+internal sealed class PaycheckTestClock : TimeProvider
+{
+    public DateTimeOffset UtcNow { get; set; } = new(2026, 9, 10, 23, 59, 0, TimeSpan.Zero);
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+}

--- a/backend.Tests/Financial/PostgreSqlPaycheckTests.cs
+++ b/backend.Tests/Financial/PostgreSqlPaycheckTests.cs
@@ -1,0 +1,599 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Contracts.Paychecks;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using BudgetPlanner.Paychecks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Npgsql;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+[Trait("Category", "PostgreSQL")]
+public sealed class PostgreSqlPaycheckTests
+{
+    [PostgreSqlFact]
+    public async Task Migration_is_additive_and_preserves_dates_precision_timestamps_and_unassigned_inflows()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-migration@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id);
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var migrator = context.GetService<IMigrator>();
+        await migrator.MigrateAsync("20260903004657_AddAccountInflowFoundation");
+        await context.Database.MigrateAsync();
+
+        Assert.Equal(app.GetDefinedMigrations(), await app.GetAppliedMigrationsAsync());
+        Assert.True(await context.Users.AnyAsync(value => value.Id == owner.Id));
+        Assert.Equal(inflow.PaycheckEvidenceRevision,
+            (await context.AccountInflows.AsNoTracking().SingleAsync()).PaycheckEvidenceRevision);
+        Assert.Empty(await context.PaycheckProfiles.ToListAsync());
+        Assert.Empty(await context.PaycheckOccurrences.ToListAsync());
+        Assert.Empty(await context.PaycheckCandidateDismissals.ToListAsync());
+
+        var types = await context.Database.SqlQueryRaw<string>("""
+            SELECT column_name || ':' || data_type || ':' || COALESCE(numeric_precision::text, '')
+                || ':' || COALESCE(numeric_scale::text, '') AS "Value"
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'PaycheckProfiles'
+            """).ToListAsync();
+        Assert.Contains("ExpectedAmount:numeric:18:2", types);
+        Assert.Contains("ExpectedMinimumAmount:numeric:18:2", types);
+        Assert.Contains("ExpectedMaximumAmount:numeric:18:2", types);
+        Assert.Contains("ReferenceAnchorDate:date::", types);
+        Assert.Contains("FirstMonthAnchor:smallint:16:0", types);
+        Assert.Contains("SecondMonthAnchor:smallint:16:0", types);
+        Assert.Contains("WindowBeforeDays:smallint:16:0", types);
+        Assert.Contains("WindowAfterDays:smallint:16:0", types);
+        Assert.Contains("CreatedAt:timestamp with time zone::", types);
+        Assert.Contains("UpdatedAt:timestamp with time zone::", types);
+        Assert.Contains("OriginEvidenceFingerprint:bytea::", types);
+
+        var profile = NewProfile(owner.Id);
+        profile.Cadence = PaycheckCadence.Biweekly;
+        profile.FirstMonthAnchor = null;
+        profile.ReferenceAnchorDate = new DateOnly(2026, 2, 28);
+        profile.ExpectedAmount = 1234.56m;
+        context.PaycheckProfiles.Add(profile);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        var persisted = await context.PaycheckProfiles.SingleAsync();
+        Assert.Equal(profile.ReferenceAnchorDate, persisted.ReferenceAnchorDate);
+        Assert.Equal(1234.56m, persisted.ExpectedAmount);
+        Assert.Equal(DateTimeKind.Utc, persisted.CreatedAt.Kind);
+        Assert.Equal(profile.CreatedAt, persisted.CreatedAt);
+    }
+
+    [PostgreSqlFact]
+    public async Task Profile_checks_reject_invalid_and_partial_nullable_shapes()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-checks@example.com");
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+
+        var invalid = new (string Check, Action<PaycheckProfile> Mutate)[]
+        {
+            ("Text", p => p.DisplayName = "  "),
+            ("Enums", p => p.Lifecycle = (PaycheckLifecycle)99),
+            ("Enums", p => p.Cadence = (PaycheckCadence)99),
+            ("Amount", p => p.AmountMode = (PaycheckAmountMode)99),
+            ("Schedule", p => p.FirstMonthAnchor = null),
+            ("Schedule", p => p.FirstMonthAnchor = 0),
+            ("Schedule", p => p.FirstMonthAnchor = 32),
+            ("Schedule", p => p.SecondMonthAnchor = 20),
+            ("Schedule", p => p.ReferenceAnchorDate = new DateOnly(2026, 1, 1)),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Weekly; p.FirstMonthAnchor = null; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Biweekly; p.FirstMonthAnchor = null; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Weekly; p.ReferenceAnchorDate = new DateOnly(2026, 1, 1); }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.FirstMonthAnchor = null; p.SecondMonthAnchor = 15; }),
+            ("Schedule", p => p.Cadence = PaycheckCadence.Semimonthly),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.SecondMonthAnchor = 10; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.SecondMonthAnchor = 16; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.FirstMonthAnchor = 1; p.SecondMonthAnchor = 31; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.FirstMonthAnchor = 31; p.SecondMonthAnchor = 15; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.FirstMonthAnchor = 0; p.SecondMonthAnchor = 15; }),
+            ("Schedule", p => { p.Cadence = PaycheckCadence.Semimonthly; p.SecondMonthAnchor = 32; }),
+            ("Windows", p => p.WindowBeforeDays = -1),
+            ("Windows", p => p.WindowBeforeDays = 4),
+            ("Windows", p => p.WindowAfterDays = -1),
+            ("Windows", p => p.WindowAfterDays = 4),
+            ("Amount", p => p.ExpectedAmount = null),
+            ("Amount", p => p.ExpectedAmount = 0),
+            ("Amount", p => p.ExpectedAmount = -1),
+            ("Amount", p => p.ExpectedMinimumAmount = 1),
+            ("Amount", p => p.ExpectedMaximumAmount = 2000),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedAmount = null; }),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedAmount = null; p.ExpectedMinimumAmount = 1; }),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedAmount = null; p.ExpectedMaximumAmount = 2; }),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedMinimumAmount = 1; p.ExpectedMaximumAmount = 2; }),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedAmount = null; p.ExpectedMinimumAmount = 0; p.ExpectedMaximumAmount = 2; }),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedAmount = null; p.ExpectedMinimumAmount = 2; p.ExpectedMaximumAmount = 2; }),
+            ("Amount", p => { p.AmountMode = PaycheckAmountMode.Range; p.ExpectedAmount = null; p.ExpectedMinimumAmount = 3; p.ExpectedMaximumAmount = 2; }),
+            ("Origin", p => p.OriginAlgorithmVersion = PaycheckCandidateDetector.AlgorithmVersion),
+            ("Origin", p => p.OriginEvidenceFingerprint = new byte[32]),
+            ("Origin", p => { p.OriginAlgorithmVersion = " "; p.OriginEvidenceFingerprint = new byte[32]; }),
+            ("Origin", p => { p.OriginAlgorithmVersion = "v1"; p.OriginEvidenceFingerprint = new byte[31]; }),
+            ("Origin", p => { p.OriginAlgorithmVersion = "v1"; p.OriginEvidenceFingerprint = new byte[33]; }),
+            ("Timestamps", p => p.UpdatedAt = p.CreatedAt.AddSeconds(-1))
+        };
+        foreach (var (check, mutate) in invalid)
+        {
+            var profile = NewProfile(owner.Id);
+            mutate(profile);
+            context.PaycheckProfiles.Add(profile);
+            var error = await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync());
+            var postgres = Assert.IsType<PostgresException>(error.InnerException);
+            Assert.Equal(PostgresErrorCodes.CheckViolation, postgres.SqlState);
+            Assert.Equal("CK_PaycheckProfile_" + check, postgres.ConstraintName);
+            context.ChangeTracker.Clear();
+        }
+
+        foreach (var cadence in Enum.GetValues<PaycheckCadence>())
+        {
+            var profile = NewProfile(owner.Id);
+            profile.Cadence = cadence;
+            if (cadence is PaycheckCadence.Weekly or PaycheckCadence.Biweekly)
+            {
+                profile.FirstMonthAnchor = null;
+                profile.ReferenceAnchorDate = new DateOnly(2026, 1, 1);
+            }
+            if (cadence == PaycheckCadence.Semimonthly)
+            {
+                profile.FirstMonthAnchor = 15;
+                profile.SecondMonthAnchor = 31;
+                profile.AmountMode = PaycheckAmountMode.Range;
+                profile.ExpectedAmount = null;
+                profile.ExpectedMinimumAmount = 900;
+                profile.ExpectedMaximumAmount = 1100;
+            }
+            context.PaycheckProfiles.Add(profile);
+        }
+        await context.SaveChangesAsync();
+        Assert.Equal(4, await context.PaycheckProfiles.CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Origin_and_dismissal_uniqueness_are_partitioned_by_owner_and_exact_tuple()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-origin@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-origin-other@example.com");
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+
+        foreach (var (ownerId, version) in new[] { (owner.Id, "v1"), (owner.Id, "v2"), (other.Id, "v1") })
+        {
+            var profile = NewProfile(ownerId);
+            profile.OriginAlgorithmVersion = version;
+            profile.OriginEvidenceFingerprint = new byte[32];
+            context.PaycheckProfiles.Add(profile);
+        }
+        await context.SaveChangesAsync();
+        var duplicate = NewProfile(owner.Id);
+        duplicate.OriginAlgorithmVersion = "v1";
+        duplicate.OriginEvidenceFingerprint = new byte[32];
+        context.PaycheckProfiles.Add(duplicate);
+        var error = await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync());
+        Assert.Equal("UX_PaycheckProfiles_Owner_Origin", Assert.IsType<PostgresException>(error.InnerException).ConstraintName);
+        context.ChangeTracker.Clear();
+
+        Task InsertDismissal(string ownerId, string version, string cadence, byte[] fingerprint) =>
+            context.Database.ExecuteSqlInterpolatedAsync($"""
+                INSERT INTO "PaycheckCandidateDismissals"
+                    ("Id", "OwnerId", "AlgorithmVersion", "Cadence", "EvidenceFingerprint", "DismissedAt")
+                VALUES ({Guid.NewGuid()}, {ownerId}, {version}, {cadence}, {fingerprint}, {DateTime.UtcNow})
+                """);
+
+        await InsertDismissal(owner.Id, "v1", "Monthly", new byte[32]);
+        await InsertDismissal(owner.Id, "v2", "Monthly", new byte[32]);
+        await InsertDismissal(owner.Id, "v1", "Weekly", new byte[32]);
+        await InsertDismissal(other.Id, "v1", "Monthly", new byte[32]);
+        var duplicateDismissal = await Assert.ThrowsAsync<PostgresException>(() =>
+            InsertDismissal(owner.Id, "v1", "Monthly", new byte[32]));
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, duplicateDismissal.SqlState);
+        Assert.Equal("UX_PaycheckCandidateDismissals_Owner_Origin", duplicateDismissal.ConstraintName);
+        foreach (var (version, cadence, fingerprint, check) in new[]
+        {
+            (" ", "Monthly", new byte[32], "AlgorithmVersion"),
+            ("v1", "Unknown", new byte[32], "Cadence"),
+            ("v1", "Monthly", new byte[31], "FingerprintLength"),
+            ("v1", "Monthly", new byte[33], "FingerprintLength")
+        })
+        {
+            var invalid = await Assert.ThrowsAsync<PostgresException>(() =>
+                InsertDismissal(owner.Id, version, cadence, fingerprint));
+            Assert.Equal(PostgresErrorCodes.CheckViolation, invalid.SqlState);
+            Assert.Equal("CK_PaycheckCandidateDismissal_" + check, invalid.ConstraintName);
+        }
+        await context.Users.Where(value => value.Id == other.Id).ExecuteDeleteAsync();
+        Assert.False(await context.PaycheckProfiles.AnyAsync(value => value.OwnerId == other.Id));
+        Assert.False(await context.PaycheckCandidateDismissals.AnyAsync(value => value.OwnerId == other.Id));
+        Assert.Equal(2, await context.PaycheckProfiles.CountAsync());
+        Assert.Equal(3, await context.PaycheckCandidateDismissals.CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Occurrences_enforce_owner_consistency_exclusivity_checks_and_edit_delete_cascades()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-links@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("paycheck-links-other@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 9, 10));
+        var secondInflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 9, 10));
+        var otherInflow = await app.SeedInflowAsync(other.Id, date: new DateOnly(2026, 9, 10));
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var profile = NewProfile(owner.Id);
+        var secondProfile = NewProfile(owner.Id);
+        var foreignProfile = NewProfile(other.Id);
+        context.PaycheckProfiles.AddRange(profile, secondProfile, foreignProfile);
+        await context.SaveChangesAsync();
+
+        Task Insert(Guid profileId, int inflowId, string ownerId, string kind, Guid revision, short offset) =>
+            context.Database.ExecuteSqlInterpolatedAsync($"""
+                INSERT INTO "PaycheckOccurrences"
+                    ("PaycheckProfileId", "AccountInflowId", "OwnerId", "Kind", "EvidenceRevisionAtAssignment", "SlotAnchor", "TimingOffsetDays", "LinkedAt")
+                VALUES ({profileId}, {inflowId}, {ownerId}, {kind}, {revision}, {inflow.Date}, {offset}, {DateTime.UtcNow})
+                """);
+
+        foreach (var (profileId, inflowId, check) in new[]
+        {
+            (foreignProfile.Id, inflow.Id, "FK_PaycheckOccurrence_Profile_Owner"),
+            (profile.Id, otherInflow.Id, "FK_PaycheckOccurrence_AccountInflow_Owner")
+        })
+        {
+            var error = await Assert.ThrowsAsync<PostgresException>(() =>
+                Insert(profileId, inflowId, owner.Id, "ConfirmationEvidence", inflow.PaycheckEvidenceRevision, 0));
+            Assert.Equal(PostgresErrorCodes.ForeignKeyViolation, error.SqlState);
+            Assert.Equal(check, error.ConstraintName);
+        }
+        foreach (var (kind, revision, offset, check) in new[]
+        {
+            ("Unknown", Guid.NewGuid(), (short)0, "Kind"),
+            ("ConfirmationEvidence", Guid.Empty, (short)0, "EvidenceRevision"),
+            ("ConfirmationEvidence", Guid.NewGuid(), (short)-4, "TimingOffset"),
+            ("ConfirmationEvidence", Guid.NewGuid(), (short)4, "TimingOffset")
+        })
+        {
+            var error = await Assert.ThrowsAsync<PostgresException>(() =>
+                Insert(profile.Id, inflow.Id, owner.Id, kind, revision, offset));
+            Assert.Equal(PostgresErrorCodes.CheckViolation, error.SqlState);
+            Assert.Equal("CK_PaycheckOccurrence_" + check, error.ConstraintName);
+        }
+
+        await Insert(profile.Id, inflow.Id, owner.Id, "ConfirmationEvidence", inflow.PaycheckEvidenceRevision, 0);
+        var duplicate = await Assert.ThrowsAsync<PostgresException>(() =>
+            Insert(secondProfile.Id, inflow.Id, owner.Id, "ConfirmationEvidence", inflow.PaycheckEvidenceRevision, 0));
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, duplicate.SqlState);
+        Assert.Equal("IX_PaycheckOccurrences_AccountInflowId", duplicate.ConstraintName);
+        var edited = await context.AccountInflows.SingleAsync(value => value.Id == inflow.Id);
+        edited.UpdateEvidence("edited synthetic deposit", 543.21m, inflow.Date.AddDays(1));
+        await context.SaveChangesAsync();
+        var occurrence = await context.PaycheckOccurrences.AsNoTracking().SingleAsync();
+        Assert.Equal(inflow.PaycheckEvidenceRevision, occurrence.EvidenceRevisionAtAssignment);
+        Assert.NotEqual(edited.PaycheckEvidenceRevision, occurrence.EvidenceRevisionAtAssignment);
+        Assert.Equal(inflow.Date, occurrence.SlotAnchor);
+        Assert.Equal(DateTimeKind.Utc, occurrence.LinkedAt.Kind);
+
+        await context.AccountInflows.Where(value => value.Id == inflow.Id).ExecuteDeleteAsync();
+        Assert.Empty(await context.PaycheckOccurrences.ToListAsync());
+        Assert.True(await context.PaycheckProfiles.AnyAsync(value => value.Id == profile.Id));
+        await Insert(secondProfile.Id, secondInflow.Id, owner.Id, "ConfirmationEvidence", secondInflow.PaycheckEvidenceRevision, 0);
+        await context.PaycheckProfiles.Where(value => value.Id == secondProfile.Id).ExecuteDeleteAsync();
+        Assert.Empty(await context.PaycheckOccurrences.ToListAsync());
+        Assert.True(await context.AccountInflows.AnyAsync(value => value.Id == secondInflow.Id));
+        await Insert(profile.Id, secondInflow.Id, owner.Id, "ConfirmationEvidence", secondInflow.PaycheckEvidenceRevision, 0);
+        await context.Users.Where(value => value.Id == owner.Id).ExecuteDeleteAsync();
+        Assert.Empty(await context.PaycheckOccurrences.ToListAsync());
+        Assert.False(await context.PaycheckProfiles.AnyAsync(value => value.OwnerId == owner.Id));
+        Assert.True(await context.PaycheckProfiles.AnyAsync(value => value.Id == foreignProfile.Id));
+    }
+
+    [PostgreSqlFact]
+    public async Task Same_candidate_confirmation_and_dismissal_races_are_idempotent()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-confirm-race@example.com");
+        var inflows = await SeedCandidateAsync(app, owner.Id);
+        var candidate = await ReadCandidateAsync(owner.Client);
+        var decision = new PaycheckCandidateDecisionRequest(
+            candidate.AlgorithmVersion, candidate.Schedule.Cadence, candidate.Fingerprint);
+        var dismissals = await Task.WhenAll(
+            owner.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision),
+            owner.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision));
+        Assert.All(dismissals, response => Assert.Equal(HttpStatusCode.NoContent, response.StatusCode));
+        using (var dismissedScope = app.Services.CreateScope())
+            Assert.Equal(1, await dismissedScope.ServiceProvider.GetRequiredService<BudgetContext>()
+                .PaycheckCandidateDismissals.CountAsync());
+        using var reconsider = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/reconsider", decision);
+        Assert.Equal(HttpStatusCode.NoContent, reconsider.StatusCode);
+        var request = Confirmation(candidate);
+        var responses = await Task.WhenAll(
+            owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request),
+            owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", request));
+        Assert.All(responses, response => Assert.Contains(response.StatusCode,
+            new[] { HttpStatusCode.Created, HttpStatusCode.OK }));
+        var bodies = await Task.WhenAll(responses.Select(response =>
+            response.Content.ReadFromJsonAsync<ConfirmPaycheckResponse>()));
+        Assert.Single(bodies, body => !body!.AlreadyConfirmed);
+        Assert.Single(bodies, body => body!.AlreadyConfirmed);
+        Assert.Single(bodies.Select(body => body!.Paycheck.Id).Distinct());
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(1, await context.PaycheckProfiles.CountAsync());
+        var occurrences = await context.PaycheckOccurrences.AsNoTracking().OrderBy(value => value.AccountInflowId).ToListAsync();
+        Assert.Equal(inflows.Select(value => value.Id), occurrences.Select(value => value.AccountInflowId));
+        foreach (var row in occurrences)
+        {
+            var source = inflows.Single(value => value.Id == row.AccountInflowId);
+            var snapshot = candidate.Evidence.Single(value => value.AccountInflowId == row.AccountInflowId);
+            Assert.Equal(source.PaycheckEvidenceRevision, row.EvidenceRevisionAtAssignment);
+            Assert.Equal(snapshot.SlotAnchor, row.SlotAnchor);
+            Assert.Equal(snapshot.TimingOffsetDays, row.TimingOffsetDays);
+        }
+        Assert.Empty(await context.PaycheckCandidateDismissals.ToListAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Overlapping_old_and_current_fingerprints_cannot_both_confirm()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-overlap@example.com");
+        var inflows = await SeedCandidateAsync(app, owner.Id);
+        var oldCandidate = await ReadCandidateAsync(owner.Client);
+        using (var editScope = app.Services.CreateScope())
+        {
+            var editContext = editScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var edited = await editContext.AccountInflows.SingleAsync(value => value.Id == inflows[0].Id);
+            edited.UpdateEvidence(edited.Description, 1001m, edited.Date);
+            await editContext.SaveChangesAsync();
+        }
+        var currentCandidate = await ReadCandidateAsync(owner.Client);
+        Assert.NotEqual(oldCandidate.Fingerprint, currentCandidate.Fingerprint);
+        Assert.Equal(oldCandidate.Evidence.Select(value => value.AccountInflowId),
+            currentCandidate.Evidence.Select(value => value.AccountInflowId));
+        var responses = await Task.WhenAll(
+            owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(oldCandidate)),
+            owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(currentCandidate)));
+        Assert.Equal(HttpStatusCode.Conflict, responses[0].StatusCode);
+        var error = await responses[0].Content.ReadFromJsonAsync<PaycheckError>();
+        Assert.Contains(error!.Code, new[] { "candidate_changed", "confirmation_conflict" });
+        Assert.Equal(HttpStatusCode.Created, responses[1].StatusCode);
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(1, await context.PaycheckProfiles.CountAsync());
+        Assert.Equal(3, await context.PaycheckOccurrences.CountAsync());
+        var profile = await context.PaycheckProfiles.SingleAsync();
+        Assert.Equal(Convert.FromHexString(currentCandidate.Fingerprint), profile.OriginEvidenceFingerprint);
+    }
+
+    [PostgreSqlFact]
+    public async Task Separate_serializable_confirmations_cannot_assign_one_inflow_to_two_profiles()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-exclusive-race@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 9, 10));
+        var bothReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var readyCount = 0;
+        async Task<bool> AssignAsync(byte discriminator)
+        {
+            using var scope = app.Services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await using var transaction = await context.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable);
+            Assert.False(await context.PaycheckOccurrences.AnyAsync(value => value.AccountInflowId == inflow.Id));
+            if (Interlocked.Increment(ref readyCount) == 2) bothReady.SetResult();
+            await bothReady.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            var profile = NewProfile(owner.Id);
+            profile.OriginAlgorithmVersion = "synthetic-test-v1";
+            profile.OriginEvidenceFingerprint = new byte[32];
+            profile.OriginEvidenceFingerprint[0] = discriminator;
+            profile.Occurrences.Add(new PaycheckOccurrence
+            {
+                AccountInflowId = inflow.Id,
+                OwnerId = owner.Id,
+                EvidenceRevisionAtAssignment = inflow.PaycheckEvidenceRevision,
+                SlotAnchor = inflow.Date,
+                LinkedAt = DateTime.UtcNow
+            });
+            context.PaycheckProfiles.Add(profile);
+            try
+            {
+                await context.SaveChangesAsync();
+                await transaction.CommitAsync();
+                return true;
+            }
+            catch (Exception exception) when (exception is PostgresException or DbUpdateException)
+            {
+                var postgres = exception as PostgresException ?? exception.InnerException as PostgresException;
+                Assert.NotNull(postgres);
+                Assert.Contains(postgres.SqlState, new[] { PostgresErrorCodes.UniqueViolation, PostgresErrorCodes.SerializationFailure });
+                await transaction.RollbackAsync();
+                return false;
+            }
+        }
+        var results = await Task.WhenAll(AssignAsync(1), AssignAsync(2));
+        Assert.Single(results, value => value);
+        Assert.Single(results, value => !value);
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(1, await context.PaycheckProfiles.CountAsync());
+        Assert.Equal(1, await context.PaycheckOccurrences.CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Occurrence_insert_failure_rolls_back_profile_and_all_assignments()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-rollback@example.com");
+        var inflows = await SeedCandidateAsync(app, owner.Id);
+        var candidate = await ReadCandidateAsync(owner.Client);
+        using (var setupScope = app.Services.CreateScope())
+        {
+            var setupContext = setupScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            await setupContext.Database.ExecuteSqlRawAsync("""
+                CREATE FUNCTION reject_later_paycheck_occurrence() RETURNS trigger
+                LANGUAGE plpgsql AS $function$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM "PaycheckOccurrences" WHERE "PaycheckProfileId" = NEW."PaycheckProfileId") THEN
+                        RAISE EXCEPTION 'intentional disposable-test paycheck occurrence rejection';
+                    END IF;
+                    RETURN NEW;
+                END;
+                $function$;
+                CREATE TRIGGER reject_later_paycheck_occurrence_insert
+                BEFORE INSERT ON "PaycheckOccurrences"
+                FOR EACH ROW EXECUTE FUNCTION reject_later_paycheck_occurrence();
+                """);
+        }
+        using var response = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(candidate));
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        var responseText = await response.Content.ReadAsStringAsync();
+        var error = JsonSerializer.Deserialize<JsonElement>(responseText);
+        Assert.Equal("confirmation_failed", error.GetProperty("code").GetString());
+        Assert.Equal(500, error.GetProperty("status").GetInt32());
+        Assert.DoesNotContain("PaycheckOccurrences", responseText);
+        Assert.DoesNotContain("reject_later_paycheck_occurrence", responseText);
+        Assert.DoesNotContain("intentional disposable-test", responseText);
+        Assert.DoesNotContain("P0001", responseText);
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Empty(await context.PaycheckProfiles.ToListAsync());
+        Assert.Empty(await context.PaycheckOccurrences.ToListAsync());
+        Assert.Empty(await context.PaycheckCandidateDismissals.ToListAsync());
+        Assert.Equal(inflows.Select(value => value.PaycheckEvidenceRevision),
+            await context.AccountInflows.OrderBy(value => value.Id).Select(value => value.PaycheckEvidenceRevision).ToListAsync());
+        Assert.Equal(candidate.Fingerprint, (await ReadCandidateAsync(owner.Client)).Fingerprint);
+    }
+
+    [PostgreSqlFact]
+    public async Task Http_inflow_edit_retains_assignment_and_delete_recomputes_projection_without_loaded_dependents()
+    {
+        await using var app = new FixedDatePostgreSqlPaycheckApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-http-evidence@example.com");
+        var inflows = new List<AccountInflow>();
+        for (var month = 7; month <= 9; month++)
+            inflows.Add(await app.SeedInflowAsync(owner.Id, "synthetic payroll", 1000m, new DateOnly(2026, month, 10)));
+        var candidate = await ReadCandidateAsync(owner.Client);
+        using var confirmation = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", Confirmation(candidate));
+        Assert.Equal(HttpStatusCode.Created, confirmation.StatusCode);
+        var confirmed = (await confirmation.Content.ReadFromJsonAsync<ConfirmPaycheckResponse>())!.Paycheck;
+        Assert.Equal(new DateOnly(2026, 10, 10), confirmed.NextProjection!.Anchor);
+        var latest = inflows[^1];
+
+        using var update = await owner.Client.PutAsJsonAsync($"/api/inflows/{latest.Id}", new
+        {
+            id = latest.Id, description = "edited synthetic payroll", amount = 1500m,
+            date = latest.Date.AddDays(1)
+        });
+        Assert.Equal(HttpStatusCode.NoContent, update.StatusCode);
+        var edited = await owner.Client.GetFromJsonAsync<PaycheckProfileDto>($"/api/paychecks/{confirmed.Id}");
+        Assert.NotNull(edited);
+        Assert.Equal(3, edited.Evidence.Count);
+        var editedEvidence = Assert.Single(edited.Evidence, value => value.AccountInflowId == latest.Id);
+        Assert.True(editedEvidence.EditedSinceConfirmation);
+        Assert.Equal("edited synthetic payroll", editedEvidence.Description);
+        Assert.Equal(1500m, editedEvidence.Amount);
+        Assert.Equal(latest.Date.AddDays(1), editedEvidence.PostedDate);
+        Assert.Equal(latest.Date, editedEvidence.SlotAnchor);
+        Assert.Equal(0, editedEvidence.TimingOffsetDays);
+        Assert.Equal(confirmed.Amount, edited.Amount);
+        Assert.Equal(confirmed.Schedule, edited.Schedule);
+        Assert.Equal(confirmed.NextProjection, edited.NextProjection);
+        using (var checkScope = app.Services.CreateScope())
+        {
+            var context = checkScope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var occurrence = await context.PaycheckOccurrences.AsNoTracking().SingleAsync(value => value.AccountInflowId == latest.Id);
+            Assert.Equal(latest.PaycheckEvidenceRevision, occurrence.EvidenceRevisionAtAssignment);
+            Assert.NotEqual(latest.PaycheckEvidenceRevision,
+                (await context.AccountInflows.AsNoTracking().SingleAsync(value => value.Id == latest.Id)).PaycheckEvidenceRevision);
+        }
+
+        // Each HTTP request creates its own context; no occurrence navigation is loaded
+        // before InflowsController deletes the principal, so PostgreSQL must cascade it.
+        using var deletion = await owner.Client.DeleteAsync($"/api/inflows/{latest.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deletion.StatusCode);
+        var remaining = await owner.Client.GetFromJsonAsync<PaycheckProfileDto>($"/api/paychecks/{confirmed.Id}");
+        Assert.NotNull(remaining);
+        Assert.Equal("active", remaining.Lifecycle);
+        Assert.Equal(confirmed.Amount, remaining.Amount);
+        Assert.Equal(inflows.Take(2).Select(value => value.Id), remaining.Evidence.Select(value => value.AccountInflowId));
+        Assert.Equal(new DateOnly(2026, 8, 10), remaining.Evidence.Max(value => value.SlotAnchor));
+        Assert.Equal(new DateOnly(2026, 9, 10), remaining.NextProjection!.Anchor);
+        Assert.Equal(new DateOnly(2026, 9, 10), remaining.NextProjection.EvaluatedOn);
+
+        foreach (var inflow in inflows.Take(2))
+        {
+            using var deleteRemaining = await owner.Client.DeleteAsync($"/api/inflows/{inflow.Id}");
+            Assert.Equal(HttpStatusCode.NoContent, deleteRemaining.StatusCode);
+        }
+        var empty = await owner.Client.GetFromJsonAsync<PaycheckProfileDto>($"/api/paychecks/{confirmed.Id}");
+        Assert.NotNull(empty);
+        Assert.Empty(empty.Evidence);
+        Assert.Equal("active", empty.Lifecycle);
+        Assert.Equal(new DateOnly(2026, 9, 10), empty.NextProjection!.Anchor);
+        using var finalScope = app.Services.CreateScope();
+        var finalContext = finalScope.ServiceProvider.GetRequiredService<BudgetContext>();
+        Assert.Equal(1, await finalContext.PaycheckProfiles.CountAsync());
+        Assert.Empty(await finalContext.PaycheckOccurrences.ToListAsync());
+        Assert.Empty(await finalContext.AccountInflows.ToListAsync());
+    }
+
+    private sealed class FixedDatePostgreSqlPaycheckApplication : PostgreSqlFinancialApiTestApplication
+    {
+        protected override void ConfigureAdditionalServices(IServiceCollection services)
+        {
+            services.RemoveAll<TimeProvider>();
+            services.AddSingleton<TimeProvider>(new FixedPaycheckDate());
+        }
+    }
+
+    private sealed class FixedPaycheckDate : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(2026, 9, 10, 23, 59, 0, TimeSpan.Zero);
+    }
+
+    private static async Task<List<AccountInflow>> SeedCandidateAsync(PostgreSqlFinancialApiTestApplication app, string ownerId)
+    {
+        var thisMonth = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        var inflows = new List<AccountInflow>();
+        for (var monthsAgo = 3; monthsAgo >= 1; monthsAgo--)
+            inflows.Add(await app.SeedInflowAsync(ownerId, "synthetic payroll", 1000m, thisMonth.AddMonths(-monthsAgo).AddDays(9)));
+        return inflows;
+    }
+
+    private static async Task<PaycheckCandidateDto> ReadCandidateAsync(HttpClient client)
+    {
+        using var response = await client.GetAsync("/api/paycheck-candidates");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<PaycheckCandidatesResponse>();
+        return Assert.Single(body!.Candidates);
+    }
+
+    private static ConfirmPaycheckRequest Confirmation(PaycheckCandidateDto candidate) => new(
+        candidate.AlgorithmVersion, candidate.Fingerprint, "Confirmed synthetic paycheck",
+        candidate.Schedule, candidate.WindowBeforeDays, candidate.WindowAfterDays,
+        new ConfirmedPaycheckAmountDto("range", null, 900m, 1100m));
+
+    private static PaycheckProfile NewProfile(string ownerId) => new()
+    {
+        Id = Guid.NewGuid(),
+        OwnerId = ownerId,
+        DisplayName = "Synthetic paycheck",
+        Lifecycle = PaycheckLifecycle.Active,
+        Cadence = PaycheckCadence.Monthly,
+        FirstMonthAnchor = 10,
+        AmountMode = PaycheckAmountMode.Fixed,
+        ExpectedAmount = 1000m,
+        CreatedAt = new DateTime(2026, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+        UpdatedAt = new DateTime(2026, 9, 1, 12, 0, 0, DateTimeKind.Utc)
+    };
+}

--- a/backend/Contracts/Paychecks/PaycheckContracts.cs
+++ b/backend/Contracts/Paychecks/PaycheckContracts.cs
@@ -1,0 +1,72 @@
+namespace BudgetPlanner.Contracts.Paychecks;
+
+public sealed record PaycheckError(string Code, string Message);
+
+public sealed record PaycheckMonthAnchorDto(string? Kind, int? Day);
+
+public sealed record PaycheckScheduleDto(
+    string? Cadence,
+    DateOnly? ReferenceAnchorDate,
+    PaycheckMonthAnchorDto? FirstMonthAnchor,
+    PaycheckMonthAnchorDto? SecondMonthAnchor);
+
+public sealed record ConfirmedPaycheckAmountDto(
+    string? Mode, decimal? FixedAmount, decimal? MinimumAmount, decimal? MaximumAmount);
+
+public sealed record ObservedPaycheckAmountDto(
+    string Mode, decimal? FixedAmount, decimal? MinimumAmount,
+    decimal? MaximumAmount, decimal LowerMedianAmount);
+
+public sealed record PaycheckCandidateDecisionRequest(
+    string? AlgorithmVersion, string? Cadence, string? Fingerprint);
+
+public sealed record CreatePaycheckRequest(
+    string? DisplayName, PaycheckScheduleDto? Schedule,
+    int? WindowBeforeDays, int? WindowAfterDays, ConfirmedPaycheckAmountDto? Amount);
+
+public sealed record ConfirmPaycheckRequest(
+    string? AlgorithmVersion, string? Fingerprint, string? DisplayName,
+    PaycheckScheduleDto? Schedule, int? WindowBeforeDays, int? WindowAfterDays,
+    ConfirmedPaycheckAmountDto? Amount);
+
+public sealed record UpdatePaycheckRequest(
+    string? DisplayName, int? WindowBeforeDays, int? WindowAfterDays,
+    ConfirmedPaycheckAmountDto? Amount);
+
+public sealed record UpdatePaycheckLifecycleRequest(string? Lifecycle);
+
+public sealed record PaycheckCandidateEvidenceDto(
+    int AccountInflowId, DateOnly PostedDate, decimal Amount, string Description,
+    string Source, DateOnly SlotAnchor, int TimingOffsetDays);
+
+public sealed record PaycheckCandidateDto(
+    string Fingerprint, string AlgorithmVersion, string NormalizedDescriptionIdentity,
+    PaycheckScheduleDto Schedule, int WindowBeforeDays, int WindowAfterDays,
+    ObservedPaycheckAmountDto ObservedAmount, DateOnly CoveredFrom, DateOnly CoveredTo,
+    int OccurrenceCount, IReadOnlyList<PaycheckCandidateEvidenceDto> Evidence);
+
+public sealed record PaycheckCandidatesResponse(
+    DateOnly EvaluatedOn, IReadOnlyList<PaycheckCandidateDto> Candidates,
+    IReadOnlyList<PaycheckCandidateDto> DismissedCandidates);
+
+public sealed record PaycheckOriginDto(string AlgorithmVersion, string Fingerprint);
+
+public sealed record PaycheckProfileEvidenceDto(
+    int AccountInflowId, DateOnly PostedDate, decimal Amount, string Description,
+    string Source, DateOnly SlotAnchor, int TimingOffsetDays, DateTime LinkedAt,
+    bool EditedSinceConfirmation);
+
+public sealed record PaycheckProjectionDto(
+    string AlgorithmVersion, DateOnly EvaluatedOn, DateOnly Anchor,
+    DateOnly EarliestExpectedDate, DateOnly LatestExpectedDate,
+    ConfirmedPaycheckAmountDto Amount);
+
+public sealed record PaycheckProfileDto(
+    Guid Id, string DisplayName, string Lifecycle, PaycheckScheduleDto Schedule,
+    int WindowBeforeDays, int WindowAfterDays, ConfirmedPaycheckAmountDto Amount,
+    string Source, PaycheckOriginDto? Origin, DateTime CreatedAt, DateTime UpdatedAt,
+    IReadOnlyList<PaycheckProfileEvidenceDto> Evidence, PaycheckProjectionDto? NextProjection);
+
+public sealed record PaychecksResponse(DateOnly EvaluatedOn, IReadOnlyList<PaycheckProfileDto> Paychecks);
+
+public sealed record ConfirmPaycheckResponse(PaycheckProfileDto Paycheck, bool AlreadyConfirmed);

--- a/backend/Controllers/PaychecksController.cs
+++ b/backend/Controllers/PaychecksController.cs
@@ -1,0 +1,134 @@
+using System.Security.Claims;
+using BudgetPlanner.Contracts.Paychecks;
+using BudgetPlanner.Paychecks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace BudgetPlanner.Controllers;
+
+[ApiController]
+[Authorize]
+[PaycheckValidation]
+[Route("api")]
+public sealed class PaychecksController(IPaycheckService paychecks) : ControllerBase
+{
+    [HttpGet("paycheck-candidates")]
+    public async Task<IActionResult> GetCandidates(CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        return ownerId is null ? Unauthorized() : Ok(await paychecks.GetCandidatesAsync(ownerId, cancellationToken));
+    }
+
+    [HttpPost("paycheck-candidates/dismiss")]
+    public async Task<IActionResult> Dismiss(PaycheckCandidateDecisionRequest request, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.DismissAsync(ownerId, request, cancellationToken);
+        return result.IsSuccess ? NoContent() : ErrorResult(result.Error!);
+    }
+
+    [HttpPost("paycheck-candidates/reconsider")]
+    public async Task<IActionResult> Reconsider(PaycheckCandidateDecisionRequest request, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.ReconsiderAsync(ownerId, request, cancellationToken);
+        return result.IsSuccess ? NoContent() : ErrorResult(result.Error!);
+    }
+
+    [HttpPost("paycheck-candidates/confirm")]
+    public async Task<IActionResult> Confirm(ConfirmPaycheckRequest request, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.ConfirmAsync(ownerId, request, cancellationToken);
+        if (!result.IsSuccess) return ErrorResult(result.Error!);
+        return result.Value!.AlreadyConfirmed ? Ok(result.Value) : StatusCode(StatusCodes.Status201Created, result.Value);
+    }
+
+    [HttpPost("paychecks")]
+    public async Task<IActionResult> Create(CreatePaycheckRequest request, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.CreateAsync(ownerId, request, cancellationToken);
+        return result.IsSuccess ? CreatedAtAction(nameof(Get), new { id = result.Value!.Id }, result.Value) : ErrorResult(result.Error!);
+    }
+
+    [HttpGet("paychecks")]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        return ownerId is null ? Unauthorized() : Ok(await paychecks.GetPaychecksAsync(ownerId, cancellationToken));
+    }
+
+    [HttpGet("paychecks/{id:guid}")]
+    public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.GetAsync(ownerId, id, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : ErrorResult(result.Error!);
+    }
+
+    [HttpPut("paychecks/{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, UpdatePaycheckRequest request, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.UpdateAsync(ownerId, id, request, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : ErrorResult(result.Error!);
+    }
+
+    [HttpPatch("paychecks/{id:guid}/lifecycle")]
+    public async Task<IActionResult> UpdateLifecycle(Guid id, UpdatePaycheckLifecycleRequest request, CancellationToken cancellationToken)
+    {
+        var ownerId = OwnerId();
+        if (ownerId is null) return Unauthorized();
+        var result = await paychecks.UpdateLifecycleAsync(ownerId, id, request, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : ErrorResult(result.Error!);
+    }
+
+    private string? OwnerId() => User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    private IActionResult ErrorResult(PaycheckError error)
+    {
+        if (error.Code == "paycheck_not_found")
+        {
+            Response.StatusCode = StatusCodes.Status404NotFound;
+            return new EmptyResult();
+        }
+        var status = error.Code switch
+        {
+            "candidate_changed" or "candidate_dismissed" or "confirmation_conflict" => StatusCodes.Status409Conflict,
+            "confirmation_failed" => StatusCodes.Status500InternalServerError,
+            _ => StatusCodes.Status400BadRequest
+        };
+        return StatusCode(status, new ProblemDetails
+        {
+            Status = status, Title = "Paycheck request failed", Detail = error.Message,
+            Type = $"https://ordo.invalid/problems/{error.Code}", Extensions = { ["code"] = error.Code }
+        });
+    }
+}
+
+// Covers ApiController's automatic binding failures without changing other APIs
+// or echoing financial input in validation messages.
+[AttributeUsage(AttributeTargets.Class)]
+internal sealed class PaycheckValidationAttribute : Attribute, IAlwaysRunResultFilter
+{
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        if (context.Result is ObjectResult { Value: ValidationProblemDetails })
+            context.Result = new BadRequestObjectResult(new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest, Title = "Paycheck request failed",
+                Detail = "The request fields are invalid.", Type = "https://ordo.invalid/problems/request_invalid",
+                Extensions = { ["code"] = "request_invalid" }
+            });
+    }
+
+    public void OnResultExecuted(ResultExecutedContext context) { }
+}

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -21,6 +21,9 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
     public DbSet<CommitmentOccurrence> CommitmentOccurrences { get; set; }
     public DbSet<CommitmentCandidateDismissal> CommitmentCandidateDismissals { get; set; }
     public DbSet<CommitmentChangeDismissal> CommitmentChangeDismissals { get; set; }
+    public DbSet<PaycheckProfile> PaycheckProfiles { get; set; }
+    public DbSet<PaycheckOccurrence> PaycheckOccurrences { get; set; }
+    public DbSet<PaycheckCandidateDismissal> PaycheckCandidateDismissals { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -319,6 +322,109 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
                 value.Dimension,
                 value.EvidenceFingerprint
             }).IsUnique().HasDatabaseName("UX_CommitmentChangeDismissals_Owner_Assessment");
+        });
+
+        modelBuilder.Entity<PaycheckProfile>(profile =>
+        {
+            profile.ToTable(table =>
+            {
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Text", "length(btrim(\"DisplayName\")) > 0");
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Enums",
+                    "\"Lifecycle\" IN ('Active', 'Paused', 'Ended') AND " +
+                    "\"Cadence\" IN ('Weekly', 'Biweekly', 'Semimonthly', 'Monthly') AND " +
+                    "\"AmountMode\" IN ('Fixed', 'Range')");
+                // Explicit IS NOT NULL guards keep PostgreSQL CHECK's unknown result
+                // from accepting incomplete nullable schedule shapes.
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Schedule",
+                    "(\"Cadence\" IN ('Weekly', 'Biweekly') AND \"ReferenceAnchorDate\" IS NOT NULL AND \"FirstMonthAnchor\" IS NULL AND \"SecondMonthAnchor\" IS NULL) OR " +
+                    "(\"Cadence\" = 'Monthly' AND \"ReferenceAnchorDate\" IS NULL AND \"FirstMonthAnchor\" IS NOT NULL AND \"FirstMonthAnchor\" BETWEEN 1 AND 31 AND \"SecondMonthAnchor\" IS NULL) OR " +
+                    "(\"Cadence\" = 'Semimonthly' AND \"ReferenceAnchorDate\" IS NULL AND \"FirstMonthAnchor\" IS NOT NULL AND \"SecondMonthAnchor\" IS NOT NULL AND " +
+                    "\"FirstMonthAnchor\" BETWEEN 1 AND 31 AND \"SecondMonthAnchor\" BETWEEN 1 AND 31 AND \"FirstMonthAnchor\" < \"SecondMonthAnchor\" AND " +
+                    "LEAST(\"SecondMonthAnchor\", 28) - LEAST(\"FirstMonthAnchor\", 28) >= 7 AND 28 - LEAST(\"SecondMonthAnchor\", 28) + LEAST(\"FirstMonthAnchor\", 28) >= 7)");
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Windows",
+                    "\"WindowBeforeDays\" BETWEEN 0 AND 3 AND \"WindowAfterDays\" BETWEEN 0 AND 3");
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Amount",
+                    "(\"AmountMode\" = 'Fixed' AND \"ExpectedAmount\" IS NOT NULL AND \"ExpectedAmount\" > 0 AND \"ExpectedMinimumAmount\" IS NULL AND \"ExpectedMaximumAmount\" IS NULL) OR " +
+                    "(\"AmountMode\" = 'Range' AND \"ExpectedAmount\" IS NULL AND \"ExpectedMinimumAmount\" IS NOT NULL AND \"ExpectedMinimumAmount\" > 0 AND " +
+                    "\"ExpectedMaximumAmount\" IS NOT NULL AND \"ExpectedMaximumAmount\" > \"ExpectedMinimumAmount\")");
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Origin",
+                    "(\"OriginAlgorithmVersion\" IS NULL AND \"OriginEvidenceFingerprint\" IS NULL) OR " +
+                    "(\"OriginAlgorithmVersion\" IS NOT NULL AND length(btrim(\"OriginAlgorithmVersion\")) > 0 AND \"OriginEvidenceFingerprint\" IS NOT NULL AND octet_length(\"OriginEvidenceFingerprint\") = 32)");
+                table.HasCheckConstraint(
+                    "CK_PaycheckProfile_Timestamps", "\"UpdatedAt\" >= \"CreatedAt\"");
+            });
+            profile.Property(value => value.DisplayName).HasMaxLength(500);
+            profile.Property(value => value.Lifecycle).HasConversion<string>().HasMaxLength(20);
+            profile.Property(value => value.Cadence).HasConversion<string>().HasMaxLength(20);
+            profile.Property(value => value.ReferenceAnchorDate).HasColumnType("date");
+            profile.Property(value => value.AmountMode).HasConversion<string>().HasMaxLength(20);
+            profile.Property(value => value.ExpectedAmount).HasColumnType("numeric(18,2)");
+            profile.Property(value => value.ExpectedMinimumAmount).HasColumnType("numeric(18,2)");
+            profile.Property(value => value.ExpectedMaximumAmount).HasColumnType("numeric(18,2)");
+            profile.Property(value => value.OriginAlgorithmVersion).HasMaxLength(100);
+            profile.Property(value => value.OriginEvidenceFingerprint).HasColumnType("bytea").HasMaxLength(32);
+            profile.HasAlternateKey(value => new { value.Id, value.OwnerId })
+                .HasName("AK_PaycheckProfiles_Id_OwnerId");
+            profile.HasOne(value => value.Owner).WithMany().HasForeignKey(value => value.OwnerId)
+                .OnDelete(DeleteBehavior.Cascade);
+            profile.HasIndex(value => value.OwnerId);
+            profile.HasIndex(value => new { value.OwnerId, value.OriginAlgorithmVersion, value.OriginEvidenceFingerprint })
+                .IsUnique().HasDatabaseName("UX_PaycheckProfiles_Owner_Origin")
+                .HasFilter("\"OriginEvidenceFingerprint\" IS NOT NULL");
+        });
+
+        modelBuilder.Entity<PaycheckOccurrence>(occurrence =>
+        {
+            occurrence.ToTable(table =>
+            {
+                table.HasCheckConstraint(
+                    "CK_PaycheckOccurrence_Kind", "\"Kind\" = 'ConfirmationEvidence'");
+                table.HasCheckConstraint(
+                    "CK_PaycheckOccurrence_EvidenceRevision",
+                    "\"EvidenceRevisionAtAssignment\" <> '00000000-0000-0000-0000-000000000000'::uuid");
+                table.HasCheckConstraint(
+                    "CK_PaycheckOccurrence_TimingOffset", "\"TimingOffsetDays\" BETWEEN -3 AND 3");
+            });
+            occurrence.HasKey(value => new { value.PaycheckProfileId, value.AccountInflowId });
+            occurrence.Property(value => value.Kind).HasConversion<string>().HasMaxLength(30);
+            occurrence.Property(value => value.SlotAnchor).HasColumnType("date");
+            occurrence.HasOne(value => value.PaycheckProfile).WithMany(value => value.Occurrences)
+                .HasForeignKey(value => new { value.PaycheckProfileId, value.OwnerId })
+                .HasPrincipalKey(value => new { value.Id, value.OwnerId })
+                .HasConstraintName("FK_PaycheckOccurrence_Profile_Owner")
+                .OnDelete(DeleteBehavior.Cascade);
+            occurrence.HasOne(value => value.AccountInflow).WithMany()
+                .HasForeignKey(value => new { value.AccountInflowId, value.OwnerId })
+                .HasPrincipalKey(value => new { value.Id, value.OwnerId })
+                .HasConstraintName("FK_PaycheckOccurrence_AccountInflow_Owner")
+                .OnDelete(DeleteBehavior.Cascade);
+            occurrence.HasIndex(value => value.AccountInflowId).IsUnique();
+        });
+
+        modelBuilder.Entity<PaycheckCandidateDismissal>(dismissal =>
+        {
+            dismissal.ToTable(table =>
+            {
+                table.HasCheckConstraint(
+                    "CK_PaycheckCandidateDismissal_AlgorithmVersion", "length(btrim(\"AlgorithmVersion\")) > 0");
+                table.HasCheckConstraint(
+                    "CK_PaycheckCandidateDismissal_Cadence", "\"Cadence\" IN ('Weekly', 'Biweekly', 'Semimonthly', 'Monthly')");
+                table.HasCheckConstraint(
+                    "CK_PaycheckCandidateDismissal_FingerprintLength", "octet_length(\"EvidenceFingerprint\") = 32");
+            });
+            dismissal.Property(value => value.AlgorithmVersion).HasMaxLength(100);
+            dismissal.Property(value => value.Cadence).HasConversion<string>().HasMaxLength(20);
+            dismissal.Property(value => value.EvidenceFingerprint).HasColumnType("bytea").HasMaxLength(32);
+            dismissal.HasOne(value => value.Owner).WithMany().HasForeignKey(value => value.OwnerId)
+                .OnDelete(DeleteBehavior.Cascade);
+            dismissal.HasIndex(value => new { value.OwnerId, value.AlgorithmVersion, value.Cadence, value.EvidenceFingerprint })
+                .IsUnique().HasDatabaseName("UX_PaycheckCandidateDismissals_Owner_Origin");
         });
 
         modelBuilder.Entity<BudgetLimit>()

--- a/backend/Migrations/20260904213643_AddPaycheckProfiles.Designer.cs
+++ b/backend/Migrations/20260904213643_AddPaycheckProfiles.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260904213643_AddPaycheckProfiles")]
+    partial class AddPaycheckProfiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260904213643_AddPaycheckProfiles.cs
+++ b/backend/Migrations/20260904213643_AddPaycheckProfiles.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPaycheckProfiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PaycheckCandidateDismissals",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    AlgorithmVersion = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Cadence = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    EvidenceFingerprint = table.Column<byte[]>(type: "bytea", maxLength: 32, nullable: false),
+                    DismissedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaycheckCandidateDismissals", x => x.Id);
+                    table.CheckConstraint("CK_PaycheckCandidateDismissal_AlgorithmVersion", "length(btrim(\"AlgorithmVersion\")) > 0");
+                    table.CheckConstraint("CK_PaycheckCandidateDismissal_Cadence", "\"Cadence\" IN ('Weekly', 'Biweekly', 'Semimonthly', 'Monthly')");
+                    table.CheckConstraint("CK_PaycheckCandidateDismissal_FingerprintLength", "octet_length(\"EvidenceFingerprint\") = 32");
+                    table.ForeignKey(
+                        name: "FK_PaycheckCandidateDismissals_AspNetUsers_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PaycheckProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Lifecycle = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Cadence = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    ReferenceAnchorDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    FirstMonthAnchor = table.Column<short>(type: "smallint", nullable: true),
+                    SecondMonthAnchor = table.Column<short>(type: "smallint", nullable: true),
+                    WindowBeforeDays = table.Column<short>(type: "smallint", nullable: false),
+                    WindowAfterDays = table.Column<short>(type: "smallint", nullable: false),
+                    AmountMode = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    ExpectedAmount = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    ExpectedMinimumAmount = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    ExpectedMaximumAmount = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    OriginAlgorithmVersion = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    OriginEvidenceFingerprint = table.Column<byte[]>(type: "bytea", maxLength: 32, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaycheckProfiles", x => x.Id);
+                    table.UniqueConstraint("AK_PaycheckProfiles_Id_OwnerId", x => new { x.Id, x.OwnerId });
+                    table.CheckConstraint("CK_PaycheckProfile_Amount", "(\"AmountMode\" = 'Fixed' AND \"ExpectedAmount\" IS NOT NULL AND \"ExpectedAmount\" > 0 AND \"ExpectedMinimumAmount\" IS NULL AND \"ExpectedMaximumAmount\" IS NULL) OR (\"AmountMode\" = 'Range' AND \"ExpectedAmount\" IS NULL AND \"ExpectedMinimumAmount\" IS NOT NULL AND \"ExpectedMinimumAmount\" > 0 AND \"ExpectedMaximumAmount\" IS NOT NULL AND \"ExpectedMaximumAmount\" > \"ExpectedMinimumAmount\")");
+                    table.CheckConstraint("CK_PaycheckProfile_Enums", "\"Lifecycle\" IN ('Active', 'Paused', 'Ended') AND \"Cadence\" IN ('Weekly', 'Biweekly', 'Semimonthly', 'Monthly') AND \"AmountMode\" IN ('Fixed', 'Range')");
+                    table.CheckConstraint("CK_PaycheckProfile_Origin", "(\"OriginAlgorithmVersion\" IS NULL AND \"OriginEvidenceFingerprint\" IS NULL) OR (\"OriginAlgorithmVersion\" IS NOT NULL AND length(btrim(\"OriginAlgorithmVersion\")) > 0 AND \"OriginEvidenceFingerprint\" IS NOT NULL AND octet_length(\"OriginEvidenceFingerprint\") = 32)");
+                    table.CheckConstraint("CK_PaycheckProfile_Schedule", "(\"Cadence\" IN ('Weekly', 'Biweekly') AND \"ReferenceAnchorDate\" IS NOT NULL AND \"FirstMonthAnchor\" IS NULL AND \"SecondMonthAnchor\" IS NULL) OR (\"Cadence\" = 'Monthly' AND \"ReferenceAnchorDate\" IS NULL AND \"FirstMonthAnchor\" IS NOT NULL AND \"FirstMonthAnchor\" BETWEEN 1 AND 31 AND \"SecondMonthAnchor\" IS NULL) OR (\"Cadence\" = 'Semimonthly' AND \"ReferenceAnchorDate\" IS NULL AND \"FirstMonthAnchor\" IS NOT NULL AND \"SecondMonthAnchor\" IS NOT NULL AND \"FirstMonthAnchor\" BETWEEN 1 AND 31 AND \"SecondMonthAnchor\" BETWEEN 1 AND 31 AND \"FirstMonthAnchor\" < \"SecondMonthAnchor\" AND LEAST(\"SecondMonthAnchor\", 28) - LEAST(\"FirstMonthAnchor\", 28) >= 7 AND 28 - LEAST(\"SecondMonthAnchor\", 28) + LEAST(\"FirstMonthAnchor\", 28) >= 7)");
+                    table.CheckConstraint("CK_PaycheckProfile_Text", "length(btrim(\"DisplayName\")) > 0");
+                    table.CheckConstraint("CK_PaycheckProfile_Timestamps", "\"UpdatedAt\" >= \"CreatedAt\"");
+                    table.CheckConstraint("CK_PaycheckProfile_Windows", "\"WindowBeforeDays\" BETWEEN 0 AND 3 AND \"WindowAfterDays\" BETWEEN 0 AND 3");
+                    table.ForeignKey(
+                        name: "FK_PaycheckProfiles_AspNetUsers_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PaycheckOccurrences",
+                columns: table => new
+                {
+                    PaycheckProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccountInflowId = table.Column<int>(type: "integer", nullable: false),
+                    OwnerId = table.Column<string>(type: "text", nullable: false),
+                    Kind = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    EvidenceRevisionAtAssignment = table.Column<Guid>(type: "uuid", nullable: false),
+                    SlotAnchor = table.Column<DateOnly>(type: "date", nullable: false),
+                    TimingOffsetDays = table.Column<short>(type: "smallint", nullable: false),
+                    LinkedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaycheckOccurrences", x => new { x.PaycheckProfileId, x.AccountInflowId });
+                    table.CheckConstraint("CK_PaycheckOccurrence_EvidenceRevision", "\"EvidenceRevisionAtAssignment\" <> '00000000-0000-0000-0000-000000000000'::uuid");
+                    table.CheckConstraint("CK_PaycheckOccurrence_Kind", "\"Kind\" = 'ConfirmationEvidence'");
+                    table.CheckConstraint("CK_PaycheckOccurrence_TimingOffset", "\"TimingOffsetDays\" BETWEEN -3 AND 3");
+                    table.ForeignKey(
+                        name: "FK_PaycheckOccurrence_AccountInflow_Owner",
+                        columns: x => new { x.AccountInflowId, x.OwnerId },
+                        principalTable: "AccountInflows",
+                        principalColumns: new[] { "Id", "OwnerId" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PaycheckOccurrence_Profile_Owner",
+                        columns: x => new { x.PaycheckProfileId, x.OwnerId },
+                        principalTable: "PaycheckProfiles",
+                        principalColumns: new[] { "Id", "OwnerId" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_PaycheckCandidateDismissals_Owner_Origin",
+                table: "PaycheckCandidateDismissals",
+                columns: new[] { "OwnerId", "AlgorithmVersion", "Cadence", "EvidenceFingerprint" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaycheckOccurrences_AccountInflowId",
+                table: "PaycheckOccurrences",
+                column: "AccountInflowId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaycheckOccurrences_AccountInflowId_OwnerId",
+                table: "PaycheckOccurrences",
+                columns: new[] { "AccountInflowId", "OwnerId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaycheckOccurrences_PaycheckProfileId_OwnerId",
+                table: "PaycheckOccurrences",
+                columns: new[] { "PaycheckProfileId", "OwnerId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaycheckProfiles_OwnerId",
+                table: "PaycheckProfiles",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_PaycheckProfiles_Owner_Origin",
+                table: "PaycheckProfiles",
+                columns: new[] { "OwnerId", "OriginAlgorithmVersion", "OriginEvidenceFingerprint" },
+                unique: true,
+                filter: "\"OriginEvidenceFingerprint\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PaycheckOccurrences");
+
+            migrationBuilder.DropTable(
+                name: "PaycheckCandidateDismissals");
+
+            migrationBuilder.DropTable(
+                name: "PaycheckProfiles");
+        }
+    }
+}

--- a/backend/Models/PaycheckCandidateDismissal.cs
+++ b/backend/Models/PaycheckCandidateDismissal.cs
@@ -1,0 +1,14 @@
+using BudgetPlanner.Paychecks;
+
+namespace BudgetPlanner.Models;
+
+public class PaycheckCandidateDismissal
+{
+    public Guid Id { get; set; }
+    public string OwnerId { get; set; } = "";
+    public ApplicationUser? Owner { get; set; }
+    public string AlgorithmVersion { get; set; } = "";
+    public PaycheckCadence Cadence { get; set; }
+    public byte[] EvidenceFingerprint { get; set; } = [];
+    public DateTime DismissedAt { get; set; }
+}

--- a/backend/Models/PaycheckOccurrence.cs
+++ b/backend/Models/PaycheckOccurrence.cs
@@ -1,0 +1,20 @@
+namespace BudgetPlanner.Models;
+
+public enum PaycheckOccurrenceKind
+{
+    ConfirmationEvidence
+}
+
+public class PaycheckOccurrence
+{
+    public Guid PaycheckProfileId { get; set; }
+    public PaycheckProfile? PaycheckProfile { get; set; }
+    public int AccountInflowId { get; set; }
+    public AccountInflow? AccountInflow { get; set; }
+    public string OwnerId { get; set; } = "";
+    public PaycheckOccurrenceKind Kind { get; set; }
+    public Guid EvidenceRevisionAtAssignment { get; set; }
+    public DateOnly SlotAnchor { get; set; }
+    public short TimingOffsetDays { get; set; }
+    public DateTime LinkedAt { get; set; }
+}

--- a/backend/Models/PaycheckProfile.cs
+++ b/backend/Models/PaycheckProfile.cs
@@ -1,0 +1,41 @@
+using BudgetPlanner.Paychecks;
+
+namespace BudgetPlanner.Models;
+
+public enum PaycheckLifecycle
+{
+    Active,
+    Paused,
+    Ended
+}
+
+public enum PaycheckAmountMode
+{
+    Fixed,
+    Range
+}
+
+public class PaycheckProfile
+{
+    public Guid Id { get; set; }
+    public string OwnerId { get; set; } = "";
+    public ApplicationUser? Owner { get; set; }
+    public string DisplayName { get; set; } = "";
+    public PaycheckLifecycle Lifecycle { get; set; }
+    public PaycheckCadence Cadence { get; set; }
+    public DateOnly? ReferenceAnchorDate { get; set; }
+    // Canonical Stage 2 anchors: 1..30 are calendar days; 31 is month end.
+    public short? FirstMonthAnchor { get; set; }
+    public short? SecondMonthAnchor { get; set; }
+    public short WindowBeforeDays { get; set; }
+    public short WindowAfterDays { get; set; }
+    public PaycheckAmountMode AmountMode { get; set; }
+    public decimal? ExpectedAmount { get; set; }
+    public decimal? ExpectedMinimumAmount { get; set; }
+    public decimal? ExpectedMaximumAmount { get; set; }
+    public string? OriginAlgorithmVersion { get; set; }
+    public byte[]? OriginEvidenceFingerprint { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public List<PaycheckOccurrence> Occurrences { get; set; } = [];
+}

--- a/backend/Paychecks/PaycheckProfileRules.cs
+++ b/backend/Paychecks/PaycheckProfileRules.cs
@@ -1,0 +1,178 @@
+using BudgetPlanner.Contracts.Paychecks;
+using BudgetPlanner.Models;
+
+namespace BudgetPlanner.Paychecks;
+
+internal sealed record PaycheckExpectation(
+    string DisplayName, short WindowBeforeDays, short WindowAfterDays,
+    ConfirmedPaycheckAmount Amount);
+
+internal static class PaycheckProfileRules
+{
+    internal static PaycheckError? ValidateExpectation(
+        string? displayName, int? before, int? after, ConfirmedPaycheckAmountDto? amount,
+        out PaycheckExpectation? expectation)
+    {
+        expectation = null;
+        var name = displayName?.Trim();
+        if (string.IsNullOrEmpty(name) || name.Length > 500)
+            return new("name_invalid", "Display name must contain between 1 and 500 characters.");
+        if (before is null or < 0 or > 3 || after is null or < 0 or > 3)
+            return new("timing_invalid", "Both timing windows must be between zero and three days.");
+
+        ConfirmedPaycheckAmount? confirmedAmount = amount switch
+        {
+            { Mode: "fixed", FixedAmount: { } value, MinimumAmount: null, MaximumAmount: null }
+                when PaycheckContractRules.IsValidAmount(value) => new FixedConfirmedPaycheckAmount(value),
+            { Mode: "range", FixedAmount: null, MinimumAmount: { } minimum, MaximumAmount: { } maximum }
+                when PaycheckContractRules.IsValidAmount(minimum)
+                    && PaycheckContractRules.IsValidAmount(maximum) && minimum < maximum =>
+                new RangeConfirmedPaycheckAmount(minimum, maximum),
+            _ => null
+        };
+        if (confirmedAmount is null)
+            return new("amount_invalid", "Provide a positive fixed amount or an explicit increasing range with at most two decimal places.");
+
+        expectation = new(name, (short)before.Value, (short)after.Value, confirmedAmount);
+        return null;
+    }
+
+    internal static bool TrySchedule(PaycheckScheduleDto? dto, out PaycheckSchedule? schedule)
+    {
+        schedule = null;
+        if (dto is null) return false;
+        switch (dto.Cadence)
+        {
+            case "weekly" or "biweekly" when dto.ReferenceAnchorDate is { } reference
+                && dto.FirstMonthAnchor is null && dto.SecondMonthAnchor is null:
+                schedule = dto.Cadence == "weekly"
+                    ? new WeeklyPaycheckSchedule(reference) : new BiweeklyPaycheckSchedule(reference);
+                return true;
+            case "monthly" when dto.ReferenceAnchorDate is null && dto.SecondMonthAnchor is null
+                && TryMonthAnchor(dto.FirstMonthAnchor, out var monthly):
+                schedule = new MonthlyPaycheckSchedule(monthly!);
+                return true;
+            case "semimonthly" when dto.ReferenceAnchorDate is null
+                && TryMonthAnchor(dto.FirstMonthAnchor, out var first)
+                && TryMonthAnchor(dto.SecondMonthAnchor, out var second)
+                && PaycheckScheduleEngine.IsValidSemimonthlyPair(first!, second!):
+                schedule = new SemimonthlyPaycheckSchedule(first!, second!);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryMonthAnchor(PaycheckMonthAnchorDto? dto, out PaycheckMonthAnchor? anchor)
+    {
+        anchor = dto switch
+        {
+            { Kind: "day_of_month", Day: >= 1 and <= 30 } => PaycheckMonthAnchor.DayOfMonth(dto.Day.Value),
+            { Kind: "month_end", Day: null } => PaycheckMonthAnchor.MonthEnd,
+            _ => null
+        };
+        return anchor is not null;
+    }
+
+    internal static bool TryCadence(string? value, out PaycheckCadence cadence)
+    {
+        cadence = value switch
+        {
+            "weekly" => PaycheckCadence.Weekly,
+            "biweekly" => PaycheckCadence.Biweekly,
+            "semimonthly" => PaycheckCadence.Semimonthly,
+            "monthly" => PaycheckCadence.Monthly,
+            _ => (PaycheckCadence)(-1)
+        };
+        return Enum.IsDefined(cadence);
+    }
+
+    internal static bool TryLifecycle(string? value, out PaycheckLifecycle lifecycle)
+    {
+        lifecycle = value switch
+        {
+            "active" => PaycheckLifecycle.Active,
+            "paused" => PaycheckLifecycle.Paused,
+            "ended" => PaycheckLifecycle.Ended,
+            _ => (PaycheckLifecycle)(-1)
+        };
+        return Enum.IsDefined(lifecycle);
+    }
+
+    internal static PaycheckSchedule ReadSchedule(PaycheckProfile profile) => profile.Cadence switch
+    {
+        PaycheckCadence.Weekly => new WeeklyPaycheckSchedule(profile.ReferenceAnchorDate!.Value),
+        PaycheckCadence.Biweekly => new BiweeklyPaycheckSchedule(profile.ReferenceAnchorDate!.Value),
+        PaycheckCadence.Monthly => new MonthlyPaycheckSchedule(ReadAnchor(profile.FirstMonthAnchor!.Value)),
+        PaycheckCadence.Semimonthly => new SemimonthlyPaycheckSchedule(
+            ReadAnchor(profile.FirstMonthAnchor!.Value), ReadAnchor(profile.SecondMonthAnchor!.Value)),
+        _ => throw new InvalidOperationException("Unsupported persisted paycheck schedule.")
+    };
+
+    private static PaycheckMonthAnchor ReadAnchor(short value) =>
+        value == 31 ? PaycheckMonthAnchor.MonthEnd : PaycheckMonthAnchor.DayOfMonth(value);
+
+    internal static ConfirmedPaycheckAmount ReadAmount(PaycheckProfile profile) => profile.AmountMode switch
+    {
+        PaycheckAmountMode.Fixed => new FixedConfirmedPaycheckAmount(profile.ExpectedAmount!.Value),
+        PaycheckAmountMode.Range => new RangeConfirmedPaycheckAmount(
+            profile.ExpectedMinimumAmount!.Value, profile.ExpectedMaximumAmount!.Value),
+        _ => throw new InvalidOperationException("Unsupported persisted paycheck amount.")
+    };
+
+    internal static void ApplyExpectation(PaycheckProfile profile, PaycheckExpectation value)
+    {
+        profile.DisplayName = value.DisplayName;
+        profile.WindowBeforeDays = value.WindowBeforeDays;
+        profile.WindowAfterDays = value.WindowAfterDays;
+        profile.AmountMode = value.Amount is FixedConfirmedPaycheckAmount ? PaycheckAmountMode.Fixed : PaycheckAmountMode.Range;
+        profile.ExpectedAmount = (value.Amount as FixedConfirmedPaycheckAmount)?.Amount;
+        profile.ExpectedMinimumAmount = (value.Amount as RangeConfirmedPaycheckAmount)?.Minimum;
+        profile.ExpectedMaximumAmount = (value.Amount as RangeConfirmedPaycheckAmount)?.Maximum;
+    }
+
+    internal static void ApplySchedule(PaycheckProfile profile, PaycheckSchedule schedule)
+    {
+        profile.Cadence = schedule.Cadence;
+        profile.ReferenceAnchorDate = schedule switch
+        {
+            WeeklyPaycheckSchedule weekly => weekly.ReferenceAnchor,
+            BiweeklyPaycheckSchedule biweekly => biweekly.ReferenceAnchor,
+            _ => null
+        };
+        profile.FirstMonthAnchor = schedule switch
+        {
+            MonthlyPaycheckSchedule monthly => (short)(monthly.Anchor.Day ?? 31),
+            SemimonthlyPaycheckSchedule semimonthly => (short)(semimonthly.First.Day ?? 31),
+            _ => null
+        };
+        profile.SecondMonthAnchor = schedule is SemimonthlyPaycheckSchedule semi
+            ? (short)(semi.Second.Day ?? 31) : null;
+    }
+
+    internal static PaycheckScheduleDto ToDto(PaycheckSchedule schedule) => schedule switch
+    {
+        WeeklyPaycheckSchedule weekly => new("weekly", weekly.ReferenceAnchor, null, null),
+        BiweeklyPaycheckSchedule biweekly => new("biweekly", biweekly.ReferenceAnchor, null, null),
+        MonthlyPaycheckSchedule monthly => new("monthly", null, ToDto(monthly.Anchor), null),
+        SemimonthlyPaycheckSchedule semi => new("semimonthly", null, ToDto(semi.First), ToDto(semi.Second)),
+        _ => throw new InvalidOperationException("Unsupported paycheck schedule.")
+    };
+
+    private static PaycheckMonthAnchorDto ToDto(PaycheckMonthAnchor anchor) =>
+        new(anchor.Kind == PaycheckMonthAnchorKind.MonthEnd ? "month_end" : "day_of_month", anchor.Day);
+
+    internal static ConfirmedPaycheckAmountDto ToDto(ConfirmedPaycheckAmount amount) => amount switch
+    {
+        FixedConfirmedPaycheckAmount fixedAmount => new("fixed", fixedAmount.Amount, null, null),
+        RangeConfirmedPaycheckAmount range => new("range", null, range.Minimum, range.Maximum),
+        _ => throw new InvalidOperationException("Unsupported paycheck amount.")
+    };
+
+    internal static ObservedPaycheckAmountDto ToDto(ObservedPaycheckAmountSummary amount) => amount switch
+    {
+        FixedObservedPaycheckAmount fixedAmount => new("fixed", fixedAmount.Amount, null, null, fixedAmount.Amount),
+        VariableObservedPaycheckAmount variable => new("variable", null, variable.Minimum, variable.Maximum, variable.LowerMedian),
+        _ => throw new InvalidOperationException("Unsupported observed paycheck amount.")
+    };
+}

--- a/backend/Paychecks/PaycheckService.cs
+++ b/backend/Paychecks/PaycheckService.cs
@@ -1,0 +1,452 @@
+using System.Data;
+using BudgetPlanner.Contracts.Paychecks;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+
+namespace BudgetPlanner.Paychecks;
+
+public sealed record PaycheckOperation<T>(T? Value, PaycheckError? Error)
+{
+    public bool IsSuccess => Error is null;
+    public static PaycheckOperation<T> Success(T value) => new(value, null);
+    public static PaycheckOperation<T> Failure(PaycheckError error) => new(default, error);
+}
+
+public interface IPaycheckService
+{
+    Task<PaycheckCandidatesResponse> GetCandidatesAsync(string ownerId, CancellationToken cancellationToken);
+    Task<PaycheckOperation<bool>> DismissAsync(string ownerId, PaycheckCandidateDecisionRequest request, CancellationToken cancellationToken);
+    Task<PaycheckOperation<bool>> ReconsiderAsync(string ownerId, PaycheckCandidateDecisionRequest request, CancellationToken cancellationToken);
+    Task<PaycheckOperation<ConfirmPaycheckResponse>> ConfirmAsync(string ownerId, ConfirmPaycheckRequest request, CancellationToken cancellationToken);
+    Task<PaycheckOperation<PaycheckProfileDto>> CreateAsync(string ownerId, CreatePaycheckRequest request, CancellationToken cancellationToken);
+    Task<PaychecksResponse> GetPaychecksAsync(string ownerId, CancellationToken cancellationToken);
+    Task<PaycheckOperation<PaycheckProfileDto>> GetAsync(string ownerId, Guid id, CancellationToken cancellationToken);
+    Task<PaycheckOperation<PaycheckProfileDto>> UpdateAsync(string ownerId, Guid id, UpdatePaycheckRequest request, CancellationToken cancellationToken);
+    Task<PaycheckOperation<PaycheckProfileDto>> UpdateLifecycleAsync(string ownerId, Guid id, UpdatePaycheckLifecycleRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class PaycheckService(
+    BudgetContext context, PaycheckCandidateDetector detector, PaycheckProjector projector,
+    TimeProvider clock) : IPaycheckService
+{
+    public async Task<PaycheckCandidatesResponse> GetCandidatesAsync(string ownerId, CancellationToken cancellationToken)
+    {
+        var evaluatedOn = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
+        var candidates = await DetectAsync(ownerId, evaluatedOn, cancellationToken);
+        var dismissals = await context.PaycheckCandidateDismissals.AsNoTracking()
+            .Where(value => value.OwnerId == ownerId).ToListAsync(cancellationToken);
+        var imported = await ImportedIdsAsync(ownerId, cancellationToken);
+        var ordered = candidates.OrderBy(value => value.NormalizedDescriptionIdentity, StringComparer.Ordinal)
+            .ThenBy(value => value.EvidenceFingerprint, StringComparer.Ordinal).ToArray();
+        return new(evaluatedOn,
+            ordered.Where(value => !IsDismissed(value, dismissals)).Select(value => ToDto(value, imported)).ToArray(),
+            ordered.Where(value => IsDismissed(value, dismissals)).Select(value => ToDto(value, imported)).ToArray());
+    }
+
+    public async Task<PaycheckOperation<bool>> DismissAsync(
+        string ownerId, PaycheckCandidateDecisionRequest request, CancellationToken cancellationToken)
+    {
+        var error = ValidateDecision(request, out var cadence, out var fingerprint);
+        if (error is not null) return PaycheckOperation<bool>.Failure(error);
+        var now = clock.GetUtcNow().UtcDateTime;
+        await using var transaction = await BeginAsync(cancellationToken);
+        try
+        {
+            if (await DismissalQuery(ownerId, request.AlgorithmVersion!, cadence, fingerprint).AnyAsync(cancellationToken))
+            {
+                await CommitAsync(transaction, cancellationToken);
+                return PaycheckOperation<bool>.Success(true);
+            }
+            var candidates = await DetectAsync(ownerId, DateOnly.FromDateTime(now), cancellationToken);
+            if (!candidates.Any(value => Matches(value, request.AlgorithmVersion!, cadence, request.Fingerprint!)))
+                return Changed<bool>();
+
+            context.PaycheckCandidateDismissals.Add(new PaycheckCandidateDismissal
+            {
+                Id = Guid.NewGuid(), OwnerId = ownerId, AlgorithmVersion = request.AlgorithmVersion!,
+                Cadence = cadence, EvidenceFingerprint = fingerprint, DismissedAt = now
+            });
+            await context.SaveChangesAsync(cancellationToken);
+            await CommitAsync(transaction, cancellationToken);
+            return PaycheckOperation<bool>.Success(true);
+        }
+        catch (Exception exception) when (IsConflict(exception))
+        {
+            await ResetAsync(transaction);
+            return await DismissalQuery(ownerId, request.AlgorithmVersion!, cadence, fingerprint).AnyAsync(cancellationToken)
+                ? PaycheckOperation<bool>.Success(true) : Changed<bool>();
+        }
+    }
+
+    public async Task<PaycheckOperation<bool>> ReconsiderAsync(
+        string ownerId, PaycheckCandidateDecisionRequest request, CancellationToken cancellationToken)
+    {
+        var error = ValidateDecision(request, out var cadence, out var fingerprint);
+        if (error is not null) return PaycheckOperation<bool>.Failure(error);
+        await using var transaction = await BeginAsync(cancellationToken);
+        try
+        {
+            var dismissal = await DismissalQuery(ownerId, request.AlgorithmVersion!, cadence, fingerprint)
+                .SingleOrDefaultAsync(cancellationToken);
+            if (dismissal is not null)
+            {
+                context.PaycheckCandidateDismissals.Remove(dismissal);
+                await context.SaveChangesAsync(cancellationToken);
+            }
+            await CommitAsync(transaction, cancellationToken);
+            return PaycheckOperation<bool>.Success(true);
+        }
+        catch (Exception exception) when (IsConflict(exception))
+        {
+            await ResetAsync(transaction);
+            return !await DismissalQuery(ownerId, request.AlgorithmVersion!, cadence, fingerprint).AnyAsync(cancellationToken)
+                ? PaycheckOperation<bool>.Success(true) : Changed<bool>();
+        }
+    }
+
+    public async Task<PaycheckOperation<ConfirmPaycheckResponse>> ConfirmAsync(
+        string ownerId, ConfirmPaycheckRequest request, CancellationToken cancellationToken)
+    {
+        if (!TryFingerprint(request.Fingerprint, out var fingerprint)) return InvalidFingerprint<ConfirmPaycheckResponse>();
+        if (!ValidVersion(request.AlgorithmVersion)) return Fail<ConfirmPaycheckResponse>("algorithm_version_invalid", "Algorithm version is invalid.");
+        var error = PaycheckProfileRules.ValidateExpectation(request.DisplayName, request.WindowBeforeDays,
+            request.WindowAfterDays, request.Amount, out var expectation);
+        if (error is not null) return PaycheckOperation<ConfirmPaycheckResponse>.Failure(error);
+        if (!PaycheckProfileRules.TrySchedule(request.Schedule, out var schedule))
+            return InvalidSchedule<ConfirmPaycheckResponse>();
+
+        var now = clock.GetUtcNow().UtcDateTime;
+        var evaluatedOn = DateOnly.FromDateTime(now);
+        await using var transaction = await BeginAsync(cancellationToken);
+        try
+        {
+            var existing = await FindOriginAsync(ownerId, request.AlgorithmVersion!, fingerprint, cancellationToken);
+            if (existing is not null)
+            {
+                var response = await ProfileDtoAsync(existing, evaluatedOn, cancellationToken);
+                await CommitAsync(transaction, cancellationToken);
+                return PaycheckOperation<ConfirmPaycheckResponse>.Success(new(response, true));
+            }
+
+            var candidates = await DetectAsync(ownerId, evaluatedOn, cancellationToken);
+            var candidate = candidates.SingleOrDefault(value =>
+                value.AlgorithmVersion == request.AlgorithmVersion && value.EvidenceFingerprint == request.Fingerprint);
+            if (candidate is null) return Changed<ConfirmPaycheckResponse>();
+            if (candidate.Schedule != schedule)
+                return Fail<ConfirmPaycheckResponse>("candidate_schedule_mismatch", "Accept the candidate schedule or create a paycheck manually.");
+            if (await DismissalQuery(ownerId, candidate.AlgorithmVersion, candidate.Schedule.Cadence, fingerprint)
+                    .AnyAsync(cancellationToken))
+                return Fail<ConfirmPaycheckResponse>("candidate_dismissed", "Reconsider the candidate before confirming it.");
+            if (candidate.ObservedAmount is VariableObservedPaycheckAmount
+                && expectation!.Amount is not RangeConfirmedPaycheckAmount)
+                return Fail<ConfirmPaycheckResponse>("amount_invalid", "Variable evidence requires an explicit accepted amount range.");
+
+            if (!await LockAndValidateEvidenceAsync(ownerId, candidate, cancellationToken))
+                return Changed<ConfirmPaycheckResponse>();
+
+            var profile = NewProfile(ownerId, schedule!, expectation!, now);
+            profile.OriginAlgorithmVersion = candidate.AlgorithmVersion;
+            profile.OriginEvidenceFingerprint = fingerprint;
+            profile.Occurrences = candidate.Evidence.Select(evidence => new PaycheckOccurrence
+            {
+                PaycheckProfileId = profile.Id, AccountInflowId = evidence.AccountInflowId, OwnerId = ownerId,
+                Kind = PaycheckOccurrenceKind.ConfirmationEvidence,
+                EvidenceRevisionAtAssignment = evidence.PaycheckEvidenceRevision,
+                SlotAnchor = evidence.SlotAnchor, TimingOffsetDays = (short)evidence.TimingOffsetDays, LinkedAt = now
+            }).ToList();
+            context.PaycheckProfiles.Add(profile);
+            await context.SaveChangesAsync(cancellationToken);
+            var created = await ProfileDtoAsync(profile, evaluatedOn, cancellationToken);
+            await CommitAsync(transaction, cancellationToken);
+            return PaycheckOperation<ConfirmPaycheckResponse>.Success(new(created, false));
+        }
+        catch (Exception exception) when (IsConflict(exception))
+        {
+            await ResetAsync(transaction);
+            var existing = await FindOriginAsync(ownerId, request.AlgorithmVersion!, fingerprint, cancellationToken);
+            return existing is not null
+                ? PaycheckOperation<ConfirmPaycheckResponse>.Success(new(
+                    await ProfileDtoAsync(existing, evaluatedOn, cancellationToken), true))
+                : Fail<ConfirmPaycheckResponse>("confirmation_conflict", "The evidence changed or was already assigned. Refresh the candidates.");
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            await ResetAsync(transaction);
+            return InvalidSchedule<ConfirmPaycheckResponse>();
+        }
+        catch (DbUpdateException)
+        {
+            await ResetAsync(transaction);
+            return Fail<ConfirmPaycheckResponse>("confirmation_failed", "Paycheck confirmation could not be completed.");
+        }
+        catch
+        {
+            await ResetAsync(transaction);
+            throw;
+        }
+    }
+
+    public async Task<PaycheckOperation<PaycheckProfileDto>> CreateAsync(
+        string ownerId, CreatePaycheckRequest request, CancellationToken cancellationToken)
+    {
+        var error = PaycheckProfileRules.ValidateExpectation(request.DisplayName, request.WindowBeforeDays,
+            request.WindowAfterDays, request.Amount, out var expectation);
+        if (error is not null) return PaycheckOperation<PaycheckProfileDto>.Failure(error);
+        if (!PaycheckProfileRules.TrySchedule(request.Schedule, out var schedule)) return InvalidSchedule<PaycheckProfileDto>();
+        var now = clock.GetUtcNow().UtcDateTime;
+        var profile = NewProfile(ownerId, schedule!, expectation!, now);
+        var response = await ProspectiveProfileDtoAsync(profile, DateOnly.FromDateTime(now), cancellationToken);
+        if (!response.IsSuccess) return response;
+        context.PaycheckProfiles.Add(profile);
+        await context.SaveChangesAsync(cancellationToken);
+        return response;
+    }
+
+    public async Task<PaychecksResponse> GetPaychecksAsync(string ownerId, CancellationToken cancellationToken)
+    {
+        var evaluatedOn = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
+        var profiles = await context.PaycheckProfiles.AsNoTracking().Where(value => value.OwnerId == ownerId)
+            .ToListAsync(cancellationToken);
+        var ordered = profiles.OrderBy(value => value.Lifecycle).ThenBy(value => value.DisplayName, StringComparer.Ordinal)
+            .ThenBy(value => value.Id).ToArray();
+        return new(evaluatedOn, await ProfileDtosAsync(ownerId, ordered, evaluatedOn, cancellationToken));
+    }
+
+    public async Task<PaycheckOperation<PaycheckProfileDto>> GetAsync(string ownerId, Guid id, CancellationToken cancellationToken)
+    {
+        var evaluatedOn = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
+        var profile = await context.PaycheckProfiles.AsNoTracking()
+            .SingleOrDefaultAsync(value => value.OwnerId == ownerId && value.Id == id, cancellationToken);
+        return profile is null ? NotFound<PaycheckProfileDto>()
+            : PaycheckOperation<PaycheckProfileDto>.Success(await ProfileDtoAsync(profile, evaluatedOn, cancellationToken));
+    }
+
+    public async Task<PaycheckOperation<PaycheckProfileDto>> UpdateAsync(
+        string ownerId, Guid id, UpdatePaycheckRequest request, CancellationToken cancellationToken)
+    {
+        var profile = await context.PaycheckProfiles.SingleOrDefaultAsync(
+            value => value.OwnerId == ownerId && value.Id == id, cancellationToken);
+        if (profile is null) return NotFound<PaycheckProfileDto>();
+        var error = PaycheckProfileRules.ValidateExpectation(request.DisplayName, request.WindowBeforeDays,
+            request.WindowAfterDays, request.Amount, out var expectation);
+        if (error is not null) return PaycheckOperation<PaycheckProfileDto>.Failure(error);
+        var now = clock.GetUtcNow().UtcDateTime;
+        var original = context.Entry(profile).CurrentValues.Clone();
+        PaycheckProfileRules.ApplyExpectation(profile, expectation!);
+        profile.UpdatedAt = now;
+        var response = await ProspectiveProfileDtoAsync(profile, DateOnly.FromDateTime(now), cancellationToken);
+        if (!response.IsSuccess)
+        {
+            context.Entry(profile).CurrentValues.SetValues(original);
+            return response;
+        }
+        await context.SaveChangesAsync(cancellationToken);
+        return response;
+    }
+
+    public async Task<PaycheckOperation<PaycheckProfileDto>> UpdateLifecycleAsync(
+        string ownerId, Guid id, UpdatePaycheckLifecycleRequest request, CancellationToken cancellationToken)
+    {
+        var profile = await context.PaycheckProfiles.SingleOrDefaultAsync(
+            value => value.OwnerId == ownerId && value.Id == id, cancellationToken);
+        if (profile is null) return NotFound<PaycheckProfileDto>();
+        if (!PaycheckProfileRules.TryLifecycle(request.Lifecycle, out var lifecycle))
+            return Fail<PaycheckProfileDto>("lifecycle_invalid", "Lifecycle must be active, paused, or ended.");
+        var now = clock.GetUtcNow().UtcDateTime;
+        var original = context.Entry(profile).CurrentValues.Clone();
+        profile.Lifecycle = lifecycle;
+        profile.UpdatedAt = now;
+        var response = await ProspectiveProfileDtoAsync(profile, DateOnly.FromDateTime(now), cancellationToken);
+        if (!response.IsSuccess)
+        {
+            context.Entry(profile).CurrentValues.SetValues(original);
+            return response;
+        }
+        await context.SaveChangesAsync(cancellationToken);
+        return response;
+    }
+
+    private async Task<IReadOnlyList<PaycheckCandidate>> DetectAsync(
+        string ownerId, DateOnly evaluatedOn, CancellationToken cancellationToken)
+    {
+        var claimed = context.PaycheckOccurrences.Where(value => value.OwnerId == ownerId).Select(value => value.AccountInflowId);
+        var inflows = await context.AccountInflows.AsNoTracking()
+            .Where(value => value.OwnerId == ownerId && !claimed.Contains(value.Id)).ToListAsync(cancellationToken);
+        return detector.Detect(inflows, evaluatedOn);
+    }
+
+    private async Task<bool> LockAndValidateEvidenceAsync(string ownerId, PaycheckCandidate candidate, CancellationToken cancellationToken)
+    {
+        var ids = candidate.Evidence.Select(value => value.AccountInflowId).Order().ToArray();
+        var current = context.Database.IsNpgsql()
+            ? await context.AccountInflows.FromSqlInterpolated($"""
+                SELECT * FROM "AccountInflows"
+                WHERE "OwnerId" = {ownerId} AND "Id" = ANY({ids})
+                ORDER BY "Id" FOR UPDATE
+                """).AsNoTracking().ToListAsync(cancellationToken)
+            : await context.AccountInflows.AsNoTracking().Where(value => value.OwnerId == ownerId && ids.Contains(value.Id))
+                .ToListAsync(cancellationToken);
+        if (current.Count != ids.Length || await context.PaycheckOccurrences.AnyAsync(
+                value => value.OwnerId == ownerId && ids.Contains(value.AccountInflowId), cancellationToken)) return false;
+        var byId = current.ToDictionary(value => value.Id);
+        return candidate.Evidence.All(value => byId.TryGetValue(value.AccountInflowId, out var inflow)
+            && inflow.PaycheckEvidenceRevision == value.PaycheckEvidenceRevision
+            && inflow.Date == value.PostedDate && inflow.Amount == value.Amount
+            && AccountInflowIdentity.NormalizeDescription(inflow.Description) == candidate.NormalizedDescriptionIdentity
+            && PaycheckScheduleEngine.IsAnchor(candidate.Schedule, value.SlotAnchor)
+            && value.PostedDate.DayNumber - value.SlotAnchor.DayNumber == value.TimingOffsetDays);
+    }
+
+    private IQueryable<PaycheckCandidateDismissal> DismissalQuery(
+        string ownerId, string version, PaycheckCadence cadence, byte[] fingerprint) =>
+        context.PaycheckCandidateDismissals.Where(value => value.OwnerId == ownerId
+            && value.AlgorithmVersion == version && value.Cadence == cadence
+            && value.EvidenceFingerprint.SequenceEqual(fingerprint));
+
+    private Task<PaycheckProfile?> FindOriginAsync(string ownerId, string version, byte[] fingerprint, CancellationToken cancellationToken) =>
+        context.PaycheckProfiles.AsNoTracking().SingleOrDefaultAsync(value => value.OwnerId == ownerId
+            && value.OriginAlgorithmVersion == version && value.OriginEvidenceFingerprint != null
+            && value.OriginEvidenceFingerprint.SequenceEqual(fingerprint), cancellationToken);
+
+    private async Task<HashSet<int>> ImportedIdsAsync(string ownerId, CancellationToken cancellationToken) =>
+        await context.ImportInflowProvenances.AsNoTracking().Where(value => value.OwnerId == ownerId
+            && value.AccountInflowId != null && value.AccountInflowOwnerId == ownerId
+            && value.Batch!.OwnerId == ownerId && value.AccountInflow!.OwnerId == ownerId)
+            .Select(value => value.AccountInflowId!.Value).ToHashSetAsync(cancellationToken);
+
+    private async Task<PaycheckProfileDto> ProfileDtoAsync(PaycheckProfile profile, DateOnly evaluatedOn, CancellationToken cancellationToken) =>
+        (await ProfileDtosAsync(profile.OwnerId, [profile], evaluatedOn, cancellationToken))[0];
+
+    private async Task<PaycheckOperation<PaycheckProfileDto>> ProspectiveProfileDtoAsync(
+        PaycheckProfile profile, DateOnly evaluatedOn, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return PaycheckOperation<PaycheckProfileDto>.Success(await ProfileDtoAsync(profile, evaluatedOn, cancellationToken));
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Valid DateOnly inputs can still place the expected window beyond
+            // the representable calendar. Reject before persisting that state.
+            return InvalidSchedule<PaycheckProfileDto>();
+        }
+    }
+
+    private async Task<IReadOnlyList<PaycheckProfileDto>> ProfileDtosAsync(
+        string ownerId, IReadOnlyList<PaycheckProfile> profiles, DateOnly evaluatedOn, CancellationToken cancellationToken)
+    {
+        var ids = profiles.Select(value => value.Id).ToArray();
+        // Filter every side before mapping; even anomalous foreign links must not disclose another owner's inflow.
+        var evidence = await (
+            from occurrence in context.PaycheckOccurrences.AsNoTracking()
+            join inflow in context.AccountInflows.AsNoTracking() on occurrence.AccountInflowId equals inflow.Id
+            where occurrence.OwnerId == ownerId && inflow.OwnerId == ownerId && ids.Contains(occurrence.PaycheckProfileId)
+            select new { Occurrence = occurrence, Inflow = inflow }).ToListAsync(cancellationToken);
+        var imported = await ImportedIdsAsync(ownerId, cancellationToken);
+        return profiles.Select(profile =>
+        {
+            var linked = evidence.Where(value => value.Occurrence.PaycheckProfileId == profile.Id)
+                .OrderBy(value => value.Inflow.Date).ThenBy(value => value.Inflow.Id).ToArray();
+            var schedule = PaycheckProfileRules.ReadSchedule(profile);
+            var amount = PaycheckProfileRules.ReadAmount(profile);
+            PaycheckProjectionDto? projection = null;
+            if (profile.Lifecycle == PaycheckLifecycle.Active)
+            {
+                var pattern = new ConfirmedPaycheckPattern(schedule, profile.WindowBeforeDays, profile.WindowAfterDays,
+                    amount, linked.Select(value => (DateOnly?)value.Occurrence.SlotAnchor).Max());
+                var projected = projector.Project(pattern, evaluatedOn);
+                projection = new(projected.AlgorithmVersion, projected.EvaluatedOn, projected.Anchor,
+                    projected.EarliestExpectedDate, projected.LatestExpectedDate, PaycheckProfileRules.ToDto(projected.Amount));
+            }
+            return new PaycheckProfileDto(profile.Id, profile.DisplayName, profile.Lifecycle.ToString().ToLowerInvariant(),
+                PaycheckProfileRules.ToDto(schedule), profile.WindowBeforeDays, profile.WindowAfterDays,
+                PaycheckProfileRules.ToDto(amount), profile.OriginEvidenceFingerprint is null ? "manual" : "candidate",
+                profile.OriginEvidenceFingerprint is null ? null : new(profile.OriginAlgorithmVersion!, Convert.ToHexStringLower(profile.OriginEvidenceFingerprint)),
+                profile.CreatedAt, profile.UpdatedAt, linked.Select(value => new PaycheckProfileEvidenceDto(
+                    value.Inflow.Id, value.Inflow.Date, value.Inflow.Amount, value.Inflow.Description,
+                    imported.Contains(value.Inflow.Id) ? "imported" : "manual", value.Occurrence.SlotAnchor,
+                    value.Occurrence.TimingOffsetDays, value.Occurrence.LinkedAt,
+                    value.Inflow.PaycheckEvidenceRevision != value.Occurrence.EvidenceRevisionAtAssignment)).ToArray(), projection);
+        }).ToArray();
+    }
+
+    private static PaycheckProfile NewProfile(string ownerId, PaycheckSchedule schedule, PaycheckExpectation expectation, DateTime now)
+    {
+        var profile = new PaycheckProfile { Id = Guid.NewGuid(), OwnerId = ownerId,
+            Lifecycle = PaycheckLifecycle.Active, CreatedAt = now, UpdatedAt = now };
+        PaycheckProfileRules.ApplySchedule(profile, schedule);
+        PaycheckProfileRules.ApplyExpectation(profile, expectation);
+        return profile;
+    }
+
+    private static PaycheckCandidateDto ToDto(PaycheckCandidate candidate, IReadOnlySet<int> imported)
+    {
+        var evidence = candidate.Evidence.OrderBy(value => value.PostedDate).ThenBy(value => value.AccountInflowId).ToArray();
+        return new(candidate.EvidenceFingerprint, candidate.AlgorithmVersion, candidate.NormalizedDescriptionIdentity,
+            PaycheckProfileRules.ToDto(candidate.Schedule), candidate.WindowBeforeDays, candidate.WindowAfterDays,
+            PaycheckProfileRules.ToDto(candidate.ObservedAmount), evidence[0].PostedDate, evidence[^1].PostedDate,
+            evidence.Length, evidence.Select(value => new PaycheckCandidateEvidenceDto(value.AccountInflowId,
+                value.PostedDate, value.Amount, value.Description, imported.Contains(value.AccountInflowId) ? "imported" : "manual",
+                value.SlotAnchor, value.TimingOffsetDays)).ToArray());
+    }
+
+    private static bool IsDismissed(PaycheckCandidate candidate, IEnumerable<PaycheckCandidateDismissal> dismissals) =>
+        dismissals.Any(value => Matches(candidate, value.AlgorithmVersion, value.Cadence, Convert.ToHexStringLower(value.EvidenceFingerprint)));
+
+    private static bool Matches(PaycheckCandidate candidate, string version, PaycheckCadence cadence, string fingerprint) =>
+        candidate.AlgorithmVersion == version && candidate.Schedule.Cadence == cadence && candidate.EvidenceFingerprint == fingerprint;
+
+    private static PaycheckError? ValidateDecision(PaycheckCandidateDecisionRequest request, out PaycheckCadence cadence, out byte[] fingerprint)
+    {
+        cadence = default;
+        if (!TryFingerprint(request.Fingerprint, out fingerprint)) return new("fingerprint_invalid", "Candidate fingerprint is invalid.");
+        if (!ValidVersion(request.AlgorithmVersion)) return new("algorithm_version_invalid", "Algorithm version is invalid.");
+        return PaycheckProfileRules.TryCadence(request.Cadence, out cadence)
+            ? null : new("cadence_invalid", "Cadence is invalid.");
+    }
+
+    private static bool ValidVersion(string? value) => !string.IsNullOrWhiteSpace(value) && value.Length <= 100;
+
+    private static bool TryFingerprint(string? value, out byte[] fingerprint)
+    {
+        fingerprint = [];
+        if (value is null || value.Length != 64 || value.Any(character =>
+                character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f'))) return false;
+        fingerprint = Convert.FromHexString(value);
+        return true;
+    }
+
+    private async Task<IDbContextTransaction?> BeginAsync(CancellationToken cancellationToken) =>
+        context.Database.IsRelational() ? await context.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken) : null;
+
+    private static Task CommitAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken) =>
+        transaction?.CommitAsync(cancellationToken) ?? Task.CompletedTask;
+
+    private async Task ResetAsync(IDbContextTransaction? transaction)
+    {
+        if (transaction is not null)
+        {
+            await transaction.RollbackAsync(CancellationToken.None);
+            await transaction.DisposeAsync();
+        }
+        context.ChangeTracker.Clear();
+    }
+
+    private static bool IsConflict(Exception exception)
+    {
+        if (exception is DbUpdateConcurrencyException) return true;
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+            if (current is PostgresException postgres)
+                return postgres.SqlState is PostgresErrorCodes.UniqueViolation or PostgresErrorCodes.SerializationFailure or PostgresErrorCodes.DeadlockDetected;
+        return false;
+    }
+
+    private static PaycheckOperation<T> Fail<T>(string code, string message) => PaycheckOperation<T>.Failure(new(code, message));
+    private static PaycheckOperation<T> Changed<T>() => Fail<T>("candidate_changed", "The candidate changed or is no longer available.");
+    private static PaycheckOperation<T> NotFound<T>() => Fail<T>("paycheck_not_found", "Paycheck was not found.");
+    private static PaycheckOperation<T> InvalidFingerprint<T>() => Fail<T>("fingerprint_invalid", "Candidate fingerprint is invalid.");
+    private static PaycheckOperation<T> InvalidSchedule<T>() => Fail<T>("schedule_invalid", "Provide a valid paycheck schedule with only its required fields.");
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Options;
 using BudgetPlanner.Import;
 using BudgetPlanner.Import.Sunflower;
 using BudgetPlanner.Commitments;
+using BudgetPlanner.Paychecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -42,6 +43,9 @@ builder.Services.AddScoped<IImportPreviewService, ImportPreviewService>();
 builder.Services.AddSingleton<ICommitmentDetector, CommitmentDetector>();
 builder.Services.AddSingleton<ICommitmentChangeDetector, CommitmentChangeDetector>();
 builder.Services.AddScoped<ICommitmentService, CommitmentService>();
+builder.Services.AddSingleton<PaycheckCandidateDetector>();
+builder.Services.AddSingleton<PaycheckProjector>();
+builder.Services.AddScoped<IPaycheckService, PaycheckService>();
 
 builder.Services
     .AddOptions<EmailSettingsOptions>()

--- a/docs/financial-domain-invariants.md
+++ b/docs/financial-domain-invariants.md
@@ -57,6 +57,120 @@ only when the user explicitly selects it during statement review; that selection
 is false by default. Credits never become Expenses, and saving an imported
 credit does not call it income or a paycheck.
 
+## Confirmed paycheck profiles
+
+The owner-approved Stage 4 plan on [issue #114](https://github.com/OL1V3S/ordo/issues/114)
+establishes the backend profile and API boundary. A detector candidate is derived
+evidence until the user explicitly confirms it. A manual profile is a separate
+explicit statement of expected paycheck behavior; creating an `AccountInflow`
+alone never creates a paycheck. Multiple profiles per owner remain valid.
+
+Profiles store a user-controlled display name, paycheck-specific lifecycle
+(`active`, `paused`, `ended`), immutable schedule, accepted timing windows, and
+either a fixed amount or an explicitly accepted range. Names are outer-trimmed,
+nonblank, and at most 500 characters. Amounts are positive `numeric(18,2)` values
+with at most two decimals; range minimum must be strictly less than maximum.
+Each timing window is explicitly supplied and is between zero and three days.
+An observed variable amount requires an explicit confirmed range; raw detector
+minimum/maximum values are never automatically adopted as the expectation.
+
+Schedules reuse the unchanged Stage 2 types and rules:
+
+- weekly and biweekly use only a reference anchor date;
+- monthly uses one canonical day-of-month or month-end anchor;
+- semimonthly uses two ordered canonical anchors that remain at least seven
+  days apart within and across months;
+- a day-of-month API anchor has `kind: day_of_month` and day `1..30`; a month-end
+  anchor has `kind: month_end` and null day. Persistence encodes month end as 31.
+
+All schedule variants have exclusive shapes: interval schedules cannot contain
+month anchors, and calendar schedules cannot contain an interval reference.
+Candidate confirmation must explicitly accept the exact detector schedule;
+changing it returns `400 candidate_schedule_mismatch`. Changing a durable
+schedule requires explicitly ending the old profile and creating/confirming a
+replacement. Updates may change only the display name, accepted windows, and
+amount. All lifecycle transitions, including reactivation, are explicit. There
+is no profile-delete API, automatic transition, or automatic evidence release.
+
+### Evidence, decisions, and concurrency
+
+Each `PaycheckOccurrence` stores one exact confirmation-evidence membership:
+profile/inflow IDs, consistent owner, evidence revision at assignment, slot
+anchor, timing offset, and link time. Composite foreign keys enforce owner
+consistency; a unique inflow index prevents assignment to a second profile.
+Occurrences do not imply employer verification, gross pay, taxes, deductions,
+payroll-document truth, or earned-income classification.
+
+Editing an assigned inflow keeps its assignment. The stored revision enables an
+`editedSinceConfirmation` flag without retaining duplicate financial snapshots
+or diagnosing a paycheck change. Deleting an inflow removes only its occurrence
+link, leaving the profile unchanged. Pausing or ending a profile retains its
+assignments. Candidate detection excludes claimed inflows before invoking the
+unchanged `paycheck-candidate-v1` detector. A later disjoint set of evidence may
+surface a new candidate, including for the same exact normalized description.
+There is no fuzzy matching or automatic attachment to an existing profile.
+
+Dismissal identity is owner + algorithm version + cadence + exact fingerprint.
+Reads partition current candidates into available/dismissed arrays without
+deleting obsolete decisions. Dismiss is idempotent for an existing exact row;
+otherwise it requires the current candidate. Reconsider removes only that exact
+owner decision and is idempotent even after the candidate changes.
+
+Confirmation recomputes owner-scoped candidates in a serializable transaction,
+checks the exact version/fingerprint and accepted schedule, rejects an exact
+dismissal, locks selected inflows in ascending ID order, and revalidates their
+revisions and assignment state. One profile and every candidate occurrence are
+written atomically. The unique owner/version/origin fingerprint makes a retry
+return the existing profile, even after later profile edits or evidence deletion.
+Conflicting confirmations cannot both claim an inflow; a loser returns the same
+winner for an identical origin or a stable conflict after rollback. Manual
+creation accepts no evidence IDs and creates no occurrences.
+
+### Authenticated API and projection contract
+
+Owner identity comes only from claims. Request and response DTOs expose no
+authoritative owner IDs. Candidate evidence contains current dates, descriptions,
+amounts, manual/imported source, and exact slot assignments; no evidence revision
+is exposed. Candidates sort by normalized identity and fingerprint ordinal;
+evidence sorts by posted date and inflow ID. Profiles sort by lifecycle rank
+(`active`, `paused`, `ended`), display name ordinal, then ID.
+
+| Route | Result |
+| --- | --- |
+| `GET /api/paycheck-candidates` | Evaluation date, available and dismissed candidates |
+| `POST /api/paycheck-candidates/dismiss` | Exact version/cadence/fingerprint dismissal; `204` |
+| `POST /api/paycheck-candidates/reconsider` | Exact decision removal; `204` |
+| `POST /api/paycheck-candidates/confirm` | Profile plus `alreadyConfirmed`; `201`, or `200` on retry |
+| `POST /api/paychecks` | Explicit active manual profile; `201` with item location |
+| `GET /api/paychecks` | One evaluation date and ordered profiles |
+| `GET /api/paychecks/{id}` | Current profile, evidence, and projection |
+| `PUT /api/paychecks/{id}` | Update display name, windows, and accepted amount |
+| `PATCH /api/paychecks/{id}/lifecycle` | Explicit active/paused/ended transition |
+
+Missing and foreign profile GET/PUT/PATCH operations return the same empty `404`.
+Validation returns privacy-safe `400` ProblemDetails with stable codes. Candidate
+staleness, dismissal, and conflicting confirmation return `409` without foreign
+owner disclosure. A failed database write during confirmation rolls back and
+returns a generic `500 confirmation_failed` without database details. Financial
+content, request bodies, and tokens are not logged.
+
+Only active profiles invoke the unchanged `paycheck-projector-v1`. The confirmed
+pattern maps directly from persisted schedule/windows/amount and the maximum
+slot anchor among currently linked occurrences, or null when no links remain.
+The response supplies algorithm version, one captured UTC evaluation date,
+anchor, earliest/latest expected dates, and accepted amount. Paused/ended
+profiles return null projection. These dates are **expected, not guaranteed**;
+there is no missed-pay diagnosis or amount/timing change detection. Writes whose
+projection window would exceed the representable calendar are rejected before
+persisting that state.
+
+The Stage 4 migration is additive and has no backfill. An ordinary application
+rollback leaves the added tables inert. Production schema readiness must precede
+application rollout; creating/testing this migration locally or in CI does not
+authorize production application. Down removes occurrence links before decision
+and profile tables and would destroy durable decisions. Production Down or data
+cleanup requires separate explicit authorization and a retention/export decision.
+
 ## Description invariant
 
 An expense description is required. At the authoritative write boundary it is
@@ -213,7 +327,7 @@ implementation must provide:
 The following remain for F1, F2, or later approved product work:
 
 - refund and reversal relationships beyond current direction-based treatment;
-- an income model;
+- a broader income model beyond the explicitly confirmed paycheck boundary;
 - merchant extraction;
 - provenance and raw descriptions;
 - parser versions;


### PR DESCRIPTION
## Summary

Paycheck candidates currently remain transient inflow evidence. This change lets users explicitly confirm a candidate or manually create a durable paycheck profile, then manage its accepted amount, timing windows, and lifecycle through authenticated APIs.

Closes #114. Implements the [approved Stage 4 plan](https://github.com/OL1V3S/ordo/issues/114#issuecomment-5543187435) under the [durable owner approval](https://github.com/OL1V3S/ordo/issues/114#issuecomment-5545891054). The broader design issue #108 remains open.

## Risk and implementation

**HIGH — approved financial-domain persistence and API work.**

- Add owner-scoped `PaycheckProfile`, `PaycheckOccurrence`, and exact-version/cadence/fingerprint dismissal persistence. Composite foreign keys enforce ownership; unique indexes enforce one inflow assignment and confirmation/dismissal idempotency.
- Add candidate read/dismiss/reconsider/confirm and manual profile create/list/get/update/lifecycle APIs with explicit owner-free DTOs, deterministic ordering, safe errors, and empty foreign/missing profile `404` responses.
- Confirm the current candidate atomically in a serializable transaction with ascending inflow locks, revision/assignment revalidation, and exact evidence membership. Concurrent identical confirmations return the same profile; conflicting evidence cannot be committed twice. Unexpected persistence failure rolls back and returns a generic error.
- Keep schedules immutable; require an explicit range for observed variable pay. Inflow edits retain assignments and expose revision mismatch; inflow deletion removes only its link. Paused/ended profiles retain evidence and suppress projection.
- Reuse the unchanged Stage 2 detector/projector. Active profile responses map the persisted expectation and latest remaining confirmed slot into an expected, non-guaranteed projection. Reject unrepresentable projection windows before profile writes.
- Document current paycheck boundaries in `ARCHITECTURE.md` and `docs/financial-domain-invariants.md`.

## Verification

### Local verification

- `./scripts/verify.sh backend` — restore/build succeeded; 455 of 457 tests passed, including all paycheck tests. Two unchanged PDF extraction tests failed locally: `Representative_pdf_extracts_ordered_pages` and `Generated_boundary_pdfs_flow_through_extractor_before_row_limit_enforcement`.
- One bounded focused retry of those two PDF tests — **2/2 passed**. The full Backend CI subsequently passed; the partial local run is not reported as a full pass.
- `./scripts/verify.sh postgresql` — **passed**: migration-chain verification (1/1) and PostgreSQL integration tests (40/40), including the nine new paycheck relational/concurrency tests.
- Migration/snapshot and generated Up/Down SQL review; changed documentation links and scoped diff checks — passed.

Calendar-overflow, privacy-safe database-failure, and regression tests protect the new boundary while preserving existing inflow behavior.

### Not run locally — capability unavailable

None for the applicable backend/PostgreSQL lanes. A disposable PostgreSQL 16 container is bound only to loopback; no hosted database was used. The initial sandbox blocked MSBuild IPC sockets, and the test commands were rerun with the required local execution permission.

### Required/proven by CI

- [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/33923627975/job/101187212713), including production container verification — **passed**.
- [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/33923627975/job/101187212969) — **passed**.
- [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/33923627949/job/101187212732) — **passed**.

All required CI succeeded on `847539dd025c63c5bcb295e1df03d8da9f756803`. Independent command-center review of the actual PR and final CI remains required. Local implementation checks are not self-approval.

## Migration and rollout boundary

One additive migration, `20260904213643_AddPaycheckProfiles`, creates the three tables and their constraints/indexes. No backfill or existing-table/data rewrite. The migration, snapshot, generated Up SQL, and Down ordering were reviewed; Down removes occurrences before dismissals/profiles and is destructive to durable paycheck decisions.

Application rollback leaves the additive schema inert. Production schema readiness must precede application rollout. This issue authorizes local/CI migration testing only: **no production migration, deployment, production access/data operation, or destructive rollback is authorized**.

## Scope and context

No frontend workflow, paycheck change detection, automatic credit classification, fuzzy/AI matching, background work, gross-pay/tax inference, budget behavior, dependency changes, or Stage 2 algorithm changes.

Started from current `main` at `f7795375a6b288acd9f53b52f73a610c0e01e0d9` on `codex/114-paycheck-profiles`; implementation commit `847539dd025c63c5bcb295e1df03d8da9f756803`. The previously authorized malformed-ref repair was already complete and a clean fetch succeeded.

Inspection covered the governing issues/approval, canonical architecture/invariants/verification docs, paycheck/inflow contracts, and exact Commitment/EF/test conventions needed for transaction, ownership, and verification behavior. It expanded to `docs/debugging.md` and the two failing PDF tests only to identify the unrelated local verification boundary; their implementation was not changed.
