### PR TITLE
Fix PostgreSQL paycheck concurrency test exception unwrapping

### DIFF
--- a/backend.Tests/Financial/PostgreSqlPaycheckTests.cs
+++ b/backend.Tests/Financial/PostgreSqlPaycheckTests.cs
@@ -411,9 +411,14 @@ public sealed class PostgreSqlPaycheckTests
                 await transaction.CommitAsync();
                 return true;
             }
-            catch (Exception exception) when (exception is PostgresException or DbUpdateException)
+            catch (Exception exception)
             {
-                var postgres = exception as PostgresException ?? exception.InnerException as PostgresException;
+                Exception? cause = exception;
+                while (cause is not null && cause is not PostgresException)
+                {
+                    cause = cause.InnerException;
+                }
+                var postgres = cause as PostgresException;
                 Assert.NotNull(postgres);
                 Assert.Contains(postgres.SqlState, new[] { PostgresErrorCodes.UniqueViolation, PostgresErrorCodes.SerializationFailure });
                 await transaction.RollbackAsync();


### PR DESCRIPTION
## Summary

The PostgreSQL concurrency test now finds the expected losing transaction's `PostgresException` through the full `InnerException` chain, including EF's outer `InvalidOperationException` wrapper. It still accepts only `UniqueViolation` or `SerializationFailure`.

## Issue

Closes #124. Resolves the unchanged test-harness CI blocker identified on #123.

## Risk

- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

## Changes

Replace the restricted catch and one-level lookup with an inline exception-chain walk in the single concurrency test. Preserve the existing SQLSTATE assertions, rollback, one-success/one-failure assertions, and one-profile/one-occurrence assertions. Exceptions with no PostgreSQL cause and unexpected SQLSTATEs still fail the test.

## Non-goals

No runtime/application code, financial semantics, isolation level, retry behavior, EF/Npgsql configuration, schema, migrations, dependencies, workflows, or PR #123 frontend files changed. No production operations.

## Verification

### Passed locally

- Reproduced the unchanged test's `InvalidOperationException -> DbUpdateException -> PostgresException(40001)` failure on disposable local PostgreSQL 16.
- Corrected focused concurrency test: **10 consecutive runs passed**, one test per run.
- `./scripts/verify.sh postgresql`: **1 migration-chain test and all 40 financial integration tests passed**, none skipped.
- `./scripts/verify.sh backend`: **457 tests passed**, none skipped.
- `git diff --check`: passed; only `backend.Tests/Financial/PostgreSqlPaycheckTests.cs` changed.

### Not run locally — capability unavailable

None for the changed test scope. .NET 9 and disposable local PostgreSQL 16 were available. The temporary local database container was removed after verification.

### Required/proven by CI

All required checks passed for head `7051f1326634d0a0d3fb8cf268d16dd68735b59b`:

- [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/34059100225/job/101556288241).
- [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/34059100228/job/101556288140), including production backend image verification.
- [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/34059100228/job/101556288036).

Frontend verification was performed by the required CI lane for this backend-test-only change.

### Smoke checks (supplemental)

No UI smoke check applies to this test-only correction. The repeated real PostgreSQL race runs above directly exercise the changed path.

### Preview evidence (non-blocking)

Automatic Vercel and Vercel Preview Comments checks passed. They are supplemental and are not required test gates.

### Remaining verification gaps

None for required executable verification. Independent command-center PR review remains required before the owner's merge. Local development review found no scope or exception-handling defects; it does not replace independent PR review.

## API impact

None.

## Database / migration impact

None. Verification used only the existing disposable local PostgreSQL test harness.

## Dependency impact

None.

## Deployment considerations

None. Test-only change; stop before merge.

## Review notes

Check that only the two approved SQLSTATEs can reach rollback and the expected `false` result. Context expanded to the PostgreSQL fixture's disposable-database guard and the existing CI PostgreSQL image only to establish safe, matching local verification.

After this fix is independently reviewed and merged by the owner, #123 must be updated/re-run against current main and pass its own required CI and independent review. This PR does not alter #123.

After merge is confirmed and the work is complete, clean up the merged remote feature branch according to `AGENTS.md`. This is a post-merge action.
