### PR TITLE
Add Paychecks frontend workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,10 +26,15 @@ frontend does not connect directly to the database.
 `frontend/src/app/` owns routing, the authenticated application shell, and
 top-level pages. Product behavior is organized under `frontend/src/features/`
 by capability, including authentication, expenses, budget limits, analytics,
-transactions, and commitment review. The protected Commitments experience
+transactions, commitment review, and paychecks. The protected Commitments experience
 consumes the owner-scoped candidate and commitment APIs and keeps evidence
 review, confirmation, dismissal/reconsideration, expectation edits, and
-lifecycle controls inside `frontend/src/features/commitments/`. Shared HTTP,
+lifecycle controls inside `frontend/src/features/commitments/`. The protected
+Paychecks experience in `frontend/src/features/paychecks/` consumes the existing
+candidate/profile APIs for explicit confirmation, dismissal/reconsideration,
+manual expectations, allowed edits, and lifecycle changes. It displays the
+server's active-profile projection as expected, never guaranteed, and keeps
+candidate schedules and saved profile schedules immutable. Shared HTTP,
 constants, theme, UI, and utilities live under
 `frontend/src/shared/`; chart-specific presentation lives under
 `frontend/src/charts/`.
@@ -80,8 +85,9 @@ occurrences, and exact-fingerprint dismissals are persisted; candidate and
 projection results remain derived. Confirmation uses a serializable transaction,
 ordered inflow locks, owner-consistent foreign keys, and exclusive evidence
 assignment. The profile schedule is immutable, while accepted amounts, windows,
-display name, and lifecycle are explicitly editable. No Paychecks frontend or
-paycheck change detection is included. See the paycheck section of
+display name, and lifecycle are explicitly editable. The Paychecks frontend
+consumes these contracts without changing their semantics. Paycheck change
+detection is not included. See the paycheck section of
 [`docs/financial-domain-invariants.md`](docs/financial-domain-invariants.md).
 
 ### Authentication and ownership boundaries

--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -5,6 +5,7 @@ import TransactionsPage from "../features/transactions/pages/TransactionsPage";
 import BudgetsPage from "../features/budgetLimits/pages/BudgetsPage";
 import AnalyticsPage from "../features/analytics/pages/AnalyticsPage";
 import CommitmentsPage from "../features/commitments/pages/CommitmentsPage";
+import PaychecksPage from "../features/paychecks/pages/PaychecksPage";
 import AuthPage from "../features/auth/components/AuthPage";
 import ConfirmEmailPage from "../features/auth/components/ConfirmEmailPage";
 import ForgotPasswordPage from "../features/auth/components/ForgotPasswordPage";
