### PR TITLE
Fix stale session recovery and visible mobile navigation labels

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,14 @@ constants, theme, UI, and utilities live under
 
 Feature UI and hooks depend on feature or shared API modules. Shared modules
 must not depend on feature-specific UI. The Axios client is the common API
-transport and attaches the current bearer token to requests.
+transport and attaches the current bearer token to requests. A shared session
+module under `frontend/src/shared/auth/` owns the existing token/email storage
+and synchronizes authentication state with React and ordinary cross-tab storage
+changes. An authenticated API `401` clears the matching current session without
+replaying the request; public auth operations explicitly retain their own error
+handling. Request session identity and a per-tab generation prevent late failures
+from invalidating a newer session established in that tab. The backend remains
+authoritative for token validity; the frontend does not refresh or extend tokens.
 
 ### Backend
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -105,6 +105,15 @@ inspect privacy-safe platform status or sanitized application logs. Route a
 deployment-only defect to separately scoped work rather than expanding the
 current issue.
 
+For frontend delivery, verify the actual documented production URL, its assigned
+deployment/source commit, and the assets it serves. A successful preview or
+GitHub deployment status alone does not prove that the production alias has the
+new frontend. When authenticated smoke is authorized, verify the changed route
+and navigation on that exact URL using a private test session; disclose missing
+alias or session access instead of claiming delivery. Alias, domain, project,
+build-setting, environment-variable, and secret changes retain their separate
+authorization gates.
+
 ## Smoke checks after a change
 
 A smoke check is the smallest changed-boundary behavior check after focused

--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
+import { clearSession, getSessionSnapshot, subscribeToSession } from "../shared/auth/session";
 
 import TransactionsPage from "../features/transactions/pages/TransactionsPage";
 import BudgetsPage from "../features/budgetLimits/pages/BudgetsPage";
@@ -17,15 +18,8 @@ import InvestingPage from "./pages/InvestingPage";
 import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
-  const [isLoggedIn, setIsLoggedIn] = useState(
-    !!localStorage.getItem("token")
-  );
-
-  function handleLogout() {
-    localStorage.removeItem("token");
-    localStorage.removeItem("email");
-    setIsLoggedIn(false);
-  }
+  const session = useSyncExternalStore(subscribeToSession, getSessionSnapshot);
+  const isLoggedIn = Boolean(session.token);
 
   return (
     <Routes>
@@ -35,7 +29,7 @@ export default function App() {
           isLoggedIn ? (
             <Navigate to="/overview" replace />
           ) : (
-            <AuthPage onLogin={() => setIsLoggedIn(true)} />
+            <AuthPage />
           )
         }
       />
@@ -44,8 +38,8 @@ export default function App() {
       <Route path="/forgot-password" element={<ForgotPasswordPage />} />
       <Route path="/reset-password" element={<ResetPasswordPage />} />
 
-      <Route element={<ProtectedRoute isAuthenticated={isLoggedIn} />}>
-        <Route element={<AppShell email={localStorage.getItem("email")} onLogout={handleLogout} />}>
+      <Route element={<ProtectedRoute key={session.generation} isAuthenticated={isLoggedIn} />}>
+        <Route element={<AppShell email={session.email} onLogout={clearSession} />}>
           <Route path="/overview" element={<OverviewPage />} />
           <Route path="/transactions" element={<TransactionsPage />} />
           <Route path="/budgets" element={<BudgetsPage />} />
@@ -53,7 +47,7 @@ export default function App() {
           <Route path="/commitments" element={<CommitmentsPage />} />
           <Route path="/paychecks" element={<PaychecksPage />} />
           <Route path="/investing" element={<InvestingPage />} />
-          <Route path="/settings" element={<SettingsPage email={localStorage.getItem("email")} />} />
+          <Route path="/settings" element={<SettingsPage email={session.email} />} />
         </Route>
       </Route>
 

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -1,12 +1,24 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { StrictMode, useState } from 'react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { AxiosError } from 'axios'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import { ThemeProvider } from '../shared/theme/ThemeProvider'
+import client from '../shared/api/client'
+import { authApi } from '../shared/api/authApi'
 
 vi.mock('../features/transactions/pages/TransactionsPage', () => ({
-  default: () => <h1>Transactions workspace</h1>,
+  default: function TransactionsWorkspace() {
+    const [dataOwner] = useState(() => localStorage.getItem('email'))
+    const [draft, setDraft] = useState('')
+    return <>
+      <h1>Transactions workspace</h1>
+      <p>Loaded transactions for {dataOwner}</p>
+      <input aria-label="Transaction draft" value={draft} onChange={(event) => setDraft(event.target.value)} />
+    </>
+  },
 }))
 
 vi.mock('../features/budgetLimits/pages/BudgetsPage', () => ({
@@ -50,16 +62,21 @@ function LocationProbe() {
   return <span data-testid="location">{location.pathname}</span>
 }
 
-function renderAt(path) {
+function renderAt(path, { strict = false } = {}) {
+  const application = <ThemeProvider><App /><LocationProbe /></ThemeProvider>
   return render(
     <MemoryRouter initialEntries={[path]}>
-      <ThemeProvider>
-        <App />
-        <LocationProbe />
-      </ThemeProvider>
+      {strict ? <StrictMode>{application}</StrictMode> : application}
     </MemoryRouter>,
   )
 }
+
+function rejectSession(config) {
+  return Promise.reject(new AxiosError('Unauthorized', AxiosError.ERR_BAD_REQUEST,
+    config, undefined, { status: 401, data: {}, headers: {}, config }))
+}
+
+const originalAdapter = client.defaults.adapter
 
 describe('application routes and shell', () => {
   beforeEach(() => {
@@ -67,7 +84,10 @@ describe('application routes and shell', () => {
     document.documentElement.removeAttribute('data-theme')
   })
 
-  afterEach(() => vi.unstubAllGlobals())
+  afterEach(() => {
+    client.defaults.adapter = originalAdapter
+    vi.unstubAllGlobals()
+  })
 
   it('shows the existing authentication experience at the root without a token', () => {
     renderAt('/')
@@ -129,6 +149,10 @@ describe('application routes and shell', () => {
     expect(navigation).toBeInTheDocument()
     expect(navigation.querySelectorAll('a')).toHaveLength(7)
     expect(within(navigation).getByRole('link', { name: 'Paychecks' })).toHaveAttribute('href', '/paychecks')
+    for (const label of ['Overview', 'Transactions', 'Budgets', 'Analytics', 'Commitments', 'Paychecks', 'Investing']) {
+      const link = within(navigation).getByRole('link', { name: label })
+      expect(within(link).getByText(label, { selector: 'span:not(.sr-only)' })).toBeInTheDocument()
+    }
     expect(screen.getAllByRole('link', { name: /Settings/ })).toHaveLength(2)
   })
 
@@ -154,6 +178,126 @@ describe('application routes and shell', () => {
     expect(localStorage.getItem('token')).toBeNull()
     expect(localStorage.getItem('email')).toBeNull()
     expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
+  })
+
+  it.each(['/overview', '/transactions', '/budgets', '/analytics', '/commitments', '/paychecks', '/investing', '/settings'])(
+    'recovers from a stale stored session on %s when the first protected request returns 401', async (path) => {
+      localStorage.setItem('token', 'synthetic-malformed-session')
+      localStorage.setItem('email', 'stale@example.invalid')
+      localStorage.setItem('budget-planner-theme', 'dark')
+      const adapter = vi.fn(rejectSession)
+      renderAt(path)
+      expect(screen.getByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument()
+
+      await act(async () => {
+        await expect(client.get('/api/paychecks', { adapter })).rejects.toMatchObject({ response: { status: 401 } })
+      })
+
+      expect(adapter).toHaveBeenCalledOnce()
+      expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
+      expect(screen.getByTestId('location')).toHaveTextContent(/^\/$/)
+      expect(screen.queryByRole('navigation', { name: 'Primary navigation' })).not.toBeInTheDocument()
+      expect(screen.queryByText('stale@example.invalid')).not.toBeInTheDocument()
+      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('email')).toBeNull()
+      expect(localStorage.getItem('budget-planner-theme')).toBe('dark')
+    },
+  )
+
+  it('leaves protected navigation on a write 401 without retrying the mutation', async () => {
+    localStorage.setItem('token', 'synthetic-session')
+    localStorage.setItem('email', 'person@example.invalid')
+    const adapter = vi.fn(rejectSession)
+    renderAt('/overview')
+    await userEvent.setup().click(within(screen.getByRole('navigation', { name: 'Primary navigation' })).getByRole('link', { name: /Paychecks/ }))
+    expect(screen.getByTestId('location')).toHaveTextContent('/paychecks')
+
+    await act(async () => {
+      await expect(client.post('/api/paychecks', { displayName: 'Synthetic expectation' }, { adapter })).rejects.toMatchObject({ response: { status: 401 } })
+    })
+
+    expect(adapter).toHaveBeenCalledOnce()
+    expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent(/^\/$/)
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('email')).toBeNull()
+  })
+
+  it('keeps the protected shell and identity after a successful authenticated response', async () => {
+    localStorage.setItem('token', 'synthetic-session')
+    localStorage.setItem('email', 'person@example.invalid')
+    renderAt('/paychecks')
+    await act(async () => {
+      await client.get('/api/paychecks', { adapter: async (config) => ({ data: [], status: 200, headers: {}, config }) })
+    })
+    expect(screen.getByRole('heading', { name: 'Paychecks workspace' })).toBeInTheDocument()
+    expect(screen.getByText('person@example.invalid')).toBeInTheDocument()
+    expect(localStorage.getItem('token')).toBe('synthetic-session')
+  })
+
+  it('keeps public recovery routing and stored identity when a public auth request returns 401', async () => {
+    localStorage.setItem('token', 'synthetic-session')
+    localStorage.setItem('email', 'person@example.invalid')
+    client.defaults.adapter = vi.fn(rejectSession)
+    renderAt('/forgot-password')
+    await act(async () => {
+      await expect(authApi.forgotPassword({ email: 'person@example.invalid' })).rejects.toMatchObject({ response: { status: 401 } })
+    })
+    expect(screen.getByRole('heading', { name: 'Forgot password content' })).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent('/forgot-password')
+    expect(localStorage.getItem('token')).toBe('synthetic-session')
+    expect(localStorage.getItem('email')).toBe('person@example.invalid')
+  })
+
+  it('observes invalidation before subscription and through StrictMode remounts', async () => {
+    localStorage.setItem('token', 'synthetic-session')
+    localStorage.setItem('email', 'person@example.invalid')
+    await expect(client.get('/api/paychecks', { adapter: rejectSession })).rejects.toMatchObject({ response: { status: 401 } })
+    const first = renderAt('/paychecks', { strict: true })
+    expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
+    first.unmount()
+
+    localStorage.setItem('token', 'another-synthetic-session')
+    renderAt('/paychecks', { strict: true })
+    await act(async () => {
+      await expect(client.get('/api/paychecks', { adapter: rejectSession })).rejects.toMatchObject({ response: { status: 401 } })
+    })
+    expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
+  })
+
+  it('synchronizes another tab clearing the session without waiting for an API request', async () => {
+    localStorage.setItem('token', 'synthetic-session')
+    localStorage.setItem('email', 'person@example.invalid')
+    renderAt('/paychecks')
+    act(() => {
+      localStorage.removeItem('token')
+      localStorage.removeItem('email')
+      window.dispatchEvent(new StorageEvent('storage', { key: 'token', storageArea: localStorage }))
+    })
+    expect(await screen.findByRole('heading', { name: 'Authentication content' })).toBeInTheDocument()
+    expect(screen.queryByText('person@example.invalid')).not.toBeInTheDocument()
+  })
+
+  it('discards protected page data and drafts when another tab replaces the session', async () => {
+    const user = userEvent.setup()
+    localStorage.setItem('token', 'first-session')
+    localStorage.setItem('email', 'first@example.invalid')
+    renderAt('/transactions')
+    expect(screen.getByText('Loaded transactions for first@example.invalid')).toBeInTheDocument()
+    await user.type(screen.getByRole('textbox', { name: 'Transaction draft' }), 'First account draft')
+
+    act(() => {
+      // A suspended tab can observe the replacement before queued logout events.
+      localStorage.setItem('token', 'second-session')
+      localStorage.setItem('email', 'second@example.invalid')
+      window.dispatchEvent(new StorageEvent('storage', { key: 'token', storageArea: localStorage }))
+    })
+
+    expect(screen.getByText('second@example.invalid')).toBeInTheDocument()
+    expect(screen.queryByText('Loaded transactions for first@example.invalid')).not.toBeInTheDocument()
+    expect(screen.getByText('Loaded transactions for second@example.invalid')).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Transaction draft' })).toHaveValue('')
+    expect(screen.getByTestId('location')).toHaveTextContent('/transactions')
   })
 
   it('exposes account identity and logout through the mobile account menu', async () => {

--- a/frontend/src/features/auth/components/AuthFlows.test.jsx
+++ b/frontend/src/features/auth/components/AuthFlows.test.jsx
@@ -44,6 +44,38 @@ describe('existing authentication flows', () => {
     expect(localStorage.getItem('email')).toBe('person@example.com')
   })
 
+  it('establishes the session without requiring an App callback', async () => {
+    const user = userEvent.setup()
+    const alert = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    authApi.login.mockResolvedValue({ data: { token: 'new-synthetic-session', email: 'person@example.invalid' } })
+    renderAt(<AuthPage />)
+    await user.type(screen.getByLabelText('Email'), 'person@example.invalid')
+    await user.type(screen.getByLabelText('Password'), 'Synthetic1!')
+    await user.click(screen.getByRole('button', { name: 'Log In' }))
+    await waitFor(() => expect(localStorage.getItem('token')).toBe('new-synthetic-session'))
+    expect(localStorage.getItem('email')).toBe('person@example.invalid')
+    expect(alert).not.toHaveBeenCalled()
+    alert.mockRestore()
+  })
+
+  it('retains the public login 401 message without establishing a session', async () => {
+    const user = userEvent.setup()
+    const onLogin = vi.fn()
+    const alert = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    authApi.login.mockRejectedValue({ response: { status: 401, data: 'Invalid credentials' } })
+    renderAt(<AuthPage onLogin={onLogin} />)
+    await user.type(screen.getByLabelText('Email'), 'person@example.invalid')
+    await user.type(screen.getByLabelText('Password'), 'Synthetic1!')
+    await user.click(screen.getByRole('button', { name: 'Log In' }))
+    await waitFor(() => expect(alert).toHaveBeenCalledWith('Invalid credentials'))
+    expect(onLogin).not.toHaveBeenCalled()
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('email')).toBeNull()
+    log.mockRestore()
+    alert.mockRestore()
+  })
+
   it('keeps the neutral registration delivery failure and rate-limit presentation', async () => {
     const user = userEvent.setup()
     authApi.register.mockRejectedValue({

--- a/frontend/src/features/auth/components/AuthPage.jsx
+++ b/frontend/src/features/auth/components/AuthPage.jsx
@@ -1,5 +1,6 @@
 import { useId, useState } from "react";
 import { authApi } from "../../../shared/api/authApi";
+import { establishSession } from "../../../shared/auth/session";
 import { Eye, EyeOff } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
@@ -39,10 +40,9 @@ export default function AuthPage({ onLogin }) {
 
       const res = await authApi.login({ email, password });
 
-      localStorage.setItem("token", res.data.token);
-      localStorage.setItem("email", res.data.email);
+      establishSession(res.data.token, res.data.email);
 
-      onLogin();
+      onLogin?.();
     } catch (err) {
       console.log("Auth error:", err.response?.data || err.message);
 

--- a/frontend/src/shared/api/authApi.js
+++ b/frontend/src/shared/api/authApi.js
@@ -1,18 +1,20 @@
 import client from "./client";
 
+const publicAuthRequest = { skipSessionInvalidation: true };
+
 export const authApi = {
-  register: (payload) => client.post("/api/auth/register", payload),
-  login: (payload) => client.post("/api/auth/login", payload),
+  register: (payload) => client.post("/api/auth/register", payload, publicAuthRequest),
+  login: (payload) => client.post("/api/auth/login", payload, publicAuthRequest),
 
   resendConfirmation: (payload) =>
-    client.post("/api/auth/resend-confirmation", payload),
+    client.post("/api/auth/resend-confirmation", payload, publicAuthRequest),
 
   confirmEmail: (payload) =>
-    client.post("/api/auth/confirm-email", payload),
+    client.post("/api/auth/confirm-email", payload, publicAuthRequest),
 
   forgotPassword: (payload) =>
-    client.post("/api/auth/forgot-password", payload),
+    client.post("/api/auth/forgot-password", payload, publicAuthRequest),
 
   resetPassword: (payload) =>
-    client.post("/api/auth/reset-password", payload),
+    client.post("/api/auth/reset-password", payload, publicAuthRequest),
 };

--- a/frontend/src/shared/api/authApi.test.js
+++ b/frontend/src/shared/api/authApi.test.js
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AxiosError } from 'axios'
+import client from './client'
+import { authApi } from './authApi'
+import { establishSession, getSessionSnapshot, subscribeToSession } from '../auth/session'
+
+const operations = [
+  ['register', '/api/auth/register', { email: 'person@example.com', password: 'Synthetic1!' }],
+  ['login', '/api/auth/login', { email: 'person@example.com', password: 'Synthetic1!' }],
+  ['resendConfirmation', '/api/auth/resend-confirmation', { email: 'person@example.com' }],
+  ['confirmEmail', '/api/auth/confirm-email', { userId: 'synthetic-user', token: 'confirmation+value' }],
+  ['forgotPassword', '/api/auth/forgot-password', { email: 'person@example.com' }],
+  ['resetPassword', '/api/auth/reset-password', { email: 'person@example.com', token: 'reset+value', newPassword: 'Synthetic2!' }],
+]
+
+describe('public authentication requests', () => {
+  let originalAdapter
+  let unsubscribe
+
+  beforeEach(() => {
+    originalAdapter = client.defaults.adapter
+    localStorage.clear()
+    establishSession('stored-token', 'person@example.com')
+  })
+
+  afterEach(() => {
+    client.defaults.adapter = originalAdapter
+    unsubscribe?.()
+    unsubscribe = undefined
+  })
+
+  it.each(operations)('%s preserves its request and error behavior without invalidating a session', async (operation, url, payload) => {
+    const current = getSessionSnapshot()
+    const listener = vi.fn()
+    unsubscribe = subscribeToSession(listener)
+    let requestConfig
+    let originalError
+    const adapter = vi.fn(async (config) => {
+      requestConfig = config
+      originalError = new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, undefined, {
+        status: 401, statusText: 'Unauthorized', data: 'Public authentication error', headers: {}, config,
+      })
+      throw originalError
+    })
+    client.defaults.adapter = adapter
+
+    const error = await authApi[operation](payload).catch((failure) => failure)
+
+    expect(requestConfig.url).toBe(url)
+    expect(requestConfig.method).toBe('post')
+    expect(JSON.parse(requestConfig.data)).toEqual(payload)
+    expect(requestConfig.headers.Authorization).toBe('Bearer stored-token')
+    expect(error).toBe(originalError)
+    expect(error.response.data).toBe('Public authentication error')
+    expect(adapter).toHaveBeenCalledOnce()
+    expect(getSessionSnapshot()).toBe(current)
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/shared/api/client.js
+++ b/frontend/src/shared/api/client.js
@@ -1,17 +1,34 @@
 import axios from "axios";
+import { getSessionSnapshot, invalidateSession } from "../auth/session";
 
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
-client.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
+const requestSessions = new WeakMap();
 
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+client.interceptors.request.use((config) => {
+  const session = getSessionSnapshot();
+
+  if (session.token) {
+    config.headers.Authorization = `Bearer ${session.token}`;
+    if (!config.skipSessionInvalidation) requestSessions.set(config, session);
   }
 
   return config;
 });
+
+client.interceptors.response.use(
+  (response) => {
+    requestSessions.delete(response.config);
+    return response;
+  },
+  (error) => {
+    const session = requestSessions.get(error.config);
+    requestSessions.delete(error.config);
+    if (error.response?.status === 401 && session) invalidateSession(session);
+    return Promise.reject(error);
+  },
+);
 
 export default client;

--- a/frontend/src/shared/api/client.test.js
+++ b/frontend/src/shared/api/client.test.js
@@ -1,5 +1,25 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AxiosError, CanceledError } from 'axios'
 import client from './client'
+import { clearSession, establishSession, getSessionSnapshot, subscribeToSession } from '../auth/session'
+
+function httpError(config, status = 401) {
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, undefined, {
+    data: { message: 'Request failed' }, status, statusText: 'Error', headers: {}, config,
+  })
+}
+
+function pendingRequest() {
+  let fail
+  let entered
+  const started = new Promise((resolve) => { entered = resolve })
+  const adapter = vi.fn((config) => new Promise((_resolve, reject) => {
+    fail = () => reject(httpError(config))
+    entered()
+  }))
+  const result = client.get('/api/expenses', { adapter }).catch((error) => error)
+  return { started, result, adapter, reject: () => fail() }
+}
 
 describe('API authorization', () => {
   beforeEach(() => localStorage.clear())
@@ -41,5 +61,141 @@ describe('API authorization', () => {
     })
 
     expect(requestConfig.headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('authenticated response recovery', () => {
+  const subscriptions = []
+
+  beforeEach(() => {
+    localStorage.clear()
+    establishSession('current-token', 'person@example.com')
+  })
+
+  afterEach(() => subscriptions.splice(0).forEach((unsubscribe) => unsubscribe()))
+
+  it.each(['get', 'post', 'put', 'patch', 'delete'])('invalidates a failed %s once and never replays the request', async (method) => {
+    localStorage.setItem('budget-planner-theme', 'dark')
+    const listener = vi.fn()
+    subscriptions.push(subscribeToSession(listener))
+    let originalError
+    const adapter = vi.fn(async (config) => {
+      originalError = httpError(config)
+      throw originalError
+    })
+
+    const error = await client.request({ url: '/api/expenses', method, data: { amount: 10 }, adapter }).catch((failure) => failure)
+
+    expect(error).toBe(originalError)
+    expect(adapter).toHaveBeenCalledOnce()
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('email')).toBeNull()
+    expect(localStorage.getItem('budget-planner-theme')).toBe('dark')
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('makes simultaneous authenticated 401s idempotent', async () => {
+    const listener = vi.fn()
+    subscriptions.push(subscribeToSession(listener))
+    const first = pendingRequest()
+    const second = pendingRequest()
+    await Promise.all([first.started, second.started])
+
+    first.reject()
+    second.reject()
+    const results = await Promise.all([first.result, second.result])
+
+    results.forEach((error) => expect(error.response.status).toBe(401))
+    expect(listener).toHaveBeenCalledOnce()
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(first.adapter).toHaveBeenCalledOnce()
+    expect(second.adapter).toHaveBeenCalledOnce()
+  })
+
+  it.each(['logout', 'different-token', 'same-token'])('ignores an old 401 after %s', async (transition) => {
+    const request = pendingRequest()
+    await request.started
+    clearSession()
+    if (transition !== 'logout') {
+      establishSession(transition === 'same-token' ? 'current-token' : 'new-token', 'new@example.com')
+    }
+    const current = getSessionSnapshot()
+    const listener = vi.fn()
+    subscriptions.push(subscribeToSession(listener))
+
+    request.reject()
+    expect((await request.result).response.status).toBe(401)
+
+    expect(getSessionSnapshot()).toBe(current)
+    expect(listener).not.toHaveBeenCalled()
+    expect(request.adapter).toHaveBeenCalledOnce()
+  })
+
+  it('ignores an old 401 when another tab replaces storage before its event arrives', async () => {
+    const request = pendingRequest()
+    await request.started
+    localStorage.setItem('token', 'other-tab-token')
+    localStorage.setItem('email', 'new@example.com')
+
+    request.reject()
+    await request.result
+
+    expect(localStorage.getItem('token')).toBe('other-tab-token')
+    expect(localStorage.getItem('email')).toBe('new@example.com')
+  })
+
+  it.each([400, 403, 404, 429, 500])('preserves the session and original error for status %s', async (status) => {
+    const current = getSessionSnapshot()
+    let originalError
+    const adapter = vi.fn(async (config) => {
+      originalError = httpError(config, status)
+      throw originalError
+    })
+    const error = await client.get('/api/expenses', { adapter }).catch((failure) => failure)
+
+    expect(error).toBe(originalError)
+    expect(getSessionSnapshot()).toBe(current)
+    expect(adapter).toHaveBeenCalledOnce()
+  })
+
+  it.each(['network', 'cancellation'])('preserves the session on %s failure', async (kind) => {
+    const current = getSessionSnapshot()
+    let originalError
+    const adapter = vi.fn(async (config) => {
+      originalError = kind === 'network'
+        ? new AxiosError('Network Error', 'ERR_NETWORK', config)
+        : new CanceledError('Request canceled', config)
+      throw originalError
+    })
+    const error = await client.get('/api/expenses', { adapter }).catch((failure) => failure)
+
+    expect(error).toBe(originalError)
+    expect(getSessionSnapshot()).toBe(current)
+    expect(adapter).toHaveBeenCalledOnce()
+  })
+
+  it('does not invalidate for an unauthenticated request returning 401', async () => {
+    clearSession()
+    const request = pendingRequest()
+    await request.started
+    establishSession('later-token', 'person@example.com')
+    const current = getSessionSnapshot()
+
+    request.reject()
+    await request.result
+
+    expect(getSessionSnapshot()).toBe(current)
+  })
+
+  it('passes successful responses through without changing the session', async () => {
+    const current = getSessionSnapshot()
+    const data = { id: 123 }
+    const response = await client.post('/api/expenses', { amount: 10 }, {
+      adapter: async (config) => ({ data, status: 201, statusText: 'Created', headers: {}, config }),
+    })
+
+    expect(response.data).toBe(data)
+    expect(response.status).toBe(201)
+    expect(getSessionSnapshot()).toBe(current)
   })
 })

--- a/frontend/src/shared/auth/session.js
+++ b/frontend/src/shared/auth/session.js
@@ -1,0 +1,64 @@
+let snapshot;
+let generation = 0;
+const listeners = new Set();
+
+export function getSessionSnapshot() {
+  const token = localStorage.getItem("token");
+  const email = localStorage.getItem("email");
+
+  if (snapshot && token !== snapshot.token) generation += 1;
+
+  if (!snapshot || token !== snapshot.token || email !== snapshot.email || generation !== snapshot.generation) {
+    snapshot = Object.freeze({ token, email, generation });
+  }
+
+  return snapshot;
+}
+
+function notifyListeners() {
+  listeners.forEach((listener) => listener());
+}
+
+function handleStorage(event) {
+  if (event.storageArea !== localStorage || ![null, "token", "email"].includes(event.key)) return;
+
+  // Read the latest values: a queued event may describe an older session.
+  getSessionSnapshot();
+  notifyListeners();
+}
+
+export function subscribeToSession(listener) {
+  if (listeners.size === 0) window.addEventListener("storage", handleStorage);
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) window.removeEventListener("storage", handleStorage);
+  };
+}
+
+export function establishSession(token, email) {
+  getSessionSnapshot();
+  localStorage.setItem("token", token);
+  localStorage.setItem("email", email);
+  generation += 1;
+  snapshot = Object.freeze({ token: localStorage.getItem("token"), email: localStorage.getItem("email"), generation });
+  notifyListeners();
+}
+
+export function clearSession() {
+  getSessionSnapshot();
+  localStorage.removeItem("token");
+  localStorage.removeItem("email");
+  generation += 1;
+  snapshot = Object.freeze({ token: null, email: null, generation });
+  notifyListeners();
+}
+
+export function invalidateSession(requestSession) {
+  const current = getSessionSnapshot();
+  if (!requestSession?.token || requestSession.token !== current.token || requestSession.generation !== current.generation) return false;
+
+  clearSession();
+  return true;
+}

--- a/frontend/src/shared/auth/session.test.js
+++ b/frontend/src/shared/auth/session.test.js
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearSession, establishSession, getSessionSnapshot, invalidateSession, subscribeToSession } from './session'
+
+const subscriptions = []
+
+function subscribe(listener = vi.fn()) {
+  const unsubscribe = subscribeToSession(listener)
+  subscriptions.push(unsubscribe)
+  return { listener, unsubscribe }
+}
+
+function storageEvent(key, storageArea = localStorage, newValue = null) {
+  window.dispatchEvent(new StorageEvent('storage', { key, storageArea, newValue }))
+}
+
+describe('shared authentication session', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    getSessionSnapshot()
+  })
+
+  afterEach(() => subscriptions.splice(0).forEach((unsubscribe) => unsubscribe()))
+
+  it('reads existing keys and returns the same snapshot while values are unchanged', () => {
+    localStorage.setItem('token', 'stored-token')
+    localStorage.setItem('email', 'person@example.com')
+    const session = getSessionSnapshot()
+
+    expect(session).toMatchObject({ token: 'stored-token', email: 'person@example.com' })
+    expect(getSessionSnapshot()).toBe(session)
+  })
+
+  it('establishes and clears a session without changing unrelated storage', () => {
+    localStorage.setItem('budget-planner-theme', 'dark')
+    const { listener } = subscribe()
+    establishSession('new-token', 'person@example.com')
+
+    expect(getSessionSnapshot()).toMatchObject({ token: 'new-token', email: 'person@example.com' })
+    expect(localStorage.getItem('token')).toBe('new-token')
+    expect(localStorage.getItem('email')).toBe('person@example.com')
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    clearSession()
+
+    expect(getSessionSnapshot()).toMatchObject({ token: null, email: null })
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('email')).toBeNull()
+    expect(localStorage.getItem('budget-planner-theme')).toBe('dark')
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener.mock.calls).toEqual([[], []])
+  })
+
+  it('invalidates the matching session only once', () => {
+    establishSession('old-token', 'person@example.com')
+    const requestSession = getSessionSnapshot()
+    const { listener } = subscribe()
+
+    expect(invalidateSession(requestSession)).toBe(true)
+    expect(invalidateSession(requestSession)).toBe(false)
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('rejects stale invalidation after establishing the same token again', () => {
+    establishSession('same-token', 'person@example.com')
+    const oldSession = getSessionSnapshot()
+    establishSession('same-token', 'person@example.com')
+
+    expect(getSessionSnapshot().generation).not.toBe(oldSession.generation)
+    expect(invalidateSession(oldSession)).toBe(false)
+    expect(localStorage.getItem('token')).toBe('same-token')
+  })
+
+  it('reconciles a different token before a queued storage event arrives', () => {
+    establishSession('old-token', 'old@example.com')
+    const oldSession = getSessionSnapshot()
+    localStorage.setItem('token', 'other-tab-token')
+    localStorage.setItem('email', 'new@example.com')
+
+    expect(invalidateSession(oldSession)).toBe(false)
+    expect(getSessionSnapshot()).toMatchObject({ token: 'other-tab-token', email: 'new@example.com' })
+  })
+
+  it('observes other-tab logout and email changes with stable snapshots', () => {
+    establishSession('stored-token', 'old@example.com')
+    const { listener } = subscribe()
+    const previous = getSessionSnapshot()
+    localStorage.setItem('email', 'new@example.com')
+    storageEvent('email', localStorage, 'new@example.com')
+
+    expect(getSessionSnapshot()).toMatchObject({ token: 'stored-token', email: 'new@example.com', generation: previous.generation })
+    expect(getSessionSnapshot()).not.toBe(previous)
+    expect(getSessionSnapshot()).toBe(getSessionSnapshot())
+
+    localStorage.removeItem('token')
+    localStorage.removeItem('email')
+    storageEvent('token')
+    expect(getSessionSnapshot()).toMatchObject({ token: null, email: null })
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('handles localStorage clear without reacting to unrelated storage events', () => {
+    establishSession('stored-token', 'person@example.com')
+    const { listener } = subscribe()
+    storageEvent('budget-planner-theme')
+    storageEvent('token', sessionStorage)
+    expect(listener).not.toHaveBeenCalled()
+
+    localStorage.clear()
+    storageEvent(null)
+    expect(getSessionSnapshot()).toMatchObject({ token: null, email: null })
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('does not replay stale event values or advance an already reconciled generation', () => {
+    establishSession('old-token', 'old@example.com')
+    localStorage.setItem('token', 'new-token')
+    localStorage.setItem('email', 'new@example.com')
+    const current = getSessionSnapshot()
+    const { listener } = subscribe()
+    storageEvent('token', localStorage, 'old-token')
+
+    expect(getSessionSnapshot()).toBe(current)
+    expect(listener).toHaveBeenCalledOnce()
+    expect(invalidateSession(current)).toBe(true)
+  })
+
+  it('cleans up listeners and reads invalidation that happened before subscribing', () => {
+    establishSession('old-token', 'person@example.com')
+    const { listener, unsubscribe } = subscribe()
+    unsubscribe()
+    clearSession()
+    storageEvent('token')
+    expect(listener).not.toHaveBeenCalled()
+
+    const next = subscribe()
+    expect(getSessionSnapshot()).toMatchObject({ token: null, email: null })
+    establishSession('new-token', 'person@example.com')
+    expect(next.listener).toHaveBeenCalledOnce()
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -45,8 +45,7 @@ input:focus, select:focus, textarea:focus { border-color: var(--color-focus); bo
 .app-nav__link:hover { color: var(--color-text); background: var(--color-surface-raised); }
 .app-nav__link--active { color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 6%, transparent); }
 .app-nav__link--active::before { position: absolute; right: var(--space-3); bottom: -1px; left: var(--space-3); height: 2px; background: var(--color-primary); content: ""; }
-.mobile-nav .app-nav__link { min-width: 0; min-height: 58px; flex-direction: column; justify-content: center; gap: 2px; padding: var(--space-1) 1px; font-size: clamp(.58rem, 2.3vw, .7rem); text-align: center; }
-.mobile-nav .app-nav__link > span:not(.sr-only) { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
+.mobile-nav .app-nav__link { min-width: 88px; min-height: 58px; flex-direction: column; justify-content: center; gap: 2px; padding: var(--space-1) var(--space-2); font-size: clamp(.7rem, 2.3vw, .78rem); text-align: center; white-space: nowrap; }
 .mobile-nav .app-nav__link:hover { transform: none; }
 .mobile-nav .app-nav__link--active::before { top: 0; right: 30%; bottom: auto; left: 30%; width: auto; height: 3px; }
 .app-sidebar .app-nav { align-items: stretch; flex-direction: column; }

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -36,7 +36,7 @@
 .app-content { min-width: 0; padding: var(--space-4); padding-bottom: 6.75rem; }
 .app-content > .container { width: 100%; max-width: none; margin: 0; padding: 0; }
 .shell-page { width: 100%; padding-block: var(--space-2) var(--space-6); animation: page-enter var(--duration-normal) var(--ease-standard); }
-.mobile-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-auto-flow: column; grid-auto-columns: minmax(44px, 1fr); overflow-x: auto; padding: var(--space-1); border-top: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 -6px 18px rgb(24 23 22 / 8%); }
+.mobile-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-auto-flow: column; grid-auto-columns: minmax(88px, 1fr); overflow-x: auto; padding: var(--space-1); border-top: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 -6px 18px rgb(24 23 22 / 8%); }
 @keyframes page-enter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 @media (min-width: 900px) {
   .app-shell { display: grid; grid-template-columns: 200px minmax(0, 1fr); }


### PR DESCRIPTION
## Summary

An expired stored token previously left the app looking signed in after authenticated requests failed. Centralized session recovery now clears token/email and returns the user to login on a matching protected 401, without replaying the request. Mobile navigation displays all seven destination labels in horizontally scrollable columns with usable touch targets.

Refs #120 — this PR completes the approved frontend slice; production Paychecks delivery remains unresolved and the issue must stay open.

**Risk: HIGH (authentication/session behavior).** Implements the [approved plan](https://github.com/OL1V3S/ordo/issues/120#issuecomment-5554250182) with [durable owner approval](https://github.com/OL1V3S/ordo/issues/120#issuecomment-5555036669). Based on main `46d2f135fd9b1113d8f1a15996a91237fe4d3291`.

## Implementation and boundaries

- Shared session snapshot/subscription integrates with React, successful login, manual logout, and ordinary cross-tab storage events. Token plus per-tab generation guard against late and simultaneous 401s. Session replacement remounts protected pages so previous account data/drafts cannot remain under the new identity.
- The shared Axios client invalidates only matching authenticated 401s, rejects the original error, and never retries. All six public auth operations explicitly opt out; public payloads, headers, errors and recovery/privacy behavior remain intact. Other HTTP statuses, network failures and cancellation preserve the session.
- Mobile-only CSS removes visually clipped labels and provides 88px columns. Desktop navigation/order is unchanged.
- Includes only the approved architecture/session description and production-alias verification reminder.
- No backend, JWT policy, token decoding/timers, refresh tokens, cookies, API contract, financial semantics, schema/migration or dependency changes. No production access with user credentials, production writes, configuration edits or production deployment.

## Verification

**Passed locally** in a fresh Git clone at `/private/tmp/ordo-120-work`:

- `./scripts/verify.sh frontend` (npm ci, all tests, ESLint, production build), followed after the bounded lifecycle correction by full `npm run verify`: **319 tests across 38 files**, ESLint and Vite build passed. Node 22.13.1 / npm 10.9.2. `git diff --check` and staged diff check passed.
- Tests cover all eight protected routes, login/manual logout, all six public auth operations, original errors/no replay for GET/POST/PUT/PATCH/DELETE, simultaneous/late 401s, same-token same-tab relogin, storage synchronization, StrictMode/subscription lifecycle, and discarded old page state after account replacement.
- Real browser against a production build and isolated loopback synthetic API: desktop Paychecks navigation/route; visible labels at 320px and 375px in light/dark themes; 88×56px mobile links, horizontal scrolling, active styling and keyboard focus; focused submit control clear of fixed navigation. Initial-load protected 401 and form-write 401 returned to `/` without refresh; fixture recorded exactly one failed `POST /api/paychecks`. Re-login, manual logout and cross-tab logout passed. Synthetic build override and fixture were temporary and are not committed.
- Scoped development review found and corrected protected-state retention on cross-tab account replacement. This is development evidence, not independent command-center PR approval.

The original Desktop checkout was preserved untouched after fetch exposed a malformed local ref (`refs/heads/codex/118-paychecks-frontend 2`). The fresh clone was verified clean at current main before creating this branch; no repair, stash, reset or cleanup was attempted in the original checkout.

**Required/proven by CI — passed** on PR head `ef095e0703a9ae6d5874c99a6fc198ef4cd14587`: [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/33995342241/job/101384804668), [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/33995342223/job/101384804697), and [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/33995342223/job/101384804503). Backend/PostgreSQL local lanes are excluded by the approved frontend-only plan; required CI still applies. The Vercel preview status succeeded, but its URL returns HTTP 302 to Vercel SSO, so no hosted preview smoke is claimed. Independent command-center review remains required.

## Production visibility and remaining delivery gate

The actual documented URL `https://oli-budget-planner.vercel.app/paychecks` was rechecked on September 5: HTTP 200 still serves `index-qCxYQ7Sd.js` and `index-lujBIR3V.css`, Last-Modified September 3 09:14:54 UTC. The approved-plan inspection proved this older JS lacks `/paychecks` and its label. GitHub's successful deployment for main points at a different, authentication-protected deployment URL; a green status/preview does not establish delivery to the documented alias.

Exact alias-to-project/deployment mapping remains inaccessible with current Vercel access. After review/merge, authorized read access must establish that mapping and source SHA, then the exact documented URL needs an authorized private authenticated Paychecks smoke check. Any production alias/domain/project/build-setting/environment-variable/secret change needs its own concrete proposal and separate explicit owner approval. This PR does not claim the production visibility symptom is fixed and does not close #120.

## Risks and rollback

Forced sign-out discards unsaved UI state; do not auto-resubmit it. Recovery occurs when the backend first proves the token invalid, not on a page that makes no authenticated request. Per-tab generation does not introduce a shared cross-tab identity protocol. Rollback is a reviewed frontend revert to a verified prior artifact, which may restore the reported defects; no data cleanup or backend rollback is involved.

Material context expansions stayed within the approved plan: read-only issuance/public auth behavior, deployed public assets and metadata, mobile computed styles, and the protected route/transaction hook to confirm the lifecycle correction.

**Draft; stop before merge per the implementation handoff. Codex must not self-approve or merge.**