@@ -50,6 +51,7 @@ export default function App() {
           <Route path="/budgets" element={<BudgetsPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/commitments" element={<CommitmentsPage />} />
+          <Route path="/paychecks" element={<PaychecksPage />} />
           <Route path="/investing" element={<InvestingPage />} />
           <Route path="/settings" element={<SettingsPage email={localStorage.getItem("email")} />} />
         </Route>

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -21,6 +21,10 @@ vi.mock('../features/commitments/pages/CommitmentsPage', () => ({
   default: () => <h1>Commitments workspace</h1>,
 }))
 
+vi.mock('../features/paychecks/pages/PaychecksPage', () => ({
+  default: () => <h1>Paychecks workspace</h1>,
+}))
+
 vi.mock('./pages/OverviewPage', () => ({
   default: () => <h1>Welcome back</h1>,
 }))
@@ -79,8 +83,8 @@ describe('application routes and shell', () => {
     expect(screen.getAllByText('ordo')).toHaveLength(2)
   })
 
-  it('redirects a protected route to authentication without a token', async () => {
-    renderAt('/transactions')
+  it.each(['/transactions', '/paychecks'])('redirects protected %s to authentication without a token', async (path) => {
+    renderAt(path)
     expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
     expect(screen.getByTestId('location')).toHaveTextContent('/')
   })
@@ -91,6 +95,7 @@ describe('application routes and shell', () => {
     ['/budgets', 'Budgets workspace'],
     ['/analytics', 'Analytics workspace'],
     ['/commitments', 'Commitments workspace'],
+    ['/paychecks', 'Paychecks workspace'],
     ['/investing', 'Investing'],
     ['/settings', 'Settings'],
   ])('supports direct authenticated navigation to %s', async (path, heading) => {
@@ -117,13 +122,24 @@ describe('application routes and shell', () => {
     expect(document.getElementById('main-content')).toHaveAttribute('id', 'main-content')
   })
 
-  it('exposes six primary destinations in mobile navigation and keeps Settings directly reachable', () => {
+  it('exposes seven primary destinations in mobile navigation and keeps Settings directly reachable', () => {
     localStorage.setItem('token', 'jwt-value')
     renderAt('/overview')
     const navigation = screen.getByRole('navigation', { name: 'Mobile navigation' })
     expect(navigation).toBeInTheDocument()
-    expect(navigation.querySelectorAll('a')).toHaveLength(6)
+    expect(navigation.querySelectorAll('a')).toHaveLength(7)
+    expect(within(navigation).getByRole('link', { name: 'Paychecks' })).toHaveAttribute('href', '/paychecks')
     expect(screen.getAllByRole('link', { name: /Settings/ })).toHaveLength(2)
+  })
+
+  it('opens Paychecks through normal navigation and marks both navigation entries current', async () => {
+    const user = userEvent.setup()
+    localStorage.setItem('token', 'jwt-value')
+    renderAt('/overview')
+    await user.click(within(screen.getByRole('navigation', { name: 'Primary navigation' })).getByRole('link', { name: /Paychecks/ }))
+    expect(await screen.findByRole('heading', { name: 'Paychecks workspace' })).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Paychecks/ })).toHaveLength(2)
+    screen.getAllByRole('link', { name: /Paychecks/ }).forEach((link) => expect(link).toHaveAttribute('aria-current', 'page'))
   })
 
   it('clears the existing auth keys and returns to authentication on logout', async () => {

--- a/frontend/src/app/navigation.js
+++ b/frontend/src/app/navigation.js
@@ -6,6 +6,7 @@ import {
   ReceiptText,
   Repeat2,
   Settings,
+  WalletCards,
 } from "lucide-react";
 
 export const APP_DESTINATIONS = [
@@ -14,6 +15,7 @@ export const APP_DESTINATIONS = [
   { to: "/budgets", label: "Budgets", icon: BarChart3 },
   { to: "/analytics", label: "Analytics", icon: ChartNoAxesCombined },
   { to: "/commitments", label: "Commitments", icon: Repeat2 },
+  { to: "/paychecks", label: "Paychecks", icon: WalletCards },
   { to: "/investing", label: "Investing", icon: Landmark },
   { to: "/settings", label: "Settings", icon: Settings },
 ];

--- a/frontend/src/features/paychecks/api/paychecksApi.js
+++ b/frontend/src/features/paychecks/api/paychecksApi.js
@@ -1,0 +1,13 @@
+import client from "../../../shared/api/client";
+
+export const paychecksApi = {
+  getCandidates: () => client.get("/api/paycheck-candidates"),
+  getPaychecks: () => client.get("/api/paychecks"),
+  getPaycheck: (id) => client.get(`/api/paychecks/${id}`),
+  confirmCandidate: (payload) => client.post("/api/paycheck-candidates/confirm", payload),
+  dismissCandidate: (tuple) => client.post("/api/paycheck-candidates/dismiss", tuple),
+  reconsiderCandidate: (tuple) => client.post("/api/paycheck-candidates/reconsider", tuple),
+  createPaycheck: (payload) => client.post("/api/paychecks", payload),
+  updatePaycheck: (id, payload) => client.put(`/api/paychecks/${id}`, payload),
+  updateLifecycle: (id, lifecycle) => client.patch(`/api/paychecks/${id}/lifecycle`, { lifecycle }),
+};

--- a/frontend/src/features/paychecks/api/paychecksApi.test.js
+++ b/frontend/src/features/paychecks/api/paychecksApi.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import client from "../../../shared/api/client";
+import { paychecksApi } from "./paychecksApi";
+
+vi.mock("../../../shared/api/client", () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn() },
+}));
+
+const schedule = {
+  cadence: "semimonthly", referenceAnchorDate: null,
+  firstMonthAnchor: { kind: "day_of_month", day: 15 },
+  secondMonthAnchor: { kind: "month_end", day: null },
+};
+const expectation = {
+  displayName: "Synthetic payroll", windowBeforeDays: 1, windowAfterDays: 2,
+  amount: { mode: "range", fixedAmount: null, minimumAmount: "900.01", maximumAmount: "1300.25" },
+};
+
+describe("paycheck API contracts", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("reads candidate lists, profile lists and an individual profile through the shared client", async () => {
+    const response = { data: { paychecks: [] } };
+    client.get.mockResolvedValue(response);
+    await paychecksApi.getCandidates();
+    await paychecksApi.getPaychecks();
+    expect(await paychecksApi.getPaycheck("profile-id")).toBe(response);
+    expect(client.get.mock.calls).toEqual([
+      ["/api/paycheck-candidates"], ["/api/paychecks"], ["/api/paychecks/profile-id"],
+    ]);
+  });
+
+  it("sends the exact candidate acceptance schedule and explicit accepted values unchanged", async () => {
+    const payload = { ...expectation, schedule, algorithmVersion: "paycheck-candidate-v1", fingerprint: "a".repeat(64) };
+    const response = { status: 200, data: { paycheck: { id: "existing" }, alreadyConfirmed: true } };
+    client.post.mockResolvedValue(response);
+    expect(await paychecksApi.confirmCandidate(payload)).toBe(response);
+    expect(client.post).toHaveBeenCalledWith("/api/paycheck-candidates/confirm", payload);
+    expect(client.post.mock.calls[0][1]).toBe(payload);
+  });
+
+  it("uses complete version/cadence/fingerprint tuples for both candidate decisions", async () => {
+    const tuple = { algorithmVersion: "paycheck-candidate-v1", cadence: "semimonthly", fingerprint: "b".repeat(64) };
+    await paychecksApi.dismissCandidate(tuple);
+    await paychecksApi.reconsiderCandidate(tuple);
+    expect(client.post.mock.calls).toEqual([
+      ["/api/paycheck-candidates/dismiss", tuple], ["/api/paycheck-candidates/reconsider", tuple],
+    ]);
+  });
+
+  it("creates complete manual profiles and updates only the supplied mutable expectation", async () => {
+    const manual = { ...expectation, schedule };
+    await paychecksApi.createPaycheck(manual);
+    await paychecksApi.updatePaycheck("profile-id", expectation);
+    expect(client.post).toHaveBeenCalledWith("/api/paychecks", manual);
+    expect(client.put).toHaveBeenCalledWith("/api/paychecks/profile-id", expectation);
+    expect(Object.keys(client.post.mock.calls[0][1]).sort()).toEqual(["amount", "displayName", "schedule", "windowAfterDays", "windowBeforeDays"]);
+    expect(Object.keys(client.put.mock.calls[0][1]).sort()).toEqual(["amount", "displayName", "windowAfterDays", "windowBeforeDays"]);
+  });
+
+  it.each(["active", "paused", "ended"])("patches the explicit %s lifecycle without other profile fields", async (lifecycle) => {
+    await paychecksApi.updateLifecycle("profile-id", lifecycle);
+    expect(client.patch).toHaveBeenCalledWith("/api/paychecks/profile-id/lifecycle", { lifecycle });
+  });
+
+  it("passes write failures to the caller without automatically retrying", async () => {
+    const error = new Error("synthetic connection failure");
+    client.post.mockRejectedValue(error);
+    await expect(paychecksApi.createPaycheck({ ...expectation, schedule })).rejects.toBe(error);
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(paychecksApi).not.toHaveProperty("deletePaycheck");
+  });
+});

--- a/frontend/src/features/paychecks/components/PaycheckEvidence.jsx
+++ b/frontend/src/features/paychecks/components/PaycheckEvidence.jsx
@@ -1,0 +1,24 @@
+import { formatDate, formatMoney } from "../utils/formatPaychecks";
+
+export default function PaycheckEvidence({ evidence = [], confirmed = false }) {
+  if (!evidence.length) return <p className="muted">No linked deposit evidence. This is your saved expectation.</p>;
+
+  return (
+    <details className="paycheck-evidence">
+      <summary>{confirmed ? "Linked deposit evidence" : "Review every deposit"} ({evidence.length})</summary>
+      <ul className="paycheck-evidence__list">
+        {evidence.map((row) => (
+          <li key={row.accountInflowId} className="paycheck-evidence__row">
+            <div>
+              <strong>{row.description}</strong>
+              <span><time dateTime={row.postedDate}>{formatDate(row.postedDate)}</time> · {row.source === "imported" ? "Imported deposit" : "Manual deposit"}</span>
+              <span>Schedule date {formatDate(row.slotAnchor)} · {row.timingOffsetDays === 0 ? "On schedule date" : `${Math.abs(row.timingOffsetDays)} day(s) ${row.timingOffsetDays < 0 ? "before" : "after"}`}</span>
+              {confirmed && row.editedSinceConfirmation && <span className="paycheck-evidence__edited">Edited since confirmation. The saved expectation is unchanged.</span>}
+            </div>
+            <strong>{formatMoney(row.amount)}</strong>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/frontend/src/features/paychecks/components/PaycheckForm.jsx
+++ b/frontend/src/features/paychecks/components/PaycheckForm.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useId, useRef, useState } from "react";
+import FormField from "../../../shared/ui/FormField";
+import { CADENCES, initialPaycheckForm, isUnsafeNumericAmount, validatePaycheckForm } from "../utils/paycheckForm";
+import { cadenceLabel, formatSchedule } from "../utils/formatPaychecks";
+
+export default function PaycheckForm({ mode, model, busy = false, submitDisabled = false, onSubmit, onCancel, formId }) {
+  const generatedId = useId();
+  const [form, setForm] = useState(() => initialPaycheckForm(mode, model));
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const formRef = useRef(null);
+  const pending = useRef(false);
+  const disabled = busy || submitting;
+  const variable = mode === "confirm" && model?.observedAmount?.mode === "variable";
+  const sourceAmount = mode === "confirm" ? model?.observedAmount : model?.amount;
+  const amountNeedsReview = Object.values(sourceAmount ?? {}).some(isUnsafeNumericAmount);
+  const submitLabel = { confirm: "Confirm paycheck", manual: "Create paycheck", edit: "Save changes" }[mode];
+
+  useEffect(() => { formRef.current?.querySelector("input")?.focus(); }, []);
+  useEffect(() => {
+    if (Object.keys(errors).length) formRef.current?.querySelector('[aria-invalid="true"]')?.focus();
+  }, [errors]);
+
+  function update(name, value) {
+    setForm((current) => {
+      const next = { ...current, [name]: value };
+      if (name === "cadence") Object.assign(next, { referenceAnchorDate: "", firstAnchorKind: "day_of_month",
+        firstAnchorDay: "", secondAnchorKind: "day_of_month", secondAnchorDay: "" });
+      if (name === "firstAnchorKind") next.firstAnchorDay = "";
+      if (name === "secondAnchorKind") next.secondAnchorDay = "";
+      if (name === "amountMode") Object.assign(next, { fixedAmount: "", minimumAmount: "", maximumAmount: "" });
+      return next;
+    });
+    setErrors({});
+    setSubmitError("");
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (disabled || submitDisabled || pending.current) return;
+    const result = validatePaycheckForm(form, mode, model);
+    setErrors(result.errors);
+    if (!result.payload) return;
+    pending.current = true;
+    setSubmitting(true);
+    setSubmitError("");
+    try { await onSubmit(result.payload); }
+    catch { setSubmitError("The action could not be completed. Check the page message before trying again."); }
+    finally { pending.current = false; setSubmitting(false); }
+  }
+
+  function field(name, label, options = {}) {
+    const { choices, ...inputProps } = options;
+    const errorId = `${generatedId}-${name}-error`;
+    return <div className="paycheck-form__field" key={name}><FormField label={label}>{(id) => <>
+      {choices ? <select id={id} value={form[name]} onChange={(event) => update(name, event.target.value)}
+        aria-invalid={Boolean(errors[name])} aria-describedby={errors[name] ? errorId : undefined}>
+        {choices.map(([value, text]) => <option key={value} value={value}>{text}</option>)}
+      </select> : <input id={id} value={form[name]} onChange={(event) => update(name, event.target.value)}
+        required aria-invalid={Boolean(errors[name])} aria-describedby={errors[name] ? errorId : undefined} {...inputProps} />}
+    </>}</FormField>{errors[name] && <span className="paycheck-form__error" id={errorId}>{errors[name]}</span>}</div>;
+  }
+
+  function anchorFields(prefix, label) {
+    return <>
+      {field(`${prefix}AnchorKind`, label, { choices: [["day_of_month", "Day of month"], ["month_end", "Month end"]] })}
+      {form[`${prefix}AnchorKind`] === "day_of_month" && field(`${prefix}AnchorDay`, `${label} day`, { inputMode: "numeric" })}
+    </>;
+  }
+
+  return <form id={formId ?? generatedId} ref={formRef} className="paycheck-form" aria-label={submitLabel}
+    aria-busy={disabled} onSubmit={handleSubmit} noValidate>
+    {mode === "manual" && <p className="paycheck-form__note">Create an active profile for your expected paycheck. This is your expectation and is not employer-verified.</p>}
+    {mode !== "manual" && <div className="paycheck-form__schedule">
+      <strong>Schedule</strong><p>{formatSchedule(model?.schedule)}</p>
+      <p>{mode === "confirm" ? "Review and accept this schedule unchanged. To use a different schedule, create a paycheck manually."
+        : "The schedule cannot be edited. End this profile and create a replacement to change its schedule. Evidence stays assigned to this profile."}</p>
+    </div>}
+    {variable && <p className="paycheck-form__note">Observed amounts vary. Enter the minimum and maximum you explicitly accept; observed bounds are not filled in.</p>}
+    {amountNeedsReview && <p className="paycheck-form__note">This amount could not be loaded with reliable cent precision. Enter the exact amount you accept before saving.</p>}
+    {Object.keys(errors).length > 0 && <p className="paycheck-form__error" role="alert">Check the highlighted fields.</p>}
+    {submitError && <p className="paycheck-form__error" role="alert">{submitError}</p>}
+    <fieldset className="paycheck-form__fields" disabled={disabled}>
+      <legend className="sr-only">Paycheck expectation</legend>
+      <div className="paycheck-form__grid">
+        {field("displayName", "Display name", { maxLength: 500 })}
+        {mode === "manual" && <>
+          {field("cadence", "Cadence", { choices: CADENCES.map((cadence) => [cadence, cadenceLabel(cadence)]) })}
+          {["weekly", "biweekly"].includes(form.cadence)
+            ? field("referenceAnchorDate", "Reference anchor date", { type: "date", min: "0001-01-01", max: "9999-12-31" })
+            : <>{anchorFields("first", form.cadence === "monthly" ? "Monthly anchor" : "First anchor")}
+              {form.cadence === "semimonthly" && anchorFields("second", "Second anchor")}</>}
+        </>}
+        {field("windowBeforeDays", "Days before", { inputMode: "numeric" })}
+        {field("windowAfterDays", "Days after", { inputMode: "numeric" })}
+        {field("amountMode", "Amount model", { choices: variable ? [["range", "Amount range"]]
+          : [["fixed", "Fixed amount"], ["range", "Amount range"]] })}
+        {form.amountMode === "fixed" ? field("fixedAmount", "Fixed amount", { inputMode: "decimal" }) : <>
+          {field("minimumAmount", "Minimum amount", { inputMode: "decimal" })}
+          {field("maximumAmount", "Maximum amount", { inputMode: "decimal" })}
+        </>}
+      </div>
+    </fieldset>
+    <div className="paycheck-form__actions inline-actions">
+      <button type="submit" disabled={disabled || submitDisabled}>{disabled ? "Saving…" : submitLabel}</button>
+      <button type="button" className="button-ghost" disabled={disabled} onClick={onCancel}>Cancel</button>
+    </div>
+  </form>;
+}

--- a/frontend/src/features/paychecks/components/PaycheckForm.test.jsx
+++ b/frontend/src/features/paychecks/components/PaycheckForm.test.jsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import PaycheckForm from "./PaycheckForm";
+import { makeCandidate, makePaycheck } from "../test/paycheckFixtures";
+
+describe("PaycheckForm", () => {
+  it("focuses the name, displays immutable candidate schedule and requires explicit submission", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const model = makeCandidate();
+    render(<PaycheckForm mode="confirm" model={model} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText("Display name")).toHaveFocus();
+    expect(screen.queryByLabelText("Cadence")).not.toBeInTheDocument();
+    expect(screen.getByText("Monthly, day 10")).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Confirm paycheck" }));
+    expect(onSubmit).toHaveBeenCalledWith({ displayName: "acme payroll", algorithmVersion: model.algorithmVersion,
+      fingerprint: model.fingerprint, schedule: model.schedule, windowBeforeDays: 1, windowAfterDays: 1,
+      amount: { mode: "fixed", fixedAmount: "2500", minimumAmount: null, maximumAmount: null } });
+  });
+
+  it("leaves variable acceptance blank, focuses described errors, and submits only explicit ranges", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PaycheckForm mode="confirm" model={makeCandidate({ observedAmount: { mode: "variable", minimumAmount: 2000, maximumAmount: 3000 } })} onSubmit={onSubmit} />);
+    expect(screen.getByLabelText("Minimum amount")).toHaveValue("");
+    expect(screen.getByLabelText("Maximum amount")).toHaveValue("");
+    expect(screen.queryByRole("option", { name: "Fixed amount" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Confirm paycheck" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    const minimum = screen.getByLabelText("Minimum amount");
+    expect(minimum).toHaveFocus();
+    expect(minimum).toHaveAttribute("aria-invalid", "true");
+    expect(minimum).toHaveAccessibleDescription(/positive amount/);
+    await user.type(minimum, "2100.01");
+    await user.type(screen.getByLabelText("Maximum amount"), "2900.99");
+    await user.click(screen.getByRole("button", { name: "Confirm paycheck" }));
+    expect(onSubmit.mock.calls[0][0].amount).toEqual({ mode: "range", fixedAmount: null, minimumAmount: "2100.01", maximumAmount: "2900.99" });
+  });
+
+  it("clears inactive schedule and amount fields and creates a complete manual profile", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PaycheckForm mode="manual" onSubmit={onSubmit} />);
+    await user.type(screen.getByLabelText("Display name"), "  New payroll  ");
+    await user.type(screen.getByLabelText("Monthly anchor day"), "10");
+    await user.type(screen.getByLabelText("Fixed amount"), "100");
+    await user.selectOptions(screen.getByLabelText("Cadence"), "biweekly");
+    fireEvent.change(screen.getByLabelText("Reference anchor date"), { target: { value: "2026-03-08" } });
+    await user.selectOptions(screen.getByLabelText("Amount model"), "range");
+    expect(screen.getByLabelText("Minimum amount")).toHaveValue("");
+    await user.type(screen.getByLabelText("Minimum amount"), "100.01");
+    await user.type(screen.getByLabelText("Maximum amount"), "100.02");
+    await user.click(screen.getByRole("button", { name: "Create paycheck" }));
+    expect(onSubmit).toHaveBeenCalledWith({ displayName: "New payroll", windowBeforeDays: 0, windowAfterDays: 0,
+      schedule: { cadence: "biweekly", referenceAnchorDate: "2026-03-08", firstMonthAnchor: null, secondMonthAnchor: null },
+      amount: { mode: "range", fixedAmount: null, minimumAmount: "100.01", maximumAmount: "100.02" } });
+  });
+
+  it("rejects invalid semimonthly spacing and decimal precision before submitting", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PaycheckForm mode="manual" onSubmit={onSubmit} />);
+    await user.type(screen.getByLabelText("Display name"), "Payroll");
+    await user.selectOptions(screen.getByLabelText("Cadence"), "semimonthly");
+    await user.type(screen.getByLabelText("First anchor day"), "1");
+    await user.selectOptions(screen.getByLabelText("Second anchor"), "month_end");
+    await user.type(screen.getByLabelText("Fixed amount"), "100.001");
+    await user.click(screen.getByRole("button", { name: "Create paycheck" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Second anchor")).toHaveFocus();
+    expect(screen.getByLabelText("Second anchor")).toHaveAccessibleDescription(/February/);
+    expect(screen.getByLabelText("Fixed amount")).toHaveValue("100.001");
+  });
+
+  it("sends restricted edits, prevents duplicate submits, and preserves drafts after failures", async () => {
+    const user = userEvent.setup();
+    let reject;
+    const onSubmit = vi.fn(() => new Promise((resolve, rejectPromise) => { reject = rejectPromise; }));
+    render(<PaycheckForm mode="edit" model={makePaycheck()} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    await user.clear(screen.getByLabelText("Display name"));
+    await user.type(screen.getByLabelText("Display name"), "Revised payroll");
+    const form = screen.getByRole("form", { name: "Save changes" });
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(Object.keys(onSubmit.mock.calls[0][0])).toEqual(["displayName", "windowBeforeDays", "windowAfterDays", "amount"]);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByLabelText("Fixed amount")).toBeDisabled();
+    reject(new Error("private response must not be shown"));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("The action could not be completed"));
+    expect(screen.getByLabelText("Display name")).toHaveValue("Revised payroll");
+    expect(screen.queryByText(/private response/)).not.toBeInTheDocument();
+  });
+
+  it("disables all controls when busy and delegates cancel without saving", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
+    const { rerender } = render(<PaycheckForm mode="edit" model={makePaycheck()} busy onSubmit={onSubmit} onCancel={onCancel} />);
+    expect(screen.getByLabelText("Display name")).toBeDisabled();
+    rerender(<PaycheckForm mode="edit" model={makePaycheck()} onSubmit={onSubmit} onCancel={onCancel} />);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("explains unsafe numeric amounts persistently instead of accepting rounded values", () => {
+    render(<PaycheckForm mode="edit" model={makePaycheck({ amount: { mode: "fixed", fixedAmount: 1e16 } })} onSubmit={vi.fn()} />);
+    expect(screen.getByLabelText("Fixed amount")).toHaveValue("");
+    expect(screen.getByText(/could not be loaded with reliable cent precision/)).toBeInTheDocument();
+  });
+
+  it("blocks uncertain resubmission while keeping cancel and draft inputs available", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
+    render(<PaycheckForm mode="edit" model={makePaycheck()} submitDisabled onSubmit={onSubmit} onCancel={onCancel} />);
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+    expect(screen.getByLabelText("Display name")).not.toBeDisabled();
+    fireEvent.submit(screen.getByRole("form", { name: "Save changes" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/features/paychecks/hooks/usePaychecks.js
+++ b/frontend/src/features/paychecks/hooks/usePaychecks.js
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { paychecksApi } from "../api/paychecksApi";
+
+const ERROR_MESSAGES = {
+  authentication_required: "Your session has expired. Sign in again to manage paychecks.",
+  paycheck_not_found: "That paycheck is no longer available. Review the current profiles.",
+  candidate_changed: "This candidate changed or is no longer available. Review the latest evidence before trying again.",
+  candidate_dismissed: "This candidate was dismissed. Reconsider it before confirming.",
+  confirmation_conflict: "The evidence changed during confirmation. Review the latest evidence before trying again.",
+  candidate_schedule_mismatch: "The candidate schedule cannot be changed. Review it again or create a manual paycheck.",
+  fingerprint_invalid: "This candidate can no longer be reviewed. Refresh the candidates.",
+  algorithm_version_invalid: "This candidate version is invalid. Refresh the candidates.",
+  name_invalid: "Enter a nonblank paycheck name of 500 characters or fewer.",
+  cadence_invalid: "Choose a valid paycheck cadence.",
+  schedule_invalid: "Enter a complete, valid paycheck schedule.",
+  timing_invalid: "Enter whole timing windows from zero to three days.",
+  amount_invalid: "Enter a positive fixed amount or increasing range, with at most two decimal places.",
+  lifecycle_invalid: "Choose active, paused, or ended.",
+  request_invalid: "Check the form fields and try again.",
+  request_failed: "The request could not be completed. Try again.",
+};
+const REFRESH_ERRORS = new Set(["candidate_changed", "candidate_dismissed", "confirmation_conflict", "paycheck_not_found"]);
+const UNCERTAIN_CREATE_MESSAGE = "We could not confirm whether the paycheck was created. Refresh and check the saved profiles before intentionally trying again.";
+const UNCERTAIN_WRITE_MESSAGE = "We could not confirm the outcome of this action. Refresh and check the current state before trying again.";
+
+function errorCode(error) {
+  if (error?.response?.status === 401) return "authentication_required";
+  if (error?.response?.status === 404) return "paycheck_not_found";
+  const code = error?.response?.data?.code;
+  return Object.hasOwn(ERROR_MESSAGES, code) ? code : "request_failed";
+}
+
+export function getPaycheckErrorMessage(error) {
+  return ERROR_MESSAGES[errorCode(error)];
+}
+
+export function usePaychecks() {
+  const [candidates, setCandidates] = useState([]);
+  const [dismissedCandidates, setDismissedCandidates] = useState([]);
+  const [paychecks, setPaychecks] = useState([]);
+  const [candidatesEvaluatedOn, setCandidatesEvaluatedOn] = useState(null);
+  const [paychecksEvaluatedOn, setPaychecksEvaluatedOn] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadError, setLoadError] = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const [notice, setNotice] = useState(null);
+  const [busyKey, setBusyKey] = useState(null);
+  const [uncertainCreate, setUncertainCreate] = useState(false);
+  const mounted = useRef(false);
+  const lifetime = useRef(0);
+  const readId = useRef(0);
+  const initialSettled = useRef(false);
+  const busyRef = useRef(null);
+  const uncertainCreateRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (!mounted.current) return false;
+    const id = ++readId.current;
+    const current = () => mounted.current && id === readId.current;
+    if (initialSettled.current) setRefreshing(true);
+    else setLoading(true);
+    setLoadError(null);
+    try {
+      const [candidateResponse, paycheckResponse] = await Promise.all([
+        paychecksApi.getCandidates(), paychecksApi.getPaychecks(),
+      ]);
+      if (!current()) return false;
+      setCandidates(candidateResponse.data.candidates);
+      setDismissedCandidates(candidateResponse.data.dismissedCandidates);
+      setCandidatesEvaluatedOn(candidateResponse.data.evaluatedOn);
+      setPaychecks(paycheckResponse.data.paychecks);
+      setPaychecksEvaluatedOn(paycheckResponse.data.evaluatedOn);
+      if (uncertainCreateRef.current) {
+        uncertainCreateRef.current = false;
+        setUncertainCreate(false);
+        setActionError((previous) => previous === UNCERTAIN_CREATE_MESSAGE ? null : previous);
+        setNotice("Paychecks loaded. Check the saved profiles before intentionally trying to create another paycheck.");
+      }
+      return true;
+    } catch (error) {
+      if (current()) setLoadError(errorCode(error) === "authentication_required"
+        ? ERROR_MESSAGES.authentication_required
+        : "Paychecks could not be loaded. Refresh to try again; the displayed information may be out of date.");
+      return false;
+    } finally {
+      if (current()) {
+        initialSettled.current = true;
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    load();
+    return () => {
+      mounted.current = false;
+      lifetime.current += 1;
+      readId.current += 1;
+    };
+  }, [load]);
+
+  const refresh = useCallback(() => busyRef.current ? Promise.resolve(false) : load(), [load]);
+
+  const perform = useCallback(async (key, operation, successMessage, manualCreate = false) => {
+    if (!mounted.current) return { ok: false, code: "unmounted" };
+    if (busyRef.current) return { ok: false, code: "busy" };
+    if (!initialSettled.current) return { ok: false, code: "loading" };
+    if (manualCreate && uncertainCreateRef.current)
+      return { ok: false, code: "creation_uncertain", uncertain: true };
+    const epoch = lifetime.current;
+    const current = () => mounted.current && lifetime.current === epoch;
+    busyRef.current = key;
+    // A read started before this mutation must not overwrite its subsequent refresh.
+    readId.current += 1;
+    setRefreshing(false);
+    setBusyKey(key);
+    if (!uncertainCreateRef.current) setActionError(null);
+    setNotice(null);
+    try {
+      const response = await operation();
+      if (!current()) return { ok: true, data: response.data, refreshOk: false };
+      setNotice(successMessage);
+      // A known successful write remains successful even if the following read fails.
+      const refreshOk = await load();
+      return { ok: true, data: response.data, refreshOk };
+    } catch (error) {
+      if (!current()) return { ok: false, code: "unmounted" };
+      const uncertain = !error?.response || error.response.status >= 500;
+      if (uncertain) {
+        if (manualCreate) {
+          uncertainCreateRef.current = true;
+          setUncertainCreate(true);
+        }
+        setActionError(manualCreate ? UNCERTAIN_CREATE_MESSAGE : UNCERTAIN_WRITE_MESSAGE);
+        return { ok: false, code: manualCreate ? "creation_uncertain" : "write_uncertain", uncertain: true };
+      }
+      const code = errorCode(error);
+      setActionError(ERROR_MESSAGES[code]);
+      if (REFRESH_ERRORS.has(code) || error.response.status === 409) {
+        const refreshOk = await load();
+        return { ok: false, code, refreshOk };
+      }
+      return { ok: false, code };
+    } finally {
+      if (current()) {
+        busyRef.current = null;
+        setBusyKey(null);
+      }
+    }
+  }, [load]);
+
+  const clearMessages = useCallback(() => {
+    if (!mounted.current) return;
+    setActionError(uncertainCreateRef.current ? UNCERTAIN_CREATE_MESSAGE : null);
+    setNotice(null);
+  }, []);
+
+  const acknowledgeUncertainCreate = useCallback(() => {
+    if (!mounted.current || busyRef.current) return;
+    uncertainCreateRef.current = false;
+    setUncertainCreate(false);
+    setActionError(null);
+  }, []);
+
+  return {
+    candidates, dismissedCandidates, paychecks, candidatesEvaluatedOn, paychecksEvaluatedOn,
+    loading, refreshing, loadError, actionError, notice, busyKey, uncertainCreate,
+    refresh, clearMessages, acknowledgeUncertainCreate,
+    confirmCandidate: (payload) => perform(`confirm:${payload.fingerprint}`,
+      () => paychecksApi.confirmCandidate(payload), "Paycheck confirmed."),
+    dismissCandidate: (tuple) => perform(`dismiss:${tuple.fingerprint}`,
+      () => paychecksApi.dismissCandidate(tuple), "Candidate dismissed. You can reconsider it below."),
+    reconsiderCandidate: (tuple) => perform(`reconsider:${tuple.fingerprint}`,
+      () => paychecksApi.reconsiderCandidate(tuple), "Candidate reconsidered."),
+    createPaycheck: (payload) => perform("create", () => paychecksApi.createPaycheck(payload), "Paycheck created.", true),
+    updatePaycheck: (id, payload) => perform(`update:${id}`,
+      () => paychecksApi.updatePaycheck(id, payload), "Paycheck updated."),
+    updateLifecycle: (id, lifecycle) => perform(`lifecycle:${id}`,
+      () => paychecksApi.updateLifecycle(id, lifecycle), "Paycheck status updated."),
+  };
+}

--- a/frontend/src/features/paychecks/hooks/usePaychecks.test.js
+++ b/frontend/src/features/paychecks/hooks/usePaychecks.test.js
@@ -1,0 +1,298 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { paychecksApi } from "../api/paychecksApi";
+import { getPaycheckErrorMessage, usePaychecks } from "./usePaychecks";
+
+vi.mock("../api/paychecksApi", () => ({ paychecksApi: {
+  getCandidates: vi.fn(), getPaychecks: vi.fn(), getPaycheck: vi.fn(), confirmCandidate: vi.fn(),
+  dismissCandidate: vi.fn(), reconsiderCandidate: vi.fn(), createPaycheck: vi.fn(),
+  updatePaycheck: vi.fn(), updateLifecycle: vi.fn(),
+} }));
+
+const candidateData = {
+  evaluatedOn: "2026-09-05", candidates: [{ fingerprint: "z" }, { fingerprint: "a" }],
+  dismissedCandidates: [{ fingerprint: "dismissed" }],
+};
+const profileData = { evaluatedOn: "2026-09-06", paychecks: [{ id: "z" }, { id: "a" }] };
+const tuple = { algorithmVersion: "paycheck-candidate-v1", cadence: "monthly", fingerprint: "z" };
+const payload = { displayName: "Synthetic paycheck", ...tuple };
+const serverError = (status, code) => ({ response: { status, data: { code, detail: "PRIVATE SERVER DATA" } } });
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+async function ready() {
+  const hook = renderHook(() => usePaychecks());
+  await waitFor(() => expect(hook.result.current.loading).toBe(false));
+  return hook;
+}
+
+describe("paycheck state", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    paychecksApi.getCandidates.mockResolvedValue({ data: candidateData });
+    paychecksApi.getPaychecks.mockResolvedValue({ data: profileData });
+    for (const method of ["confirmCandidate", "dismissCandidate", "reconsiderCandidate", "createPaycheck", "updatePaycheck", "updateLifecycle"])
+      paychecksApi[method].mockResolvedValue({ data: { id: "saved" } });
+  });
+
+  it("loads both resource envelopes, preserves server order and keeps their distinct evaluation dates", async () => {
+    const { result } = await ready();
+    expect(result.current.candidates).toEqual(candidateData.candidates);
+    expect(result.current.dismissedCandidates).toEqual(candidateData.dismissedCandidates);
+    expect(result.current.paychecks).toEqual(profileData.paychecks);
+    expect(result.current.candidatesEvaluatedOn).toBe("2026-09-05");
+    expect(result.current.paychecksEvaluatedOn).toBe("2026-09-06");
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it.each([
+    [[], [], []], [[{ fingerprint: "x" }], [], []], [[], [{ fingerprint: "x" }], []], [[], [], [{ id: "x" }]],
+  ])("retains empty combinations independently", async (candidates, dismissedCandidates, paychecks) => {
+    paychecksApi.getCandidates.mockResolvedValue({ data: { evaluatedOn: "2026-09-05", candidates, dismissedCandidates } });
+    paychecksApi.getPaychecks.mockResolvedValue({ data: { evaluatedOn: "2026-09-05", paychecks } });
+    const { result } = await ready();
+    expect([result.current.candidates, result.current.dismissedCandidates, result.current.paychecks]).toEqual([candidates, dismissedCandidates, paychecks]);
+  });
+
+  it("distinguishes initial loading from read-only refreshing and keeps rendered data during refresh", async () => {
+    const { result } = await ready();
+    const next = deferred();
+    paychecksApi.getCandidates.mockReturnValueOnce(next.promise);
+    let refresh;
+    act(() => { refresh = result.current.refresh(); });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.candidates).toEqual(candidateData.candidates);
+    await act(async () => { next.resolve({ data: { ...candidateData, candidates: [] } }); await refresh; });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.candidates).toEqual([]);
+  });
+
+  it("exposes a persistent safe initial failure and supports a read-only retry", async () => {
+    paychecksApi.getCandidates.mockRejectedValueOnce(serverError(500, "private"));
+    const { result } = await ready();
+    expect(result.current.loadError).toContain("could not be loaded");
+    expect(result.current.loadError).not.toContain("PRIVATE");
+    let refreshed;
+    await act(async () => { refreshed = await result.current.refresh(); });
+    expect(refreshed).toBe(true);
+    expect(result.current.loadError).toBeNull();
+    expect(paychecksApi.createPaycheck).not.toHaveBeenCalled();
+  });
+
+  it("retains both previous resources when either refresh fails", async () => {
+    const { result } = await ready();
+    paychecksApi.getCandidates.mockResolvedValueOnce({ data: { ...candidateData, candidates: [] } });
+    paychecksApi.getPaychecks.mockRejectedValueOnce(new Error("network"));
+    await act(() => result.current.refresh());
+    expect(result.current.candidates).toEqual(candidateData.candidates);
+    expect(result.current.paychecks).toEqual(profileData.paychecks);
+    expect(result.current.loadError).toContain("out of date");
+  });
+
+  it("ignores older successful and failed reads when a newer refresh wins", async () => {
+    const { result } = await ready();
+    const old = deferred();
+    paychecksApi.getCandidates.mockReturnValueOnce(old.promise);
+    let first;
+    act(() => { first = result.current.refresh(); });
+    paychecksApi.getCandidates.mockResolvedValueOnce({ data: { ...candidateData, candidates: [{ fingerprint: "new" }] } });
+    await act(() => result.current.refresh());
+    await act(async () => { old.resolve({ data: { ...candidateData, candidates: [] } }); expect(await first).toBe(false); });
+    expect(result.current.candidates).toEqual([{ fingerprint: "new" }]);
+    const failed = deferred();
+    paychecksApi.getCandidates.mockReturnValueOnce(failed.promise);
+    act(() => { first = result.current.refresh(); });
+    await act(() => result.current.refresh());
+    await act(async () => { failed.reject(serverError(401)); await first; });
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it.each([
+    ["confirmCandidate", [payload]], ["dismissCandidate", [tuple]], ["reconsiderCandidate", [tuple]],
+    ["createPaycheck", [payload]], ["updatePaycheck", ["profile", payload]], ["updateLifecycle", ["profile", "ended"]],
+  ])("%s returns a structured success and refreshes both resources", async (method, args) => {
+    const { result } = await ready();
+    let outcome;
+    await act(async () => { outcome = await result.current[method](...args); });
+    expect(paychecksApi[method]).toHaveBeenCalledWith(...args);
+    expect(outcome).toEqual({ ok: true, data: { id: "saved" }, refreshOk: true });
+    expect(paychecksApi.getCandidates).toHaveBeenCalledTimes(2);
+    expect(paychecksApi.getPaychecks).toHaveBeenCalledTimes(2);
+    expect(result.current.busyKey).toBeNull();
+    expect(result.current.notice).toBeTruthy();
+  });
+
+  it("accepts an idempotent confirmation200 as success", async () => {
+    const data = { paycheck: { id: "existing" }, alreadyConfirmed: true };
+    paychecksApi.confirmCandidate.mockResolvedValueOnce({ status: 200, data });
+    const { result } = await ready();
+    let outcome;
+    await act(async () => { outcome = await result.current.confirmCandidate(payload); });
+    expect(outcome).toEqual({ ok: true, data, refreshOk: true });
+    expect(result.current.notice).toBe("Paycheck confirmed.");
+  });
+
+  it("guards duplicate and conflicting actions immediately, including during their refresh", async () => {
+    const write = deferred();
+    const refreshRead = deferred();
+    paychecksApi.createPaycheck.mockReturnValueOnce(write.promise);
+    const { result } = await ready();
+    paychecksApi.getCandidates.mockReturnValueOnce(refreshRead.promise);
+    let first, second;
+    act(() => {
+      first = result.current.createPaycheck(payload);
+      second = result.current.updateLifecycle("profile", "ended");
+    });
+    expect(await second).toEqual({ ok: false, code: "busy" });
+    expect(result.current.busyKey).toBe("create");
+    await act(async () => { write.resolve({ data: { id: "saved" } }); await Promise.resolve(); });
+    expect(result.current.busyKey).toBe("create");
+    expect(await result.current.refresh()).toBe(false);
+    expect(await result.current.createPaycheck(payload)).toEqual({ ok: false, code: "busy" });
+    await act(async () => { refreshRead.resolve({ data: candidateData }); await first; });
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
+    expect(paychecksApi.updateLifecycle).not.toHaveBeenCalled();
+  });
+
+  it("invalidates a pre-mutation read so it cannot replace state refreshed after the write", async () => {
+    const { result } = await ready();
+    const stale = deferred();
+    paychecksApi.getCandidates.mockReturnValueOnce(stale.promise);
+    let oldRead;
+    act(() => { oldRead = result.current.refresh(); });
+    paychecksApi.getCandidates.mockResolvedValueOnce({ data: { ...candidateData, candidates: [] } });
+    await act(() => result.current.dismissCandidate(tuple));
+    await act(async () => { stale.resolve({ data: candidateData }); await oldRead; });
+    expect(result.current.candidates).toEqual([]);
+  });
+
+  it("keeps known creation success when refresh fails, without retrying or reporting a failed write", async () => {
+    const { result } = await ready();
+    paychecksApi.getPaychecks.mockRejectedValueOnce(new Error("network"));
+    let outcome;
+    await act(async () => { outcome = await result.current.createPaycheck(payload); });
+    expect(outcome).toEqual({ ok: true, data: { id: "saved" }, refreshOk: false });
+    expect(result.current.notice).toBe("Paycheck created.");
+    expect(result.current.actionError).toBeNull();
+    expect(result.current.loadError).toContain("could not be loaded");
+    expect(result.current.uncertainCreate).toBe(false);
+    act(() => result.current.clearMessages());
+    expect(result.current.loadError).toBeTruthy();
+    await act(() => result.current.refresh());
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["candidate_changed", "candidate_dismissed", "confirmation_conflict"])("refreshes %s conflicts without claiming an unsuccessful refresh succeeded", async (code) => {
+    const { result } = await ready();
+    paychecksApi.confirmCandidate.mockRejectedValueOnce(serverError(409, code));
+    paychecksApi.getCandidates.mockRejectedValueOnce(new Error("network"));
+    let outcome;
+    await act(async () => { outcome = await result.current.confirmCandidate(payload); });
+    expect(outcome).toEqual({ ok: false, code, refreshOk: false });
+    expect(result.current.actionError).toBe(getPaycheckErrorMessage(serverError(409, code)));
+    expect(result.current.actionError).not.toMatch(/has been loaded|refreshed|PRIVATE/);
+    expect(result.current.loadError).toBeTruthy();
+    expect(result.current.notice).toBeNull();
+    expect(paychecksApi.confirmCandidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps empty404 to unavailable and401 to expired session without leaking server text", async () => {
+    const { result } = await ready();
+    paychecksApi.updatePaycheck.mockRejectedValueOnce({ response: { status: 404, data: "" } });
+    let outcome;
+    await act(async () => { outcome = await result.current.updatePaycheck("missing", payload); });
+    expect(outcome.code).toBe("paycheck_not_found");
+    expect(result.current.actionError).toContain("no longer available");
+    paychecksApi.updateLifecycle.mockRejectedValueOnce(serverError(401, "private"));
+    await act(() => result.current.updateLifecycle("profile", "active"));
+    expect(result.current.actionError).toContain("Sign in again");
+    paychecksApi.getCandidates.mockRejectedValueOnce(serverError(401));
+    await act(() => result.current.refresh());
+    expect(result.current.loadError).toContain("Sign in again");
+  });
+
+  it("keeps correctable validation failures separate from uncertain writes", async () => {
+    const { result } = await ready();
+    paychecksApi.createPaycheck.mockRejectedValueOnce(serverError(400, "amount_invalid"));
+    let outcome;
+    await act(async () => { outcome = await result.current.createPaycheck(payload); });
+    expect(outcome).toEqual({ ok: false, code: "amount_invalid" });
+    expect(result.current.uncertainCreate).toBe(false);
+    expect(result.current.actionError).toContain("positive fixed amount");
+    expect(paychecksApi.getPaychecks).toHaveBeenCalledTimes(1);
+    expect(getPaycheckErrorMessage(serverError(400, "__proto__"))).toBe("The request could not be completed. Try again.");
+  });
+
+  it.each([new Error("network timeout"), serverError(502, "private")])("blocks immediate manual retry after an uncertain response until a successful refresh", async (error) => {
+    const { result } = await ready();
+    paychecksApi.createPaycheck.mockRejectedValueOnce(error);
+    let outcome;
+    await act(async () => { outcome = await result.current.createPaycheck(payload); });
+    expect(outcome).toEqual({ ok: false, code: "creation_uncertain", uncertain: true });
+    expect(result.current.uncertainCreate).toBe(true);
+    expect(result.current.actionError).toContain("check the saved profiles");
+    act(() => result.current.clearMessages());
+    expect(result.current.actionError).toContain("could not confirm");
+    expect(await result.current.createPaycheck(payload)).toEqual(outcome);
+    paychecksApi.getPaychecks.mockRejectedValueOnce(new Error("still offline"));
+    await act(() => result.current.refresh());
+    expect(result.current.uncertainCreate).toBe(true);
+    await act(() => result.current.refresh());
+    expect(result.current.uncertainCreate).toBe(false);
+    expect(result.current.notice).toContain("Check the saved profiles");
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("permits only an explicit retry after uncertainty acknowledgement", async () => {
+    const { result } = await ready();
+    paychecksApi.createPaycheck.mockRejectedValueOnce(new Error("offline"));
+    await act(() => result.current.createPaycheck(payload));
+    act(() => result.current.acknowledgeUncertainCreate());
+    expect(result.current.uncertainCreate).toBe(false);
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
+    await act(() => result.current.createPaycheck(payload));
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(2);
+  });
+
+  it("explains unknown outcomes of other writes without automatically retrying", async () => {
+    const { result } = await ready();
+    paychecksApi.updateLifecycle.mockRejectedValueOnce(new Error("offline"));
+    let outcome;
+    await act(async () => { outcome = await result.current.updateLifecycle("profile", "ended"); });
+    expect(outcome).toEqual({ ok: false, code: "write_uncertain", uncertain: true });
+    expect(result.current.actionError).toContain("Refresh and check");
+    expect(result.current.uncertainCreate).toBe(false);
+    expect(paychecksApi.updateLifecycle).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores read completions after unmount and prevents later imperative actions", async () => {
+    const read = deferred();
+    paychecksApi.getCandidates.mockReturnValueOnce(read.promise);
+    const { result, unmount } = renderHook(() => usePaychecks());
+    const actions = result.current;
+    unmount();
+    await act(async () => { read.resolve({ data: candidateData }); await Promise.resolve(); });
+    expect(await actions.refresh()).toBe(false);
+    expect(await actions.createPaycheck(payload)).toEqual({ ok: false, code: "unmounted" });
+    expect(paychecksApi.createPaycheck).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("does not start a refresh after a write completes on an unmounted hook (success=%s)", async (success) => {
+    const write = deferred();
+    const { result, unmount } = await ready();
+    paychecksApi.createPaycheck.mockReturnValueOnce(write.promise);
+    let pending;
+    act(() => { pending = result.current.createPaycheck(payload); });
+    unmount();
+    await act(async () => {
+      if (success) write.resolve({ data: { id: "saved" } });
+      else write.reject(new Error("offline"));
+      await pending;
+    });
+    expect(paychecksApi.getCandidates).toHaveBeenCalledTimes(1);
+    expect(paychecksApi.getPaychecks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/paychecks/pages/PaychecksPage.jsx
+++ b/frontend/src/features/paychecks/pages/PaychecksPage.jsx
@@ -1,0 +1,253 @@
+import { useEffect, useRef, useState } from "react";
+import { Plus, WalletCards } from "lucide-react";
+import Card from "../../../shared/ui/Card";
+import StatusMessage from "../../../shared/ui/StatusMessage";
+import PaycheckEvidence from "../components/PaycheckEvidence";
+import PaycheckForm from "../components/PaycheckForm";
+import { usePaychecks } from "../hooks/usePaychecks";
+import { formatAmount, formatDate, formatMoney, formatSchedule, formatWindow } from "../utils/formatPaychecks";
+
+const LIFECYCLES = ["active", "paused", "ended"];
+const LIFECYCLE_LABELS = { active: "Active", paused: "Paused", ended: "Ended" };
+const STALE_CODES = new Set(["candidate_changed", "candidate_dismissed", "confirmation_conflict", "paycheck_not_found"]);
+
+function CandidateCard({ candidate, dismissed, busy, editor, onReview, onCancel, onConfirm, onDecision }) {
+  const name = candidate.normalizedDescriptionIdentity;
+  const reviewing = editor?.mode === "confirm" && editor.key === candidate.fingerprint;
+  const observed = candidate.observedAmount;
+  return (
+    <Card as="article" className="paycheck-card">
+      <header className="paycheck-card__header">
+        <div>
+          <p className="paycheck-eyebrow">{dismissed ? "Dismissed candidate" : "Possible paycheck"}</p>
+          <h3>{name}</h3>
+          <p className="muted">{formatSchedule(candidate.schedule)}</p>
+        </div>
+        <div className="paycheck-card__amount">
+          <span>Observed deposits</span>
+          <strong>{observed.mode === "fixed" ? formatMoney(observed.fixedAmount) : `${formatMoney(observed.minimumAmount)}–${formatMoney(observed.maximumAmount)}`}</strong>
+        </div>
+      </header>
+      <dl className="paycheck-facts">
+        <div><dt>Evidence</dt><dd>{candidate.occurrenceCount} deposits · {formatDate(candidate.coveredFrom)}–{formatDate(candidate.coveredTo)}</dd></div>
+        <div><dt>Observed timing</dt><dd>{formatWindow(candidate.windowBeforeDays, candidate.windowAfterDays)}</dd></div>
+        <div><dt>Observed amounts</dt><dd>{observed.mode === "fixed" ? "The same amount in each deposit" : `Variable · lower median ${formatMoney(observed.lowerMedianAmount)}. This history is not an accepted range.`}</dd></div>
+      </dl>
+      <PaycheckEvidence evidence={candidate.evidence} />
+      {reviewing ? (
+        <PaycheckForm key={candidate.fingerprint} mode="confirm" model={editor.model} busy={busy} onSubmit={onConfirm} onCancel={onCancel} />
+      ) : (
+        <div className="inline-actions paycheck-actions">
+          {dismissed ? (
+            <button type="button" disabled={busy} onClick={() => onDecision(candidate, true)} aria-label={`Reconsider ${name}`}>Reconsider</button>
+          ) : (
+            <>
+              <button type="button" disabled={busy} onClick={(event) => onReview(candidate, event.currentTarget)} aria-label={`Review and confirm ${name}`}>Review and confirm</button>
+              <button type="button" className="button-ghost" disabled={busy} onClick={() => onDecision(candidate, false)} aria-label={`Dismiss ${name}`}>Dismiss</button>
+            </>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ProfileCard({ profile, busy, editor, onEdit, onCancel, onSave, onLifecycle }) {
+  const [ending, setEnding] = useState(false);
+  const endTrigger = useRef(null);
+  const endConfirm = useRef(null);
+  const editing = editor?.mode === "edit" && editor.key === profile.id;
+  const projection = profile.lifecycle === "active" ? profile.nextProjection : null;
+
+  useEffect(() => {
+    if (ending) endConfirm.current?.focus();
+  }, [ending]);
+
+  async function end() {
+    const result = await onLifecycle(profile.id, "ended");
+    if (result?.ok) setEnding(false);
+  }
+
+  return (
+    <Card as="article" className={`paycheck-card paycheck-card--${profile.lifecycle}`}>
+      <header className="paycheck-card__header">
+        <div>
+          <p className="paycheck-eyebrow">{LIFECYCLE_LABELS[profile.lifecycle]} · {profile.source === "manual" ? "Entered by you" : "Confirmed from deposits"}</p>
+          <h3>{profile.displayName}</h3>
+          <p className="muted">{formatSchedule(profile.schedule)}</p>
+        </div>
+        <div className="paycheck-card__amount"><span>Accepted expectation</span><strong>{formatAmount(profile.amount)}</strong></div>
+      </header>
+      {projection ? (
+        <div className="paycheck-projection">
+          <p className="paycheck-eyebrow">Next expected paycheck</p>
+          <p className="paycheck-projection__date">{formatDate(projection.earliestExpectedDate)}{projection.earliestExpectedDate !== projection.latestExpectedDate && `–${formatDate(projection.latestExpectedDate)}`}</p>
+          <p>{formatAmount(projection.amount)} · schedule date {formatDate(projection.anchor)}</p>
+          <p className="muted">Expected based on your confirmed pattern; payment is not guaranteed. Evaluated {formatDate(projection.evaluatedOn)}.</p>
+        </div>
+      ) : (
+        <p className="paycheck-inactive">{profile.lifecycle === "active" ? "No expected projection is available." : `${LIFECYCLE_LABELS[profile.lifecycle]} profiles have no active payment projection.`}</p>
+      )}
+      <dl className="paycheck-facts">
+        <div><dt>Accepted timing window</dt><dd>{formatWindow(profile.windowBeforeDays, profile.windowAfterDays)}</dd></div>
+        <div><dt>Confirmation evidence</dt><dd>{profile.evidence.length} linked deposit(s)</dd></div>
+      </dl>
+      <PaycheckEvidence evidence={profile.evidence} confirmed />
+      {editing ? (
+        <PaycheckForm key={profile.id} mode="edit" model={editor.model} busy={busy} onSubmit={(payload) => onSave(profile.id, payload)} onCancel={onCancel} />
+      ) : (
+        <>
+          <p className="muted paycheck-schedule-note">To change this schedule, end this profile and create or confirm a replacement. Linked evidence stays with this profile.</p>
+          {ending ? (
+            <div className="paycheck-end-confirmation" role="group" aria-label={`End ${profile.displayName}`}>
+              <p>End {profile.displayName}? Its projection will stop. The profile and linked evidence will remain, and you can reactivate it.</p>
+              <div className="inline-actions">
+                <button ref={endConfirm} type="button" disabled={busy} onClick={end}>Confirm end</button>
+                <button type="button" className="button-ghost" disabled={busy} onClick={() => { setEnding(false); requestAnimationFrame(() => endTrigger.current?.focus()); }}>Cancel ending</button>
+              </div>
+            </div>
+          ) : (
+            <div className="inline-actions paycheck-actions">
+              <button type="button" className="button-ghost" disabled={busy} onClick={(event) => onEdit(profile, event.currentTarget)} aria-label={`Edit ${profile.displayName}`}>Edit expectation</button>
+              {profile.lifecycle !== "active" && <button type="button" disabled={busy} onClick={() => onLifecycle(profile.id, "active")} aria-label={`Reactivate ${profile.displayName}`}>Reactivate</button>}
+              {profile.lifecycle !== "paused" && <button type="button" className="button-ghost" disabled={busy} onClick={() => onLifecycle(profile.id, "paused")} aria-label={`Pause ${profile.displayName}`}>Pause</button>}
+              {profile.lifecycle !== "ended" && <button ref={endTrigger} type="button" className="button-ghost" disabled={busy} onClick={() => setEnding(true)} aria-label={`End ${profile.displayName}`}>End</button>}
+            </div>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}
+
+export default function PaychecksPage() {
+  const state = usePaychecks();
+  const [editor, setEditor] = useState(null);
+  const editorTrigger = useRef(null);
+  const editorLocation = useRef(null);
+  const profilesHeading = useRef(null);
+  const candidatesHeading = useRef(null);
+  const dismissedHeading = useRef(null);
+  const feedback = useRef(null);
+  const busy = Boolean(state.busyKey) || state.loading || state.refreshing;
+  const hasContent = state.paychecks.length + state.candidates.length + state.dismissedCandidates.length > 0;
+  const showContent = hasContent || (!state.loading && !state.loadError);
+
+  function focus(ref) {
+    requestAnimationFrame(() => ref.current?.focus());
+  }
+
+  function openEditor(mode, model, trigger) {
+    editorTrigger.current = trigger;
+    editorLocation.current = { container: trigger.closest("article"), label: trigger.getAttribute("aria-label") };
+    state.clearMessages();
+    setEditor({ mode, model, key: mode === "confirm" ? model.fingerprint : model?.id ?? "manual" });
+  }
+
+  function cancelEditor() {
+    setEditor(null);
+    requestAnimationFrame(() => {
+      const original = editorTrigger.current;
+      const location = editorLocation.current;
+      const replacement = Array.from(location?.container?.querySelectorAll("button[aria-label]") ?? [])
+        .find((button) => button.getAttribute("aria-label") === location.label);
+      const target = original?.isConnected ? original : replacement?.isConnected ? replacement : profilesHeading.current;
+      target?.focus();
+    });
+  }
+
+  async function submit(operation) {
+    const result = await operation();
+    if (result?.ok) {
+      setEditor(null);
+      focus(profilesHeading);
+    } else if (STALE_CODES.has(result?.code)) {
+      setEditor(null);
+      focus(feedback);
+    } else {
+      focus(feedback);
+    }
+    return result;
+  }
+
+  async function decide(candidate, reconsider) {
+    const tuple = { algorithmVersion: candidate.algorithmVersion, cadence: candidate.schedule.cadence, fingerprint: candidate.fingerprint };
+    const result = await (reconsider ? state.reconsiderCandidate(tuple) : state.dismissCandidate(tuple));
+    focus(result?.ok ? (reconsider ? candidatesHeading : dismissedHeading) : feedback);
+  }
+
+  async function lifecycle(id, value) {
+    const result = await state.updateLifecycle(id, value);
+    focus(result?.ok ? profilesHeading : feedback);
+    return result;
+  }
+
+  return (
+    <div className="container paychecks-page">
+      <header className="page-header">
+        <div>
+          <p className="page-header__eyebrow">Plan around your pay</p>
+          <h1>Paychecks</h1>
+          <p className="muted">Review recurring deposits and save the paycheck expectations you choose.</p>
+        </div>
+        <button type="button" className="paycheck-create" disabled={busy || Boolean(state.loadError) || state.uncertainCreate} onClick={(event) => openEditor("manual", null, event.currentTarget)}>
+          <Plus size={18} aria-hidden="true" /> Add paycheck manually
+        </button>
+      </header>
+
+      <div ref={feedback} tabIndex={-1} className="paycheck-feedback">
+        {state.loadError && <StatusMessage tone="danger">{state.loadError}</StatusMessage>}
+        {state.actionError && <StatusMessage tone="danger">{state.actionError}</StatusMessage>}
+        {state.notice && <StatusMessage tone="success">{state.notice}</StatusMessage>}
+        {(state.loadError || state.actionError) && <button type="button" className="button-ghost" disabled={busy} onClick={() => state.refresh()}>Refresh paychecks</button>}
+        {state.uncertainCreate && <button type="button" className="button-ghost" disabled={busy} onClick={state.acknowledgeUncertainCreate}>I checked my profiles; allow another attempt</button>}
+        {state.busyKey && <StatusMessage>Saving your decision…</StatusMessage>}
+        {state.refreshing && <StatusMessage>Refreshing paychecks…</StatusMessage>}
+      </div>
+
+      {editor?.mode === "manual" && (
+        <section className="paycheck-manual" aria-labelledby="manual-paycheck-heading">
+          <h2 id="manual-paycheck-heading">Add a paycheck expectation</h2>
+          <p className="muted">This is your own expectation, not employer-verified. It will be active without attaching any deposit evidence.</p>
+          <PaycheckForm key="manual" mode="manual" busy={busy} submitDisabled={state.uncertainCreate} onSubmit={(payload) => submit(() => state.createPaycheck(payload))} onCancel={cancelEditor} />
+        </section>
+      )}
+
+      {state.loading && <StatusMessage>Loading paychecks…</StatusMessage>}
+      {showContent && (
+        <>
+          <section className="paycheck-section" aria-labelledby="paycheck-profiles-heading" aria-busy={Boolean(state.busyKey)}>
+            <header className="paycheck-section__header">
+              <div><h2 id="paycheck-profiles-heading" ref={profilesHeading} tabIndex={-1}>Your paychecks</h2><p className="muted">Saved expectations, kept separate from unconfirmed deposit patterns.</p></div>
+              {state.paychecksEvaluatedOn && <p className="paycheck-evaluated">Evaluated {formatDate(state.paychecksEvaluatedOn)}</p>}
+            </header>
+            {state.paychecks.length === 0 ? (
+              <div className="paycheck-empty"><WalletCards size={28} aria-hidden="true" /><h3>No paycheck profiles yet</h3><p>Review a candidate below or add an expectation manually. A deposit alone is not a confirmed paycheck.</p></div>
+            ) : LIFECYCLES.map((lifecycleValue) => {
+              const profiles = state.paychecks.filter((profile) => profile.lifecycle === lifecycleValue);
+              return profiles.length > 0 && (
+                <div key={lifecycleValue} className="paycheck-group" role="group" aria-label={`${LIFECYCLE_LABELS[lifecycleValue]} paychecks`}>
+                  <p className="paycheck-group__label">{LIFECYCLE_LABELS[lifecycleValue]} <span>{profiles.length}</span></p>
+                  {profiles.map((profile) => <ProfileCard key={profile.id} profile={profile} busy={busy} editor={editor} onEdit={(model, trigger) => openEditor("edit", model, trigger)} onCancel={cancelEditor} onSave={(id, payload) => submit(() => state.updatePaycheck(id, payload))} onLifecycle={lifecycle} />)}
+                </div>
+              );
+            })}
+          </section>
+
+          <section className="paycheck-section" aria-labelledby="paycheck-candidates-heading">
+            <header className="paycheck-section__header">
+              <div><h2 id="paycheck-candidates-heading" ref={candidatesHeading} tabIndex={-1}>Candidates to review</h2><p className="muted">These deposits may form a paycheck pattern. Review the evidence before accepting an expectation.</p></div>
+              {state.candidatesEvaluatedOn && <p className="paycheck-evaluated">Evaluated {formatDate(state.candidatesEvaluatedOn)}</p>}
+            </header>
+            {state.candidates.length === 0 ? <p className="paycheck-empty">No paycheck candidates need review. You can still add a manual expectation.</p> : state.candidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} busy={busy} editor={editor} onReview={(model, trigger) => openEditor("confirm", model, trigger)} onCancel={cancelEditor} onConfirm={(payload) => submit(() => state.confirmCandidate(payload))} onDecision={decide} />)}
+          </section>
+
+          <section className="paycheck-section" aria-labelledby="paycheck-dismissed-heading">
+            <header><h2 id="paycheck-dismissed-heading" ref={dismissedHeading} tabIndex={-1}>Dismissed candidates</h2><p className="muted">Dismissal applies to the exact evidence reviewed. Reconsider a candidate to review it again.</p></header>
+            {state.dismissedCandidates.length === 0 ? <p className="muted">No dismissed candidates.</p> : state.dismissedCandidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} dismissed busy={busy} onDecision={decide} />)}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/paychecks/pages/PaychecksPage.test.jsx
+++ b/frontend/src/features/paychecks/pages/PaychecksPage.test.jsx
@@ -1,0 +1,228 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PaychecksPage from "./PaychecksPage";
+import { paychecksApi } from "../api/paychecksApi";
+import { makeCandidate, makeCandidateResponse, makePaycheck, makePaychecksResponse } from "../test/paycheckFixtures";
+
+vi.mock("../api/paychecksApi", () => ({ paychecksApi: {
+  getCandidates: vi.fn(), getPaychecks: vi.fn(), confirmCandidate: vi.fn(),
+  dismissCandidate: vi.fn(), reconsiderCandidate: vi.fn(), createPaycheck: vi.fn(),
+  updatePaycheck: vi.fn(), updateLifecycle: vi.fn(),
+} }));
+const response = (data) => ({ data });
+const deferred = () => { let resolve, reject; const promise = new Promise((yes, no) => { resolve = yes; reject = no; }); return { promise, resolve, reject }; };
+const card = (name) => screen.getByRole("heading", { name, exact: true }).closest("article");
+
+function loadState({ candidates = [makeCandidate()], dismissedCandidates = [], paychecks = [makePaycheck()] } = {}) {
+  paychecksApi.getCandidates.mockResolvedValue(response(makeCandidateResponse({ candidates, dismissedCandidates })));
+  paychecksApi.getPaychecks.mockResolvedValue(response(makePaychecksResponse({ paychecks })));
+}
+async function renderPage() {
+  render(<PaychecksPage />);
+  await screen.findByRole("heading", { name: "Your paychecks" });
+}
+async function fillManual(user, name = "Manual salary") {
+  await user.click(screen.getByRole("button", { name: "Add paycheck manually" }));
+  const form = screen.getByRole("form", { name: "Create paycheck" });
+  await user.type(within(form).getByLabelText("Display name"), name);
+  await user.type(within(form).getByLabelText("Monthly anchor day"), "10");
+  await user.type(within(form).getByLabelText("Fixed amount"), "2500.00");
+  return form;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  loadState();
+  paychecksApi.confirmCandidate.mockResolvedValue(response({ paycheck: makePaycheck(), alreadyConfirmed: false }));
+  paychecksApi.dismissCandidate.mockResolvedValue(response(null));
+  paychecksApi.reconsiderCandidate.mockResolvedValue(response(null));
+  paychecksApi.createPaycheck.mockResolvedValue(response(makePaycheck({ source: "manual", origin: null, evidence: [] })));
+  paychecksApi.updatePaycheck.mockResolvedValue(response(makePaycheck()));
+  paychecksApi.updateLifecycle.mockResolvedValue(response(makePaycheck()));
+});
+
+describe("Paychecks page", () => {
+  it("separates lifecycle/candidate groups, exact evidence and evaluation dates; projects only active profiles", async () => {
+    const active = makePaycheck();
+    active.evidence[0].editedSinceConfirmation = true;
+    const paused = makePaycheck({ id: "22222222-2222-2222-2222-222222222222", displayName: "Paused pay", lifecycle: "paused" });
+    const ended = makePaycheck({ id: "33333333-3333-3333-3333-333333333333", displayName: "Ended pay", lifecycle: "ended", nextProjection: null });
+    const dismissed = makeCandidate({ fingerprint: "d".repeat(64), normalizedDescriptionIdentity: "old payroll" });
+    loadState({ paychecks: [active, paused, ended], dismissedCandidates: [dismissed] });
+    paychecksApi.getCandidates.mockResolvedValue(response(makeCandidateResponse({ evaluatedOn: "2026-07-13", dismissedCandidates: [dismissed] })));
+    await renderPage();
+    expect(screen.getByText("Evaluated Jul 12, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Evaluated Jul 13, 2026")).toBeInTheDocument();
+    for (const lifecycle of ["Active", "Paused", "Ended"]) expect(screen.getByRole("group", { name: `${lifecycle} paychecks` })).toBeInTheDocument();
+    expect(screen.getAllByText(/Expected based on your confirmed pattern; payment is not guaranteed/)).toHaveLength(1);
+    expect(screen.getByText("Paused profiles have no active payment projection.")).toBeInTheDocument();
+    expect(screen.getByText("Ended profiles have no active payment projection.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "old payroll" })).toBeInTheDocument();
+    const profile = within(card("Acme Payroll"));
+    await userEvent.setup().click(profile.getByText("Linked deposit evidence (3)"));
+    expect(profile.getByText(/Edited since confirmation\. The saved expectation is unchanged/)).toBeVisible();
+    expect(profile.getAllByRole("listitem")).toHaveLength(3);
+    expect(profile.getByText(/May 10, 2026/, { selector: "time" })).toHaveAttribute("datetime", "2026-05-10");
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("shows initial loading and durable load error, then retries to intentional empty states", async () => {
+    const pending = deferred();
+    paychecksApi.getCandidates.mockReturnValue(pending.promise);
+    render(<PaychecksPage />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading paychecks");
+    await act(async () => pending.reject(new Error("offline")));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Paychecks could not be loaded");
+    loadState({ candidates: [], dismissedCandidates: [], paychecks: [] });
+    await userEvent.setup().click(screen.getByRole("button", { name: "Refresh paychecks" }));
+    expect(await screen.findByText("No paycheck profiles yet")).toBeInTheDocument();
+    expect(screen.getByText(/No paycheck candidates need review/)).toBeInTheDocument();
+    expect(screen.getByText("No dismissed candidates.")).toBeInTheDocument();
+  });
+
+  it.each([true, false])("handles the candidates/profiles-only empty combination (candidates=%s)", async (candidatesOnly) => {
+    loadState({ candidates: candidatesOnly ? [makeCandidate()] : [], paychecks: candidatesOnly ? [] : [makePaycheck()] });
+    await renderPage();
+    expect(Boolean(screen.queryByText("No paycheck profiles yet"))).toBe(candidatesOnly);
+    expect(Boolean(screen.queryByText(/No paycheck candidates need review/))).toBe(!candidatesOnly);
+  });
+
+  it("requires explicit fixed confirmation and sends the exact candidate schedule and accepted decimal", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await user.click(within(card("acme payroll")).getByRole("button", { name: "Review and confirm acme payroll" }));
+    const form = within(screen.getByRole("form", { name: "Confirm paycheck" }));
+    expect(form.queryByLabelText("Cadence")).not.toBeInTheDocument();
+    expect(form.getByText("Monthly, day 10")).toBeInTheDocument();
+    await user.clear(form.getByLabelText("Display name"));
+    await user.type(form.getByLabelText("Display name"), "Acme salary");
+    await user.clear(form.getByLabelText("Fixed amount"));
+    await user.type(form.getByLabelText("Fixed amount"), "2500.10");
+    loadState({ candidates: [], paychecks: [makePaycheck({ displayName: "Acme salary" })] });
+    await user.click(form.getByRole("button", { name: "Confirm paycheck" }));
+    expect(paychecksApi.confirmCandidate).toHaveBeenCalledExactlyOnceWith({
+      algorithmVersion: "paycheck-candidate-v1", fingerprint: makeCandidate().fingerprint,
+      displayName: "Acme salary", schedule: makeCandidate().schedule, windowBeforeDays: 1, windowAfterDays: 1,
+      amount: { mode: "fixed", fixedAmount: "2500.10", minimumAmount: null, maximumAmount: null },
+    });
+    expect(await screen.findByRole("heading", { name: "Acme salary" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Your paychecks" })).toHaveFocus());
+  });
+
+  it("requires typed bounds for variable candidates and refreshes exact dismissal/reconsideration decisions", async () => {
+    const user = userEvent.setup();
+    const variable = makeCandidate({ fingerprint: "c".repeat(64), observedAmount: { mode: "variable", fixedAmount: null, minimumAmount: 1800, maximumAmount: 2600, lowerMedianAmount: 2100 } });
+    const other = makeCandidate({ fingerprint: "d".repeat(64), normalizedDescriptionIdentity: "other payroll" });
+    loadState({ candidates: [variable, other], paychecks: [] });
+    await renderPage();
+    await user.click(within(card("acme payroll")).getByRole("button", { name: "Review and confirm acme payroll" }));
+    const form = within(screen.getByRole("form", { name: "Confirm paycheck" }));
+    expect(form.getByLabelText("Minimum amount")).toHaveValue("");
+    expect(form.getByLabelText("Maximum amount")).toHaveValue("");
+    await user.click(form.getByRole("button", { name: "Confirm paycheck" }));
+    expect(paychecksApi.confirmCandidate).not.toHaveBeenCalled();
+    expect(form.getByRole("alert")).toHaveTextContent("Check the highlighted fields");
+    await user.type(form.getByLabelText("Minimum amount"), "1800.00");
+    await user.type(form.getByLabelText("Maximum amount"), "2600.25");
+    loadState({ candidates: [other] });
+    await user.click(form.getByRole("button", { name: "Confirm paycheck" }));
+    expect(paychecksApi.confirmCandidate).toHaveBeenCalledWith(expect.objectContaining({ amount: { mode: "range", fixedAmount: null, minimumAmount: "1800.00", maximumAmount: "2600.25" } }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Dismiss other payroll" })).toBeEnabled());
+    loadState({ candidates: [], dismissedCandidates: [other] });
+    await user.click(screen.getByRole("button", { name: "Dismiss other payroll" }));
+    await screen.findByRole("button", { name: "Reconsider other payroll" });
+    const tuple = { algorithmVersion: other.algorithmVersion, cadence: "monthly", fingerprint: other.fingerprint };
+    expect(paychecksApi.dismissCandidate).toHaveBeenCalledExactlyOnceWith(tuple);
+    loadState({ candidates: [other] });
+    await user.click(screen.getByRole("button", { name: "Reconsider other payroll" }));
+    expect(paychecksApi.reconsiderCandidate).toHaveBeenCalledExactlyOnceWith(tuple);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Candidates to review" })).toHaveFocus());
+  });
+
+  it("keeps a known manual creation successful when refresh fails, without offering repeat submission", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    const form = await fillManual(user);
+    paychecksApi.getCandidates.mockRejectedValue(new Error("refresh failed"));
+    await user.click(within(form).getByRole("button", { name: "Create paycheck" }));
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledExactlyOnceWith({
+      displayName: "Manual salary", schedule: makeCandidate().schedule, windowBeforeDays: 0, windowAfterDays: 0,
+      amount: { mode: "fixed", fixedAmount: "2500.00", minimumAmount: null, maximumAmount: null },
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent("Paychecks could not be loaded");
+    expect(screen.getByRole("status")).toHaveTextContent("Paycheck created");
+    expect(screen.queryByRole("form", { name: "Create paycheck" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add paycheck manually" })).toBeDisabled();
+  });
+
+  it("disables conflicting actions while saving and protects an uncertain manual result until checked", async () => {
+    const user = userEvent.setup();
+    const pending = deferred();
+    paychecksApi.createPaycheck.mockReturnValue(pending.promise);
+    await renderPage();
+    const form = await fillManual(user);
+    await user.click(within(form).getByRole("button", { name: "Create paycheck" }));
+    expect(screen.getByRole("button", { name: "Dismiss acme payroll" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Edit Acme Payroll" })).toBeDisabled();
+    await act(async () => pending.reject(new Error("network lost")));
+    expect(await screen.findByRole("alert")).toHaveTextContent("could not confirm whether the paycheck was created");
+    expect(within(form).getByRole("button", { name: "Create paycheck" })).toBeDisabled();
+    expect(within(form).getByRole("button", { name: "Cancel" })).toBeEnabled();
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "Refresh paychecks" }));
+    await waitFor(() => expect(within(form).getByRole("button", { name: "Create paycheck" })).toBeEnabled());
+    expect(screen.getByRole("status")).toHaveTextContent("Check the saved profiles");
+    expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes a stale review with a visible conflict and requires explicit review of replacement evidence", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await user.click(screen.getByRole("button", { name: "Review and confirm acme payroll" }));
+    paychecksApi.confirmCandidate.mockRejectedValue({ response: { status: 409, data: { code: "candidate_changed" } } });
+    loadState({ candidates: [makeCandidate({ fingerprint: "e".repeat(64) })] });
+    await user.click(screen.getByRole("button", { name: "Confirm paycheck" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Review the latest evidence");
+    await waitFor(() => expect(screen.queryByRole("form", { name: "Confirm paycheck" })).not.toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Review and confirm acme payroll" })).toBeEnabled();
+    expect(paychecksApi.confirmCandidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves edit restrictions and restores focus for cancel, then moves profiles through lifecycle groups", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await user.click(screen.getByRole("button", { name: "Edit Acme Payroll" }));
+    expect(screen.getByLabelText("Display name")).toHaveFocus();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Edit Acme Payroll" })).toHaveFocus());
+    await user.click(screen.getByRole("button", { name: "Edit Acme Payroll" }));
+    await user.clear(screen.getByLabelText("Display name"));
+    await user.type(screen.getByLabelText("Display name"), "Renamed payroll");
+    const profile = makePaycheck({ displayName: "Renamed payroll" });
+    loadState({ paychecks: [profile] });
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(paychecksApi.updatePaycheck).toHaveBeenCalledExactlyOnceWith(profile.id, {
+      displayName: "Renamed payroll", windowBeforeDays: 1, windowAfterDays: 1,
+      amount: { mode: "fixed", fixedAmount: "2500", minimumAmount: null, maximumAmount: null },
+    });
+    await screen.findByRole("button", { name: "Pause Renamed payroll" });
+    loadState({ paychecks: [{ ...profile, lifecycle: "paused", nextProjection: null }] });
+    await user.click(screen.getByRole("button", { name: "Pause Renamed payroll" }));
+    expect(await screen.findByRole("group", { name: "Paused paychecks" })).toHaveTextContent("Renamed payroll");
+    expect(paychecksApi.updateLifecycle).toHaveBeenLastCalledWith(profile.id, "paused");
+    await user.click(screen.getByRole("button", { name: "End Renamed payroll" }));
+    expect(screen.getByRole("button", { name: "Confirm end" })).toHaveFocus();
+    await user.click(screen.getByRole("button", { name: "Cancel ending" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "End Renamed payroll" })).toHaveFocus());
+    await user.click(screen.getByRole("button", { name: "End Renamed payroll" }));
+    loadState({ paychecks: [{ ...profile, lifecycle: "ended", nextProjection: null }] });
+    await user.click(screen.getByRole("button", { name: "Confirm end" }));
+    expect(await screen.findByRole("group", { name: "Ended paychecks" })).toHaveTextContent("Renamed payroll");
+    expect(paychecksApi.updateLifecycle).toHaveBeenLastCalledWith(profile.id, "ended");
+    loadState({ paychecks: [profile] });
+    await user.click(screen.getByRole("button", { name: "Reactivate Renamed payroll" }));
+    expect(await screen.findByRole("group", { name: "Active paychecks" })).toHaveTextContent("Renamed payroll");
+    expect(paychecksApi.updateLifecycle).toHaveBeenLastCalledWith(profile.id, "active");
+  });
+});

--- a/frontend/src/features/paychecks/test/paycheckFixtures.js
+++ b/frontend/src/features/paychecks/test/paycheckFixtures.js
@@ -1,0 +1,134 @@
+export const evaluatedOn = "2026-07-12";
+
+const fingerprint = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function makeSchedule() {
+  return {
+    cadence: "monthly",
+    referenceAnchorDate: null,
+    firstMonthAnchor: { kind: "day_of_month", day: 10 },
+    secondMonthAnchor: null,
+  };
+}
+
+function makeAmount() {
+  return {
+    mode: "fixed",
+    fixedAmount: 2500,
+    minimumAmount: null,
+    maximumAmount: null,
+  };
+}
+
+function makeCandidateEvidence() {
+  return [
+    {
+      accountInflowId: 101,
+      postedDate: "2026-05-10",
+      amount: 2500,
+      description: "Acme Payroll",
+      source: "imported",
+      slotAnchor: "2026-05-10",
+      timingOffsetDays: 0,
+    },
+    {
+      accountInflowId: 102,
+      postedDate: "2026-06-10",
+      amount: 2500,
+      description: "Acme Payroll",
+      source: "manual",
+      slotAnchor: "2026-06-10",
+      timingOffsetDays: 0,
+    },
+    {
+      accountInflowId: 103,
+      postedDate: "2026-07-10",
+      amount: 2500,
+      description: "Acme Payroll",
+      source: "imported",
+      slotAnchor: "2026-07-10",
+      timingOffsetDays: 0,
+    },
+  ];
+}
+
+function makeProfileEvidence() {
+  return makeCandidateEvidence().map((evidence, index) => ({
+    ...evidence,
+    linkedAt: `2026-07-12T0${index + 1}:00:00.000Z`,
+    editedSinceConfirmation: false,
+  }));
+}
+
+function makeProjection() {
+  return {
+    algorithmVersion: "paycheck-projector-v1",
+    evaluatedOn,
+    anchor: "2026-08-10",
+    earliestExpectedDate: "2026-08-09",
+    latestExpectedDate: "2026-08-11",
+    amount: makeAmount(),
+  };
+}
+
+export function makeCandidate(overrides = {}) {
+  return {
+    fingerprint,
+    algorithmVersion: "paycheck-candidate-v1",
+    normalizedDescriptionIdentity: "acme payroll",
+    schedule: makeSchedule(),
+    windowBeforeDays: 1,
+    windowAfterDays: 1,
+    observedAmount: {
+      mode: "fixed",
+      fixedAmount: 2500,
+      minimumAmount: null,
+      maximumAmount: null,
+      lowerMedianAmount: 2500,
+    },
+    coveredFrom: "2026-05-10",
+    coveredTo: "2026-07-10",
+    occurrenceCount: 3,
+    evidence: makeCandidateEvidence(),
+    ...overrides,
+  };
+}
+
+export function makePaycheck(overrides = {}) {
+  return {
+    id: "8a8a5c92-8a4f-4a41-9e2f-2d4b1c6d7e8f",
+    displayName: "Acme Payroll",
+    lifecycle: "active",
+    schedule: makeSchedule(),
+    windowBeforeDays: 1,
+    windowAfterDays: 1,
+    amount: makeAmount(),
+    source: "candidate",
+    origin: {
+      algorithmVersion: "paycheck-candidate-v1",
+      fingerprint,
+    },
+    createdAt: "2026-07-12T12:00:00.000Z",
+    updatedAt: "2026-07-12T12:00:00.000Z",
+    evidence: makeProfileEvidence(),
+    nextProjection: makeProjection(),
+    ...overrides,
+  };
+}
+
+export function makeCandidateResponse(overrides = {}) {
+  return {
+    evaluatedOn,
+    candidates: [makeCandidate()],
+    dismissedCandidates: [],
+    ...overrides,
+  };
+}
+
+export function makePaychecksResponse(overrides = {}) {
+  return {
+    evaluatedOn,
+    paychecks: [makePaycheck()],
+    ...overrides,
+  };
+}

--- a/frontend/src/features/paychecks/utils/formatPaychecks.js
+++ b/frontend/src/features/paychecks/utils/formatPaychecks.js
@@ -1,0 +1,46 @@
+import { isCalendarDate, isUnsafeNumericAmount } from "./paycheckForm";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export function formatDate(value) {
+  if (!isCalendarDate(String(value ?? ""))) return "Unknown date";
+  const [year, month, day] = value.split("-");
+  return `${MONTHS[Number(month) - 1]} ${Number(day)}, ${year}`;
+}
+
+export function formatMoney(value) {
+  if (isUnsafeNumericAmount(value)) return "Amount needs review";
+  if (value == null || value === "" || !Number.isFinite(Number(value))) return "Amount unavailable";
+  // String decimal values retain their cents, including at numeric(18,2)'s limit.
+  const match = String(value).match(/^(-?)(\d+)(?:\.(\d{1,2}))?$/);
+  if (match) return `${match[1]}$${match[2].replace(/\B(?=(\d{3})+(?!\d))/g, ",")}.${(match[3] ?? "").padEnd(2, "0")}`;
+  return "Amount needs review";
+}
+
+export function cadenceLabel(cadence) {
+  return { weekly: "Weekly", biweekly: "Every two weeks", semimonthly: "Twice a month", monthly: "Monthly" }[cadence] ?? "Unknown cadence";
+}
+
+function formatAnchor(anchor) {
+  return anchor?.kind === "month_end" ? "month end" : `day ${anchor?.day ?? "?"}`;
+}
+
+export function formatSchedule(schedule) {
+  if (!schedule) return "Schedule unavailable";
+  const cadence = cadenceLabel(schedule.cadence);
+  if (["weekly", "biweekly"].includes(schedule.cadence))
+    return `${cadence}, reference date ${formatDate(schedule.referenceAnchorDate)}`;
+  if (schedule.cadence === "semimonthly")
+    return `${cadence}, ${formatAnchor(schedule.firstMonthAnchor)} and ${formatAnchor(schedule.secondMonthAnchor)}`;
+  return `${cadence}, ${formatAnchor(schedule.firstMonthAnchor)}`;
+}
+
+export function formatAmount(amount) {
+  if (!amount) return "Amount unavailable";
+  if (amount.mode === "fixed") return formatMoney(amount.fixedAmount);
+  return `${formatMoney(amount.minimumAmount)} – ${formatMoney(amount.maximumAmount)}`;
+}
+
+export function formatWindow(before, after) {
+  return `${before} ${Number(before) === 1 ? "day" : "days"} before · ${after} ${Number(after) === 1 ? "day" : "days"} after`;
+}

--- a/frontend/src/features/paychecks/utils/formatPaychecks.test.js
+++ b/frontend/src/features/paychecks/utils/formatPaychecks.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { cadenceLabel, formatAmount, formatDate, formatMoney, formatSchedule, formatWindow } from "./formatPaychecks";
+
+describe("paycheck display formatting", () => {
+  it("keeps date-only calendar days through DST dates and early years", () => {
+    expect(formatDate("2026-03-08")).toBe("Mar 8, 2026");
+    expect(formatDate("2026-11-01")).toBe("Nov 1, 2026");
+    expect(formatDate("0001-01-01")).toBe("Jan 1, 0001");
+    expect(formatDate("2026-02-29")).toBe("Unknown date");
+  });
+  it("formats money without inventing cents discarded by JSON numeric parsing", () => {
+    expect(formatMoney(1234.56)).toBe("$1,234.56");
+    expect(formatMoney("9999999999999999.99")).toBe("$9,999,999,999,999,999.99");
+    expect(formatMoney(1e16)).toBe("Amount needs review");
+    expect(formatMoney(Number("70368744177664.01"))).toBe("Amount needs review");
+    expect(formatMoney(null)).toBe("Amount unavailable");
+    expect(formatAmount({ mode: "range", minimumAmount: "100.01", maximumAmount: "200.99" })).toBe("$100.01 – $200.99");
+  });
+  it("distinguishes all schedules and month end", () => {
+    expect(cadenceLabel("biweekly")).toBe("Every two weeks");
+    expect(formatSchedule({ cadence: "weekly", referenceAnchorDate: "2026-01-02" })).toBe("Weekly, reference date Jan 2, 2026");
+    expect(formatSchedule({ cadence: "biweekly", referenceAnchorDate: "2026-01-02" })).toContain("Every two weeks");
+    expect(formatSchedule({ cadence: "monthly", firstMonthAnchor: { kind: "month_end", day: null } })).toBe("Monthly, month end");
+    expect(formatSchedule({ cadence: "semimonthly", firstMonthAnchor: { kind: "day_of_month", day: 15 }, secondMonthAnchor: { kind: "month_end", day: null } }))
+      .toBe("Twice a month, day 15 and month end");
+    expect(formatWindow(1, 3)).toBe("1 day before · 3 days after");
+  });
+});

--- a/frontend/src/features/paychecks/utils/paycheckForm.js
+++ b/frontend/src/features/paychecks/utils/paycheckForm.js
@@ -1,0 +1,124 @@
+export const CADENCES = ["weekly", "biweekly", "semimonthly", "monthly"];
+const MAX_CENTS = 999999999999999999n;
+
+// Keep accepted decimals exact through JSON serialization. ASP.NET Core's web
+// JSON defaults accept quoted numbers for the existing decimal DTO properties.
+export function parseAmount(value) {
+  const text = String(value ?? "").trim();
+  if (!/^(?:\d+(?:\.\d{1,2})?|\.\d{1,2})$/.test(text)) return null;
+  const [whole = "0", fraction = ""] = text.split(".");
+  const canonicalWhole = (whole || "0").replace(/^0+(?=\d)/, "");
+  if (canonicalWhole.length > 16) return null;
+  const cents = BigInt(canonicalWhole) * 100n + BigInt(fraction.padEnd(2, "0"));
+  if (cents <= 0n || cents > MAX_CENTS) return null;
+  return { cents, value: `${canonicalWhole}${fraction ? `.${fraction}` : ""}` };
+}
+
+export function isCalendarDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (year < 1 || year > 9999 || month < 1 || month > 12) return false;
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  return day >= 1 && day <= [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+}
+
+export function validSemimonthlyPair(first, second) {
+  return Number.isInteger(first) && Number.isInteger(second)
+    && first >= 1 && second <= 31 && first < second
+    && Math.min(second, 28) - Math.min(first, 28) >= 7
+    && 28 - Math.min(second, 28) + Math.min(first, 28) >= 7;
+}
+
+export function isUnsafeNumericAmount(value) {
+  // At 2^46 dollars, adjacent binary floats are farther apart than one cent.
+  // Distinct valid API decimals can therefore decode to the same JS number.
+  return typeof value === "number" && (!Number.isFinite(value) || Math.abs(value) >= 2 ** 46);
+}
+
+function initialAmount(value) {
+  // JSON numbers outside this boundary cannot reliably retain individual cents.
+  if (isUnsafeNumericAmount(value)) return "";
+  return value == null ? "" : String(value);
+}
+
+export function initialPaycheckForm(mode, model = {}) {
+  const amount = mode === "confirm" ? model.observedAmount : model.amount;
+  const variable = mode === "confirm" && amount?.mode === "variable";
+  return {
+    displayName: model.displayName ?? model.normalizedDescriptionIdentity ?? "",
+    cadence: "monthly", referenceAnchorDate: "",
+    firstAnchorKind: "day_of_month", firstAnchorDay: "",
+    secondAnchorKind: "day_of_month", secondAnchorDay: "",
+    windowBeforeDays: String(model.windowBeforeDays ?? 0),
+    windowAfterDays: String(model.windowAfterDays ?? 0),
+    amountMode: variable || amount?.mode === "range" ? "range" : "fixed",
+    fixedAmount: variable ? "" : initialAmount(amount?.fixedAmount),
+    minimumAmount: mode === "confirm" ? "" : initialAmount(amount?.minimumAmount),
+    maximumAmount: mode === "confirm" ? "" : initialAmount(amount?.maximumAmount),
+  };
+}
+
+function integerInRange(value, minimum, maximum) {
+  return /^\d+$/.test(value) && Number(value) >= minimum && Number(value) <= maximum;
+}
+
+export function validatePaycheckForm(form, mode, model) {
+  const errors = {};
+  const name = form.displayName.trim();
+  if (!name || name.length > 500) errors.displayName = "Enter a display name of 1 to 500 characters.";
+  let schedule;
+  if (mode === "manual") {
+    if (!CADENCES.includes(form.cadence)) errors.cadence = "Choose a supported cadence.";
+    const interval = form.cadence === "weekly" || form.cadence === "biweekly";
+    const readAnchor = (prefix) => {
+      if (form[`${prefix}AnchorKind`] === "month_end") return { kind: "month_end", day: null };
+      if (form[`${prefix}AnchorKind`] !== "day_of_month") {
+        errors[`${prefix}AnchorKind`] = "Choose a day of month or month end.";
+      } else if (!integerInRange(form[`${prefix}AnchorDay`], 1, 30)) {
+        errors[`${prefix}AnchorDay`] = "Enter a whole day from 1 to 30, or choose month end.";
+      }
+      return { kind: "day_of_month", day: Number(form[`${prefix}AnchorDay`]) };
+    };
+    if (interval && !isCalendarDate(form.referenceAnchorDate))
+      errors.referenceAnchorDate = "Enter a valid reference anchor date.";
+    const first = interval ? null : readAnchor("first");
+    const second = form.cadence === "semimonthly" ? readAnchor("second") : null;
+    if (second && !errors.firstAnchorDay && !errors.secondAnchorDay
+      && !errors.firstAnchorKind && !errors.secondAnchorKind
+      && !validSemimonthlyPair(first.day ?? 31, second.day ?? 31)) {
+      errors.secondAnchorKind = "Choose ordered anchors at least seven days apart, including across February's month boundary.";
+    }
+    schedule = { cadence: form.cadence, referenceAnchorDate: interval ? form.referenceAnchorDate : null,
+      firstMonthAnchor: first, secondMonthAnchor: second };
+  }
+  for (const field of ["windowBeforeDays", "windowAfterDays"])
+    if (!integerInRange(form[field], 0, 3)) errors[field] = "Enter a whole number from 0 to 3.";
+
+  const fixed = form.amountMode === "fixed";
+  const variableCandidate = mode === "confirm" && model?.observedAmount?.mode === "variable";
+  if (!["fixed", "range"].includes(form.amountMode) || (variableCandidate && fixed))
+    errors.amountMode = "Variable evidence requires an explicit amount range.";
+  const fields = fixed ? ["fixedAmount"] : ["minimumAmount", "maximumAmount"];
+  const amounts = {};
+  for (const field of fields) {
+    amounts[field] = parseAmount(form[field]);
+    if (!amounts[field]) errors[field] = "Enter a positive amount with at most two decimals, up to 9999999999999999.99.";
+  }
+  if (!fixed && amounts.minimumAmount && amounts.maximumAmount
+    && amounts.minimumAmount.cents >= amounts.maximumAmount.cents)
+    errors.maximumAmount = "Maximum amount must be greater than minimum amount.";
+
+  if (Object.keys(errors).length) return { errors, payload: null };
+  return { errors, payload: {
+    displayName: name,
+    ...(mode === "manual" ? { schedule } : {}),
+    ...(mode === "confirm" ? {
+      algorithmVersion: model.algorithmVersion, fingerprint: model.fingerprint, schedule: model.schedule,
+    } : {}),
+    windowBeforeDays: Number(form.windowBeforeDays), windowAfterDays: Number(form.windowAfterDays),
+    amount: { mode: form.amountMode,
+      fixedAmount: fixed ? amounts.fixedAmount.value : null,
+      minimumAmount: fixed ? null : amounts.minimumAmount.value,
+      maximumAmount: fixed ? null : amounts.maximumAmount.value },
+  } };
+}

--- a/frontend/src/features/paychecks/utils/paycheckForm.test.js
+++ b/frontend/src/features/paychecks/utils/paycheckForm.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { initialPaycheckForm, isCalendarDate, parseAmount, validatePaycheckForm, validSemimonthlyPair } from "./paycheckForm";
+import { makeCandidate, makePaycheck } from "../test/paycheckFixtures";
+
+function manual(overrides = {}) {
+  return { ...initialPaycheckForm("manual"), displayName: "  My payroll  ", firstAnchorDay: "10", fixedAmount: "1234.56", ...overrides };
+}
+
+describe("paycheck form contracts", () => {
+  it.each(["weekly", "biweekly", "monthly", "semimonthly"])("builds the complete exclusive %s schedule", (cadence) => {
+    const interval = cadence === "weekly" || cadence === "biweekly";
+    const { payload, errors } = validatePaycheckForm(manual({ cadence, referenceAnchorDate: "2026-03-08",
+      firstAnchorDay: "15", secondAnchorKind: "month_end" }), "manual");
+    expect(errors).toEqual({});
+    expect(payload).toEqual({ displayName: "My payroll", windowBeforeDays: 0, windowAfterDays: 0,
+      schedule: { cadence, referenceAnchorDate: interval ? "2026-03-08" : null,
+        firstMonthAnchor: interval ? null : { kind: "day_of_month", day: 15 },
+        secondMonthAnchor: cadence === "semimonthly" ? { kind: "month_end", day: null } : null },
+      amount: { mode: "fixed", fixedAmount: "1234.56", minimumAmount: null, maximumAmount: null } });
+  });
+
+  it("keeps candidate schedule and origin exact while edit payloads omit them", () => {
+    const candidate = makeCandidate();
+    const confirm = validatePaycheckForm(initialPaycheckForm("confirm", candidate), "confirm", candidate).payload;
+    expect(confirm.schedule).toBe(candidate.schedule);
+    expect(confirm.algorithmVersion).toBe(candidate.algorithmVersion);
+    expect(confirm.fingerprint).toBe(candidate.fingerprint);
+    expect(confirm).not.toHaveProperty("evidence");
+    const profile = makePaycheck();
+    const edit = validatePaycheckForm(initialPaycheckForm("edit", profile), "edit", profile).payload;
+    expect(Object.keys(edit)).toEqual(["displayName", "windowBeforeDays", "windowAfterDays", "amount"]);
+  });
+
+  it("never adopts variable observation bounds and requires explicit acceptance", () => {
+    const candidate = makeCandidate({ observedAmount: { mode: "variable", minimumAmount: 1000, maximumAmount: 2000, lowerMedianAmount: 1500 } });
+    const form = initialPaycheckForm("confirm", candidate);
+    expect(form).toMatchObject({ amountMode: "range", minimumAmount: "", maximumAmount: "", fixedAmount: "" });
+    expect(validatePaycheckForm(form, "confirm", candidate).payload).toBeNull();
+    expect(validatePaycheckForm({ ...form, amountMode: "fixed", fixedAmount: "1500" }, "confirm", candidate).errors.amountMode).toBeTruthy();
+    expect(validatePaycheckForm({ ...form, minimumAmount: "1200", maximumAmount: "1800" }, "confirm", candidate).payload.amount)
+      .toEqual({ mode: "range", fixedAmount: null, minimumAmount: "1200", maximumAmount: "1800" });
+  });
+
+  it.each(["", " ", "0", "-1", "1.001", "1e2", "1,000", "NaN", "Infinity", "10000000000000000", "9999999999999999.991"])("rejects invalid amount %s without rounding", (value) => {
+    expect(parseAmount(value)).toBeNull();
+  });
+
+  it("preserves exact cents beyond Number's safe range and validates strict increasing ranges", () => {
+    expect(parseAmount("9999999999999999.99")).toEqual({ value: "9999999999999999.99", cents: 999999999999999999n });
+    expect(parseAmount(" .50 ")).toEqual({ value: "0.50", cents: 50n });
+    const valid = validatePaycheckForm(manual({ amountMode: "range", minimumAmount: "9999999999999999.98", maximumAmount: "9999999999999999.99" }), "manual");
+    expect(valid.payload.amount.maximumAmount).toBe("9999999999999999.99");
+    for (const maximumAmount of ["100", "99.99"])
+      expect(validatePaycheckForm(manual({ amountMode: "range", minimumAmount: "100", maximumAmount }), "manual").errors.maximumAmount).toBeTruthy();
+  });
+
+  it.each(["", "4", "-1", "1.5", "1e0", " 1 "])("rejects noncanonical window %s", (value) => {
+    const result = validatePaycheckForm(manual({ windowBeforeDays: value, windowAfterDays: value }), "manual");
+    expect(result.errors.windowBeforeDays).toBeTruthy();
+    expect(result.errors.windowAfterDays).toBeTruthy();
+  });
+
+  it.each([[1, 7], [1, 31], [22, 31], [15, 15], [31, 15], [0, 15], [15, 32]])("rejects semimonthly pair %s/%s", (first, second) => {
+    expect(validSemimonthlyPair(first, second)).toBe(false);
+  });
+  it.each([[1, 8], [7, 31], [15, 31], [21, 28]])("accepts semimonthly pair %s/%s", (first, second) => {
+    expect(validSemimonthlyPair(first, second)).toBe(true);
+  });
+
+  it("validates actual calendar dates without Date/UTC conversions", () => {
+    for (const value of ["2024-02-29", "0001-01-01", "2026-03-08", "2026-11-01"]) expect(isCalendarDate(value)).toBe(true);
+    for (const value of ["2026-02-29", "0000-01-01", "2026-04-31", "2026-13-01", "2026-1-01", "2026-01-01T00:00:00Z"]) expect(isCalendarDate(value)).toBe(false);
+  });
+
+  it("requires explicit entry when a numeric API amount cannot retain reliable cents", () => {
+    const profile = makePaycheck({ amount: { mode: "fixed", fixedAmount: 1e16 } });
+    const form = initialPaycheckForm("edit", profile);
+    expect(form.fixedAmount).toBe("");
+    expect(validatePaycheckForm(form, "edit", profile).payload).toBeNull();
+    expect(initialPaycheckForm("edit", makePaycheck({ amount: { mode: "fixed", fixedAmount: "9999999999999999.99" } })).fixedAmount).toBe("9999999999999999.99");
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,3 +3,4 @@
 @import "./styles/globals.css";
 @import "./styles/layout.css";
 @import "./styles/components.css";
+@import "./styles/paychecks.css";

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -36,7 +36,7 @@
 .app-content { min-width: 0; padding: var(--space-4); padding-bottom: 6.75rem; }
 .app-content > .container { width: 100%; max-width: none; margin: 0; padding: 0; }
 .shell-page { width: 100%; padding-block: var(--space-2) var(--space-6); animation: page-enter var(--duration-normal) var(--ease-standard); }
-.mobile-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); overflow: hidden; padding: var(--space-1); border-top: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 -6px 18px rgb(24 23 22 / 8%); }
+.mobile-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-auto-flow: column; grid-auto-columns: minmax(44px, 1fr); overflow-x: auto; padding: var(--space-1); border-top: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 -6px 18px rgb(24 23 22 / 8%); }
 @keyframes page-enter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 @media (min-width: 900px) {
   .app-shell { display: grid; grid-template-columns: 200px minmax(0, 1fr); }

--- a/frontend/src/styles/paychecks.css
+++ b/frontend/src/styles/paychecks.css
@@ -1,0 +1,65 @@
+.paychecks-page { display: grid; gap: var(--space-6); padding-bottom: var(--space-5); }
+.paychecks-page > .page-header { margin-bottom: 0; }
+.paycheck-create { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); white-space: nowrap; }
+.paycheck-feedback:empty { display: none; }
+.paycheck-feedback { display: grid; justify-items: start; gap: var(--space-2); }
+.paycheck-feedback p { margin: 0; }
+.paycheck-feedback button { margin-top: var(--space-1); }
+.paycheck-section, .paycheck-group { display: grid; min-width: 0; gap: var(--space-4); }
+.paycheck-section__header { display: flex; align-items: start; justify-content: space-between; gap: var(--space-4); }
+.paycheck-section h2 { margin-bottom: var(--space-2); }
+.paycheck-section header p { margin-bottom: 0; }
+.paycheck-evaluated { flex-shrink: 0; padding-top: var(--space-1); color: var(--color-text-muted); font-size: var(--text-sm); }
+.paycheck-group__label { display: flex; gap: var(--space-2); align-items: center; margin: var(--space-2) 0 0; font-weight: 800; }
+.paycheck-group__label span { display: inline-grid; place-items: center; min-width: 26px; min-height: 26px; border-radius: var(--radius-pill); background: var(--color-surface-raised); font-size: var(--text-sm); }
+.paycheck-card { display: grid; min-width: 0; gap: var(--space-4); box-shadow: var(--shadow-sm); }
+.paycheck-card--active { border-left: 3px solid var(--color-primary); }
+.paycheck-card__header { display: flex; align-items: start; justify-content: space-between; gap: var(--space-4); }
+.paycheck-card__header > div { min-width: 0; }
+.paycheck-card h3, .paycheck-card p, .paycheck-card dd { overflow-wrap: anywhere; }
+.paycheck-card h3 { margin-bottom: var(--space-2); font-size: var(--text-xl); }
+.paycheck-eyebrow { margin: 0 0 var(--space-2); color: var(--color-text-muted); font-size: var(--text-xs); letter-spacing: .06em; text-transform: uppercase; font-weight: 800; }
+.paycheck-card__amount { display: grid; gap: var(--space-1); flex-shrink: 0; text-align: right; font-variant-numeric: tabular-nums; }
+.paycheck-card__amount span { color: var(--color-text-muted); font-size: var(--text-xs); }
+.paycheck-card__amount strong { font-size: var(--text-xl); }
+.paycheck-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); margin: 0; }
+.paycheck-facts > div { min-width: 0; }
+.paycheck-facts dt { margin-bottom: var(--space-1); color: var(--color-text-muted); font-size: var(--text-sm); }
+.paycheck-facts dd { margin: 0; }
+.paycheck-projection { padding: var(--space-4); background: color-mix(in srgb, var(--color-primary) 5%, var(--color-surface)); border: 1px solid color-mix(in srgb, var(--color-primary) 20%, var(--color-border)); border-radius: var(--radius-sm); }
+.paycheck-projection p { margin-bottom: var(--space-2); }
+.paycheck-projection p:last-child { margin: 0; font-size: var(--text-sm); }
+.paycheck-projection__date { font-size: var(--text-xl); font-weight: 800; font-variant-numeric: tabular-nums; }
+.paycheck-inactive { padding: var(--space-3); margin: 0; border: 1px solid var(--color-divider); color: var(--color-text-muted); border-radius: var(--radius-sm); }
+.paycheck-evidence { min-width: 0; border-block: 1px solid var(--color-divider); padding-block: var(--space-3); }
+.paycheck-evidence summary { width: fit-content; max-width: 100%; min-height: 32px; cursor: pointer; font-weight: 700; }
+.paycheck-evidence__list { display: grid; gap: var(--space-3); margin: var(--space-3) 0 0; padding: 0; list-style: none; }
+.paycheck-evidence__row { display: flex; justify-content: space-between; gap: var(--space-3); padding: var(--space-3); border-radius: var(--radius-sm); background: var(--color-surface-subtle); overflow-wrap: anywhere; }
+.paycheck-evidence__row > div { display: grid; min-width: 0; gap: var(--space-1); }
+.paycheck-evidence__row span { color: var(--color-text-muted); font-size: var(--text-sm); }
+.paycheck-evidence__row > strong { flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.paycheck-evidence__row .paycheck-evidence__edited { color: var(--color-text); font-weight: 700; }
+.paycheck-actions { flex-wrap: wrap; }
+.paycheck-schedule-note { margin: 0; font-size: var(--text-sm); }
+.paycheck-empty { display: grid; justify-items: start; gap: var(--space-2); margin: 0; padding: var(--space-5); background: var(--color-surface); border: 1px dashed var(--color-border); border-radius: var(--radius-md); color: var(--color-text-muted); }
+.paycheck-empty h3, .paycheck-empty p { margin: 0; }
+.paycheck-empty h3 { color: var(--color-text); }
+.paycheck-manual { padding: var(--space-5); background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); }
+.paycheck-form { display: grid; min-width: 0; gap: var(--space-4); padding-top: var(--space-4); border-top: 1px solid var(--color-divider); }
+.paycheck-form__fields { min-width: 0; margin: 0; padding: 0; border: 0; }
+.paycheck-form__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+.paycheck-form input, .paycheck-form select { max-width: 100%; min-width: 0; }
+.paycheck-form__schedule, .paycheck-form__note { margin: 0; color: var(--color-text-muted); }
+.paycheck-form__error { margin: 0; color: var(--color-danger); }
+.paycheck-form__actions { display: flex; flex-wrap: wrap; gap: var(--space-3); }
+.paycheck-end-confirmation { padding: var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface-subtle); }
+.paycheck-end-confirmation p { margin-bottom: var(--space-3); }
+.paychecks-page h2:focus, .paycheck-feedback:focus { outline: 3px solid color-mix(in srgb, var(--color-focus) 55%, transparent); outline-offset: 3px; }
+@media (max-width: 720px) {
+  .paycheck-card__header, .paycheck-section__header, .paycheck-evidence__row { flex-direction: column; }
+  .paycheck-card__amount { text-align: left; flex-shrink: 1; }
+  .paycheck-card__amount strong { overflow-wrap: anywhere; }
+  .paycheck-facts, .paycheck-form__grid { grid-template-columns: minmax(0, 1fr); }
+  .paycheck-manual { padding: var(--space-4); }
+  .paycheck-evaluated { margin: 0; padding: 0; }
+}


### PR DESCRIPTION
## Summary

Adds the protected Paychecks workflow so users can review recurring deposit evidence, explicitly confirm an accepted expectation, dismiss/reconsider candidates, and create manual expectations. Saved profiles support allowed edits and all lifecycle transitions; active projections are presented as expected and never guaranteed.

Closes #118.

## Authority and scope

**MEDIUM risk**, implementing the exact [approved plan](https://github.com/OL1V3S/ordo/issues/118#issuecomment-5547192275) under [durable owner approval](https://github.com/OL1V3S/ordo/issues/118#issuecomment-5553841562). Base: `aa21d237567b716cc5d83e30f8f3d46cb7e2a40f`.

Frontend only, with the corresponding current-architecture description. No backend, schema, migration, authentication, detector, AccountInflow, budgeting, dependency, or production configuration changes. Existing API contracts and immutable schedules are preserved. Codex has not self-approved or merged this PR; independent command-center review remains required.

## Implementation

- Candidate/profile API module and guarded state hook preserve separate evaluation dates, evidence, safe errors, stale refresh behavior, duplicate-submit protection, and known-success versus uncertain-write outcomes.
- Confirmation, manual creation, and edit forms validate supported schedules, timing windows, and fixed/range amounts. Variable candidates require explicit blank range inputs. Accepted decimal amounts are sent as strings to preserve cents; unsafe numeric read values require explicit review instead of silent rounding.
- Inline forms and lifecycle confirmation provide persistent feedback and focus restoration. Responsive styles and the mobile navigation accommodate Paychecks using existing themes and UI primitives.
- API, validation, hook, form, page, route, and navigation tests cover the approved behavior and error boundaries.

## Verification

- **Passed locally in an isolated source copy:** `npm ci` and `npm run verify` — 269 tests across 36 files, ESLint, and the Vite production build. SHA-256 checks verified the copy, and all 114 frontend files were then matched against the committed Git blobs. No environment files were copied.
- The initial canonical `./scripts/verify.sh frontend` run caught a cancel-focus defect, which was corrected. Subsequent runs in the Desktop checkout encountered intermittent dependency loading/file stalls and unrelated Vite HMR reloads. The clean temporary copy passed the complete lane without application/dependency workarounds; the original checkout's full run is not claimed as a pass.
- **Passed locally in a static build with an isolated synthetic API:** protected-route sign-in, explicit variable-range confirmation, manual month-end creation, permitted edits, pause/end/reactivation, dismissal/reconsideration, evidence expansion, and keyboard focus entry/restoration. Inspected desktop dark, 375px light, and 320px dark layouts; no page overflow, all seven mobile targets exceed 44px, and no runtime errors were recorded. Every observed API request targeted loopback test infrastructure. These are frontend contract/interaction checks, not backend integration evidence.
- **Preview limitation:** Vercel deployment succeeded, but opening its `/paychecks` route redirects the isolated browser to Vercel sign-in protection. Authenticated preview coverage was unavailable; no production credentials or data mutations were used.
- `git diff --check` passed. Bounded internal code/accessibility review found no remaining actionable defect; this is development evidence, not independent PR approval.
- **Proven by CI on `e71a1970c873d4da0bdf86fa1385d5ed1c493ace`:** [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/33985744612/job/101358797355), [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/33985744627/job/101358797158), and [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/33985744627/job/101358797245) all succeeded. Vercel deployment and preview-comment checks also succeeded. This draft is ready for independent command-center review; it has not been self-approved or merged.
- No local backend/PostgreSQL lane is applicable to this frontend-only change. No hosted database or production mutation was used for testing.

Material context expansions were the fixed-width mobile navigation, read-only Paycheck schedule/DTO validation and default decimal JSON binding, and the existing auth page contract for isolated browser setup. Rollback is application rollback without data cleanup.
