### PR TITLE
Add exact historical cash-flow analytics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,14 @@ Desktop retains individual destinations. Home preserves the recorded-spending
 summary and offers direct links to the planning features. Theme tokens also
 drive chart presentation in explicit and system appearance modes.
 
+Analytics combines historical cash in and Expenses through an analytics-local
+read API and session-aware snapshot hook. The selected-month comparison and
+six-month trend show all recorded inflows, with confirmed-paycheck-linked and
+other inflows as an exact partition. Exact cent strings are formatted with
+integer arithmetic; approximate numbers are used only for chart geometry.
+Accessible text and disclosures accompany the graphs. Existing spending/budget
+drilldowns retain their separate read boundaries and behavior.
+
 Feature UI and hooks depend on feature or shared API modules. Shared modules
 must not depend on feature-specific UI. The Axios client is the common API
 transport and attaches the current bearer token to requests. A shared session
@@ -103,6 +111,16 @@ display name, and lifecycle are explicitly editable. The Paychecks frontend
 consumes these contracts without changing their semantics. Paycheck change
 detection is not included. See the paycheck section of
 [`docs/financial-domain-invariants.md`](docs/financial-domain-invariants.md).
+
+`backend/Analytics/` owns the historical cash-flow read model and pure exact-cent
+aggregation. The authenticated `/api/analytics/cash-flow` endpoint reads owner
+Expenses, AccountInflows, and owner-consistent paycheck evidence membership in
+one read-only repeatable-read PostgreSQL snapshot. It returns selected-month
+totals/categories, explicit monthly trend buckets, record counts, and available
+months, with monetary amounts encoded as integer-cent strings. It does not
+invoke candidate detection or projection, write financial data, or introduce
+new persistence. Current recorded dates and amounts govern history; the explicit
+date-only cutoff preserves the Analytics browser-local calendar convention.
 
 ### Authentication and ownership boundaries
 

--- a/backend.Tests/Financial/CashFlowAggregationTests.cs
+++ b/backend.Tests/Financial/CashFlowAggregationTests.cs
@@ -1,0 +1,171 @@
+using BudgetPlanner.Analytics;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+public sealed class CashFlowAggregationTests
+{
+    [Theory]
+    [InlineData(null, "2026-09-10")]
+    [InlineData("2026-09", null)]
+    [InlineData("2026-9", "2026-09-10")]
+    [InlineData("2026-09-01", "2026-09-10")]
+    [InlineData("2026-00", "2026-09-10")]
+    [InlineData("2026-13", "2026-09-10")]
+    [InlineData("0000-01", "2026-09-10")]
+    [InlineData("10000-01", "2026-09-10")]
+    [InlineData("2026-09", "2026-9-10")]
+    [InlineData("2026-09", "2026-09-10T00:00:00Z")]
+    [InlineData("2026-09", " 2026-09-10")]
+    [InlineData("2026-02", "2026-02-29")]
+    [InlineData("2026-04", "2026-04-31")]
+    [InlineData("2026-10", "2026-09-30")]
+    public void Invalid_or_noncanonical_periods_are_rejected(string? month, string? cutoff)
+    {
+        Assert.False(CashFlowPeriod.TryCreate(month, cutoff, out var period));
+        Assert.Null(period);
+    }
+
+    [Theory]
+    [InlineData("2024-02", "2024-02-29", "2023-09-01", "2024-02-29", 6)]
+    [InlineData("2024-02", "2026-09-10", "2023-09-01", "2024-02-29", 6)]
+    [InlineData("2026-01", "2026-01-10", "2025-08-01", "2026-01-10", 6)]
+    [InlineData("0001-01", "0001-01-01", "0001-01-01", "0001-01-01", 1)]
+    [InlineData("0001-03", "0001-03-31", "0001-01-01", "0001-03-31", 3)]
+    [InlineData("9999-12", "9999-12-31", "9999-07-01", "9999-12-31", 6)]
+    public void Calendar_periods_have_explicit_inclusive_bounds_without_overflow(
+        string month, string cutoff, string trendStart, string selectedEnd, int count)
+    {
+        var period = Period(month, cutoff);
+        var response = CashFlowAggregation.Aggregate(period, [], [], [], []);
+
+        Assert.Equal(DateOnly.Parse(trendStart), period.TrendFrom);
+        Assert.Equal(DateOnly.Parse(selectedEnd), response.To);
+        Assert.Equal(count, response.Months.Count);
+        Assert.Equal(response.Selected, response.Months[^1]);
+        Assert.Equal(month, response.Selected.Month);
+        Assert.All(response.Months, value =>
+        {
+            Assert.Equal("0", value.CashInMinor);
+            Assert.Equal("0", value.PaycheckCashInMinor);
+            Assert.Equal("0", value.OtherCashInMinor);
+            Assert.Equal("0", value.SpentMinor);
+            Assert.Equal("0", value.NetMinor);
+            Assert.Equal(0, value.InflowCount);
+            Assert.Equal(0, value.ExpenseCount);
+        });
+    }
+
+    [Fact]
+    public void Partition_uses_observed_values_and_membership_without_multiplying_money()
+    {
+        var revision = Guid.NewGuid();
+        var profile = Guid.NewGuid();
+        CashFlowInflowRow[] inflows =
+        [
+            new(1, new(2026, 9, 1), 100.01m, revision),
+            new(2, new(2026, 9, 1), 100.01m, revision), // Separate, identical-looking saved observation.
+            new(3, new(2026, 9, 10), 20m, Guid.NewGuid()),
+            new(4, new(2026, 9, 11), 999m, revision)
+        ];
+        CashFlowMembershipRow[] memberships =
+        [
+            new(1, profile, revision), new(1, profile, revision),
+            new(3, Guid.NewGuid(), revision), new(4, profile, revision)
+        ];
+        CashFlowExpenseRow[] expenses =
+        [
+            new(1, new(2026, 9, 1), 200m, "transfers"),
+            new(2, new(2026, 9, 10), 40m, "uncategorized"),
+            new(3, new(2026, 9, 11), 900m, "future")
+        ];
+
+        var response = CashFlowAggregation.Aggregate(Period(), inflows, expenses, memberships, inflows.Select(value => value.Date));
+
+        Assert.Equal("22002", response.Selected.CashInMinor);
+        Assert.Equal("12001", response.Selected.PaycheckCashInMinor);
+        Assert.Equal("10001", response.Selected.OtherCashInMinor);
+        Assert.Equal("24000", response.Selected.SpentMinor);
+        Assert.Equal("-1998", response.Selected.NetMinor);
+        Assert.Equal(3, response.Selected.InflowCount);
+        Assert.Equal(2, response.Selected.PaycheckInflowCount);
+        Assert.Equal(1, response.Selected.OtherInflowCount);
+        Assert.Equal(2, response.Selected.PaycheckProfileCount);
+        Assert.Equal(1, response.Selected.EditedPaycheckInflowCount);
+        Assert.Equal(2, response.Selected.ExpenseCount);
+        Assert.Equal(["transfers", "uncategorized"], response.Categories.Select(value => value.Category));
+        Assert.Equal(["20000", "4000"], response.Categories.Select(value => value.AmountMinor));
+    }
+
+    [Fact]
+    public void Maximum_amounts_aggregate_exactly_beyond_one_record_and_javascript_ranges()
+    {
+        var revision = Guid.NewGuid();
+        var maximum = 9999999999999999.99m;
+        var response = CashFlowAggregation.Aggregate(Period(),
+            [new(1, new(2026, 9, 1), maximum, revision), new(2, new(2026, 9, 1), maximum, revision), new(3, new(2026, 9, 1), 0.01m, revision)],
+            [new(1, new(2026, 9, 1), maximum, "food")],
+            [new(1, Guid.NewGuid(), revision)], []);
+
+        Assert.Equal("1999999999999999999", response.Selected.CashInMinor);
+        Assert.Equal("999999999999999999", response.Selected.PaycheckCashInMinor);
+        Assert.Equal("1000000000000000000", response.Selected.OtherCashInMinor);
+        Assert.Equal("999999999999999999", response.Selected.SpentMinor);
+        Assert.Equal("1000000000000000000", response.Selected.NetMinor);
+    }
+
+    [Fact]
+    public void Tiny_or_absent_cash_in_preserves_expenses_and_signed_net_without_a_ratio()
+    {
+        var expense = new CashFlowExpenseRow(1, new(2026, 9, 1), 9999999999999999.99m, "food");
+        var empty = CashFlowAggregation.Aggregate(Period(), [], [expense], [], []);
+        var tiny = CashFlowAggregation.Aggregate(Period(),
+            [new(1, new(2026, 9, 1), 0.01m, Guid.NewGuid())], [expense], [], []);
+
+        Assert.Equal("0", empty.Selected.CashInMinor);
+        Assert.Equal("-999999999999999999", empty.Selected.NetMinor);
+        Assert.Equal("1", tiny.Selected.CashInMinor);
+        Assert.Equal("-999999999999999998", tiny.Selected.NetMinor);
+    }
+
+    [Fact]
+    public void Empty_buckets_and_month_metadata_include_all_inflows_and_stable_category_ties()
+    {
+        CashFlowInflowRow[] inflows =
+        [
+            new(1, new(2026, 4, 1), 12m, Guid.NewGuid()),
+            new(2, new(2026, 8, 31), 15m, Guid.NewGuid())
+        ];
+        CashFlowExpenseRow[] expenses =
+        [
+            new(1, new(2026, 9, 1), 1m, "zebra"),
+            new(2, new(2026, 9, 2), 1m, "custom category"),
+            new(3, new(2026, 9, 3), 1m, "custom category"),
+            new(4, new(2026, 9, 4), 1m, "apple")
+        ];
+        var response = CashFlowAggregation.Aggregate(Period(), inflows, expenses, [],
+            [new(2020, 1, 1), new(2026, 4, 1), new(2026, 4, 2), new(2026, 8, 31), new(2026, 10, 1)]);
+
+        Assert.Equal(["2026-04", "2026-05", "2026-06", "2026-07", "2026-08", "2026-09"], response.Months.Select(value => value.Month));
+        Assert.Equal(["1200", "0", "0", "0", "1500", "0"], response.Months.Select(value => value.CashInMinor));
+        Assert.Equal(["2026-09", "2026-08", "2026-04", "2020-01"], response.AvailableMonths);
+        Assert.Equal(["custom category", "apple", "zebra"], response.Categories.Select(value => value.Category));
+        Assert.Equal("400", response.Selected.SpentMinor);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("1.001")]
+    public void Invalid_recorded_amounts_are_not_silently_dropped_or_rounded(string amount)
+    {
+        Assert.Throws<InvalidOperationException>(() => CashFlowAggregation.Aggregate(Period(),
+            [new(1, new(2026, 9, 1), decimal.Parse(amount, System.Globalization.CultureInfo.InvariantCulture), Guid.NewGuid())], [], [], []));
+    }
+
+    private static CashFlowPeriod Period(string month = "2026-09", string cutoff = "2026-09-10")
+    {
+        Assert.True(CashFlowPeriod.TryCreate(month, cutoff, out var period));
+        return period!;
+    }
+}

--- a/backend.Tests/Financial/CashFlowApiTests.cs
+++ b/backend.Tests/Financial/CashFlowApiTests.cs
@@ -1,0 +1,303 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Analytics;
+using BudgetPlanner.Contracts.Analytics;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using BudgetPlanner.Paychecks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+public sealed class CashFlowApiTests
+{
+    private const string Route = "/api/analytics/cash-flow?month=2026-09&throughDate=2026-09-10";
+
+    [Fact]
+    public async Task Endpoint_requires_authentication()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var client = app.CreateTestClient();
+        using var response = await client.GetAsync(Route);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("?month=2026-09")]
+    [InlineData("?throughDate=2026-09-10")]
+    [InlineData("?month=2026-10&throughDate=2026-09-10")]
+    [InlineData("?month=2026-09&throughDate=2026-09-10T00:00:00Z")]
+    [InlineData("?month=PRIVATE_FINANCIAL_INPUT&throughDate=2026-09-10")]
+    public async Task Invalid_filters_return_a_stable_privacy_safe_problem(string query)
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-validation@example.com");
+        using var response = await owner.Client.GetAsync($"/api/analytics/cash-flow{query}");
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("cash_flow_period_invalid", body.GetProperty("code").GetString());
+        Assert.DoesNotContain("PRIVATE_FINANCIAL_INPUT", body.GetRawText());
+    }
+
+    [Fact]
+    public async Task Explicit_response_has_exact_strings_calendar_dates_empty_buckets_and_no_private_fields()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-response@example.com");
+        await app.SeedInflowAsync(owner.Id, "PRIVATE SAVED DEPOSIT", 9999999999999999.99m, new(2026, 9, 1));
+        await app.SeedExpenseAsync(owner.Id, "PRIVATE EXPENSE", 0.01m, new(2026, 9, 10), "food");
+        using var response = await owner.Client.GetAsync(Route);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(["availableMonths", "categories", "from", "month", "months", "selected", "throughDate", "to"],
+            body.EnumerateObject().Select(value => value.Name).Order(StringComparer.Ordinal));
+        Assert.Equal("2026-09-01", body.GetProperty("from").GetString());
+        Assert.Equal("2026-09-10", body.GetProperty("to").GetString());
+        Assert.Equal("2026-09-10", body.GetProperty("throughDate").GetString());
+        var selected = body.GetProperty("selected");
+        Assert.Equal("999999999999999999", selected.GetProperty("cashInMinor").GetString());
+        Assert.Equal("999999999999999998", selected.GetProperty("netMinor").GetString());
+        Assert.Equal("0", selected.GetProperty("paycheckCashInMinor").GetString());
+        Assert.Equal(6, body.GetProperty("months").GetArrayLength());
+        Assert.Equal("1", body.GetProperty("categories")[0].GetProperty("amountMinor").GetString());
+        Assert.DoesNotContain("PRIVATE", body.GetRawText());
+        Assert.DoesNotContain(owner.Id, body.GetRawText());
+        Assert.DoesNotContain("projection", body.GetRawText(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Owners_cutoffs_and_month_discovery_apply_to_every_source_and_membership_side()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("cashflow-foreign@example.com");
+        var linked = await app.SeedInflowAsync(owner.Id, amount: 100m, date: new(2026, 9, 1));
+        var unlinked = await app.SeedInflowAsync(owner.Id, amount: 25m, date: new(2026, 9, 10));
+        var foreign = await app.SeedInflowAsync(other.Id, "FOREIGN PRIVATE", 999m, new(2026, 9, 1));
+        await app.SeedInflowAsync(owner.Id, amount: 900m, date: new(2026, 9, 11));
+        await app.SeedInflowAsync(owner.Id, amount: 1m, date: new(2020, 2, 1));
+        await app.SeedInflowAsync(other.Id, amount: 1m, date: new(2019, 3, 1));
+        await app.SeedExpenseAsync(owner.Id, amount: 30m, date: new(2026, 9, 10));
+        await app.SeedExpenseAsync(owner.Id, amount: 500m, date: new(2026, 9, 11));
+        await app.SeedExpenseAsync(other.Id, "FOREIGN EXPENSE", 700m, new(2026, 9, 1), "foreign category");
+        await app.SeedExpenseAsync(owner.Id, amount: 1m, date: new(2021, 4, 1));
+        await LinkAsync(app, owner.Id, [linked], PaycheckLifecycle.Ended);
+
+        // InMemory deliberately permits malformed links so each ownership filter
+        // is exercised independently of PostgreSQL's composite foreign keys.
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var foreignProfile = Profile(other.Id, PaycheckLifecycle.Active);
+            var ownedProfile = Profile(owner.Id, PaycheckLifecycle.Active);
+            db.PaycheckProfiles.AddRange(foreignProfile, ownedProfile);
+            db.PaycheckOccurrences.AddRange(
+                Link(owner.Id, foreignProfile.Id, unlinked),
+                Link(other.Id, ownedProfile.Id, unlinked),
+                Link(owner.Id, ownedProfile.Id, foreign));
+            await db.SaveChangesAsync();
+        }
+
+        var result = await ReadAsync(owner.Client, Route + $"&ownerId={other.Id}");
+        Assert.Equal("12500", result.Selected.CashInMinor);
+        Assert.Equal("10000", result.Selected.PaycheckCashInMinor);
+        Assert.Equal("2500", result.Selected.OtherCashInMinor);
+        Assert.Equal("3000", result.Selected.SpentMinor);
+        Assert.Equal(1, result.Selected.PaycheckProfileCount);
+        Assert.Equal(["2026-09", "2021-04", "2020-02"], result.AvailableMonths);
+        Assert.Equal("food", Assert.Single(result.Categories).Category);
+    }
+
+    [Fact]
+    public async Task All_lifecycles_pool_observed_evidence_while_manual_profiles_add_no_money()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-lifecycles@example.com");
+        foreach (var state in Enum.GetValues<PaycheckLifecycle>())
+        {
+            var inflow = await app.SeedInflowAsync(owner.Id, amount: 100m, date: new(2026, 9, 1));
+            await LinkAsync(app, owner.Id, [inflow], state);
+        }
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var expectation = Profile(owner.Id, PaycheckLifecycle.Active);
+            expectation.ExpectedAmount = 9999999999999999.99m;
+            db.PaycheckProfiles.Add(expectation);
+            await db.SaveChangesAsync();
+        }
+
+        var result = await ReadAsync(owner.Client);
+        Assert.Equal("30000", result.Selected.CashInMinor);
+        Assert.Equal("30000", result.Selected.PaycheckCashInMinor);
+        Assert.Equal("0", result.Selected.OtherCashInMinor);
+        Assert.Equal(3, result.Selected.InflowCount);
+        Assert.Equal(3, result.Selected.PaycheckProfileCount);
+    }
+
+    [Fact]
+    public async Task Saved_manual_duplicates_and_imports_count_but_unsaved_preview_rows_do_not()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-sources@example.com");
+        foreach (var unused in new[] { 1, 2 })
+        {
+            using var created = await owner.Client.PostAsJsonAsync("/api/inflows", new
+            {
+                description = "Same manual refund", amount = 20m, date = "2026-09-01"
+            });
+            Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+        }
+        var imported = await app.SeedInflowAsync(owner.Id, "Imported transfer", 30m, new(2026, 9, 2));
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            db.ImportPreviewBatches.Add(new ImportPreviewBatch
+            {
+                Id = Guid.NewGuid(), OwnerId = owner.Id, SourceType = "sunflower_pdf", ParserRuleVersion = "cashflow-tests",
+                DocumentDigest = new byte[32], CreatedAt = DateTime.UtcNow, ExpiresAt = DateTime.UtcNow.AddDays(1),
+                Lifecycle = ImportPreviewLifecycle.Confirmed, ConfirmedAt = DateTime.UtcNow,
+                InflowProvenance = [new() { OwnerId = owner.Id, AccountInflowId = imported.Id,
+                    AccountInflowOwnerId = owner.Id, SourceRowOrdinal = 1 }],
+                Rows = [new() { Id = Guid.NewGuid(), SourceRowOrdinal = 2, Amount = 99999m, PostedDate = new(2026, 9, 1) }]
+            });
+            await db.SaveChangesAsync();
+        }
+        await app.SeedExpenseAsync(owner.Id, amount: 10m, date: new(2026, 9, 1), category: "original purchase");
+
+        var result = await ReadAsync(owner.Client);
+        Assert.Equal("7000", result.Selected.CashInMinor);
+        Assert.Equal("7000", result.Selected.OtherCashInMinor);
+        Assert.Equal("0", result.Selected.PaycheckCashInMinor);
+        Assert.Equal("1000", result.Selected.SpentMinor);
+        Assert.Equal("6000", result.Selected.NetMinor);
+        Assert.Equal(3, result.Selected.InflowCount);
+    }
+
+    [Fact]
+    public async Task Confirmation_changes_only_composition_and_dismissal_or_expectations_do_not_change_cash_totals()
+    {
+        await using var app = new PaycheckTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-confirmation@example.com");
+        foreach (var month in new[] { 7, 8, 9 })
+            await app.SeedInflowAsync(owner.Id, "Monthly observed pay", 1000m, new(2026, month, 10));
+        await app.SeedExpenseAsync(owner.Id, amount: 75m, date: new(2026, 9, 10));
+        var candidates = await owner.Client.GetFromJsonAsync<JsonElement>("/api/paycheck-candidates");
+        var candidate = Assert.Single(candidates.GetProperty("candidates").EnumerateArray());
+        var decision = new
+        {
+            algorithmVersion = candidate.GetProperty("algorithmVersion").GetString(),
+            cadence = candidate.GetProperty("schedule").GetProperty("cadence").GetString(),
+            fingerprint = candidate.GetProperty("fingerprint").GetString()
+        };
+        var before = await ReadAsync(owner.Client);
+        Assert.Equal("100000", before.Selected.OtherCashInMinor);
+        using var dismissed = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/dismiss", decision);
+        dismissed.EnsureSuccessStatusCode();
+        Assert.Equal(before.Selected, (await ReadAsync(owner.Client)).Selected);
+        using var reconsidered = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/reconsider", decision);
+        reconsidered.EnsureSuccessStatusCode();
+        using var confirmed = await owner.Client.PostAsJsonAsync("/api/paycheck-candidates/confirm", new
+        {
+            decision.algorithmVersion, decision.fingerprint, displayName = "Confirmed stream",
+            schedule = candidate.GetProperty("schedule"), windowBeforeDays = 0, windowAfterDays = 0,
+            amount = new { mode = "fixed", fixedAmount = 9999m }
+        });
+        Assert.Equal(HttpStatusCode.Created, confirmed.StatusCode);
+        var profileId = (await confirmed.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("paycheck").GetProperty("id").GetGuid();
+        var after = await ReadAsync(owner.Client);
+        Assert.Equal(before.Selected.CashInMinor, after.Selected.CashInMinor);
+        Assert.Equal(before.Selected.NetMinor, after.Selected.NetMinor);
+        Assert.Equal(before.Selected.SpentMinor, after.Selected.SpentMinor);
+        Assert.Equal("100000", after.Selected.PaycheckCashInMinor);
+        Assert.Equal("0", after.Selected.OtherCashInMinor);
+
+        using var updated = await owner.Client.PutAsJsonAsync($"/api/paychecks/{profileId}", new
+        {
+            displayName = "Changed expectation", windowBeforeDays = 1, windowAfterDays = 1,
+            amount = new { mode = "fixed", fixedAmount = 25000m }
+        });
+        updated.EnsureSuccessStatusCode();
+        using var ended = await owner.Client.PatchAsJsonAsync($"/api/paychecks/{profileId}/lifecycle", new { lifecycle = "ended" });
+        ended.EnsureSuccessStatusCode();
+        Assert.Equal(after.Selected, (await ReadAsync(owner.Client)).Selected);
+        await app.SeedInflowAsync(owner.Id, "Monthly observed pay", 1000m, new(2026, 9, 10));
+        var later = await ReadAsync(owner.Client);
+        Assert.Equal("200000", later.Selected.CashInMinor);
+        Assert.Equal("100000", later.Selected.PaycheckCashInMinor);
+        Assert.Equal("100000", later.Selected.OtherCashInMinor);
+    }
+
+    [Fact]
+    public async Task Inflow_edits_and_deletion_use_current_dates_amounts_and_surviving_links_without_mutating_on_read()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cashflow-edits@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, "Original", 100m, new(2026, 8, 31));
+        await LinkAsync(app, owner.Id, [inflow], PaycheckLifecycle.Paused);
+        using var edited = await owner.Client.PutAsJsonAsync($"/api/inflows/{inflow.Id}", new
+        {
+            id = inflow.Id, description = "Edited observation", amount = 110.01m, date = "2026-09-01"
+        });
+        edited.EnsureSuccessStatusCode();
+        var result = await ReadAsync(owner.Client);
+        Assert.Equal("11001", result.Selected.CashInMinor);
+        Assert.Equal("11001", result.Selected.PaycheckCashInMinor);
+        Assert.Equal(1, result.Selected.EditedPaycheckInflowCount);
+        Assert.Equal("0", result.Months.Single(value => value.Month == "2026-08").CashInMinor);
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            Assert.True(CashFlowPeriod.TryCreate("2026-09", "2026-09-10", out var period));
+            await new CashFlowService(db).GetAsync(owner.Id, period!, default);
+            Assert.Empty(db.ChangeTracker.Entries());
+            // InMemory does not enforce relational cascade without loading the dependent.
+            // PostgreSQL coverage proves the public delete cascade separately.
+            var persisted = await db.AccountInflows.SingleAsync(value => value.Id == inflow.Id);
+            await db.PaycheckOccurrences.ToListAsync();
+            db.AccountInflows.Remove(persisted);
+            await db.SaveChangesAsync();
+        }
+        var deleted = await ReadAsync(owner.Client);
+        Assert.Equal("0", deleted.Selected.CashInMinor);
+        Assert.Equal("0", deleted.Selected.PaycheckCashInMinor);
+        Assert.Equal(0, deleted.Selected.EditedPaycheckInflowCount);
+    }
+
+    private static async Task<CashFlowResponse> ReadAsync(HttpClient client, string route = Route) =>
+        (await client.GetFromJsonAsync<CashFlowResponse>(route))!;
+
+    private static async Task LinkAsync(
+        FinancialApiTestApplicationBase app, string ownerId, IReadOnlyList<AccountInflow> inflows, PaycheckLifecycle lifecycle)
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var profile = Profile(ownerId, lifecycle);
+        db.PaycheckProfiles.Add(profile);
+        db.PaycheckOccurrences.AddRange(inflows.Select(value => Link(ownerId, profile.Id, value)));
+        await db.SaveChangesAsync();
+    }
+
+    private static PaycheckProfile Profile(string ownerId, PaycheckLifecycle lifecycle) => new()
+    {
+        Id = Guid.NewGuid(), OwnerId = ownerId, DisplayName = "Synthetic stream", Lifecycle = lifecycle,
+        Cadence = PaycheckCadence.Monthly, FirstMonthAnchor = 1, AmountMode = PaycheckAmountMode.Fixed,
+        ExpectedAmount = 500m, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow
+    };
+
+    private static PaycheckOccurrence Link(string ownerId, Guid profileId, AccountInflow inflow) => new()
+    {
+        PaycheckProfileId = profileId, AccountInflowId = inflow.Id, OwnerId = ownerId,
+        Kind = PaycheckOccurrenceKind.ConfirmationEvidence,
+        EvidenceRevisionAtAssignment = inflow.PaycheckEvidenceRevision,
+        SlotAnchor = inflow.Date, TimingOffsetDays = 0, LinkedAt = DateTime.UtcNow
+    };
+}

--- a/backend.Tests/Financial/PostgreSqlCashFlowTests.cs
+++ b/backend.Tests/Financial/PostgreSqlCashFlowTests.cs
@@ -1,0 +1,283 @@
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BudgetPlanner.Data;
+using BudgetPlanner.Models;
+using BudgetPlanner.Paychecks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BudgetPlanner.Tests.Financial;
+
+[Collection("Environment variable tests")]
+[Trait("Category", "PostgreSQL")]
+public sealed class PostgreSqlCashFlowTests
+{
+    private const string Route = "/api/analytics/cash-flow?month=2026-09&throughDate=2026-09-06";
+
+    [PostgreSqlFact]
+    public async Task Read_preserves_full_precision_partitions_stored_records_and_isolates_owners()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cash-flow-owner@example.com");
+        using var other = await app.CreateAuthenticatedUserAsync("cash-flow-other@example.com");
+        var linked = await app.SeedInflowAsync(owner.Id, "synthetic same deposit", 9999999999999999.99m, new(2026, 9, 1));
+        await app.SeedInflowAsync(owner.Id, "synthetic same deposit", 9999999999999999.99m, new(2026, 9, 1));
+        var refund = await app.SeedInflowAsync(owner.Id, "synthetic refund", 0.01m, new(2026, 9, 3));
+        await app.SeedExpenseAsync(owner.Id, "synthetic outflow", 0.10m, new(2026, 9, 2), "uncategorized");
+        await app.SeedInflowAsync(owner.Id, "future deposit", 999m, new(2026, 9, 7));
+        await app.SeedExpenseAsync(owner.Id, "future outflow", 999m, new(2026, 9, 7));
+        await app.SeedInflowAsync(owner.Id, "old other-only month", 1m, new(2026, 2, 1));
+        var foreign = await app.SeedInflowAsync(other.Id, "foreign deposit", 777m, new(2026, 9, 1));
+        await app.SeedExpenseAsync(other.Id, "foreign outflow", 777m, new(2026, 9, 1), "foreign category");
+        await app.SeedInflowAsync(other.Id, "foreign month", 1m, new(2025, 1, 1));
+
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var profile = NewProfile(owner.Id, PaycheckLifecycle.Ended);
+        var foreignProfile = NewProfile(other.Id);
+        db.PaycheckProfiles.AddRange(profile, foreignProfile);
+        db.PaycheckOccurrences.AddRange(Link(profile, linked), Link(foreignProfile, foreign));
+        var now = new DateTime(2026, 9, 3, 12, 0, 0, DateTimeKind.Utc);
+        db.ImportPreviewBatches.Add(new ImportPreviewBatch
+        {
+            Id = Guid.NewGuid(), OwnerId = owner.Id, SourceType = "sunflower_pdf",
+            ParserRuleVersion = "cash-flow-test", DocumentDigest = new byte[32],
+            CreatedAt = now, ExpiresAt = now.AddHours(1), ConfirmedAt = now,
+            Lifecycle = ImportPreviewLifecycle.Confirmed,
+            InflowProvenance = [new ImportInflowProvenance
+            {
+                OwnerId = owner.Id, AccountInflowId = refund.Id,
+                AccountInflowOwnerId = owner.Id, SourceRowOrdinal = 1
+            }]
+        });
+        await db.SaveChangesAsync();
+        var before = await RecordStateAsync(db);
+
+        var body = await ReadAsync(owner.Client);
+        var selected = body.GetProperty("selected");
+        Assert.Equal("1999999999999999999", Money(selected, "cashInMinor"));
+        Assert.Equal("999999999999999999", Money(selected, "paycheckCashInMinor"));
+        Assert.Equal("1000000000000000000", Money(selected, "otherCashInMinor"));
+        Assert.Equal("10", Money(selected, "spentMinor"));
+        Assert.Equal("1999999999999999989", Money(selected, "netMinor"));
+        Assert.Equal(3, selected.GetProperty("inflowCount").GetInt32());
+        Assert.Equal(1, selected.GetProperty("paycheckInflowCount").GetInt32());
+        Assert.Equal(2, selected.GetProperty("otherInflowCount").GetInt32());
+        Assert.Equal(1, selected.GetProperty("expenseCount").GetInt32());
+        Assert.Equal(1, selected.GetProperty("paycheckProfileCount").GetInt32());
+        var category = Assert.Single(body.GetProperty("categories").EnumerateArray());
+        Assert.Equal("uncategorized", category.GetProperty("category").GetString());
+        Assert.Equal("10", Money(category, "amountMinor"));
+        Assert.Equal(["2026-09", "2026-02"],
+            body.GetProperty("availableMonths").EnumerateArray().Select(value => value.GetString()));
+        Assert.Equal(6, body.GetProperty("months").GetArrayLength());
+        Assert.Equal("2026-09-06", body.GetProperty("to").GetString());
+        Assert.DoesNotContain("foreign", body.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ownerId", body.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("description", body.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(before, await RecordStateAsync(db));
+
+        using var anonymous = app.CreateTestClient();
+        using var rejected = await anonymous.GetAsync(Route);
+        Assert.Equal(HttpStatusCode.Unauthorized, rejected.StatusCode);
+        var otherBody = await ReadAsync(other.Client);
+        Assert.Equal("77700", Money(otherBody.GetProperty("selected"), "cashInMinor"));
+        Assert.Equal("77700", Money(otherBody.GetProperty("selected"), "paycheckCashInMinor"));
+    }
+
+    [PostgreSqlFact]
+    public async Task Membership_lifecycle_edit_and_delete_preserve_cash_flow_meaning()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cash-flow-changes@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, "synthetic deposit", 1200.25m, new(2026, 9, 1));
+        await app.SeedExpenseAsync(owner.Id, "synthetic outflow", 200m, new(2026, 9, 2));
+        var initial = (await ReadAsync(owner.Client)).GetProperty("selected");
+        Assert.Equal("120025", Money(initial, "otherCashInMinor"));
+
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var profile = NewProfile(owner.Id);
+        db.PaycheckProfiles.Add(profile);
+        db.PaycheckOccurrences.Add(Link(profile, inflow));
+        await db.SaveChangesAsync();
+        foreach (var lifecycle in Enum.GetValues<PaycheckLifecycle>())
+        {
+            profile.Lifecycle = lifecycle;
+            profile.ExpectedAmount = 999m;
+            await db.SaveChangesAsync();
+            var selected = (await ReadAsync(owner.Client)).GetProperty("selected");
+            Assert.Equal(Money(initial, "cashInMinor"), Money(selected, "cashInMinor"));
+            Assert.Equal(Money(initial, "netMinor"), Money(selected, "netMinor"));
+            Assert.Equal("120025", Money(selected, "paycheckCashInMinor"));
+            Assert.Equal("0", Money(selected, "otherCashInMinor"));
+        }
+
+        var tracked = await db.AccountInflows.SingleAsync(value => value.Id == inflow.Id);
+        tracked.UpdateEvidence("synthetic edited deposit", 1300.27m, new(2026, 8, 31));
+        await db.SaveChangesAsync();
+        var moved = await ReadAsync(owner.Client);
+        Assert.Equal("0", Money(moved.GetProperty("selected"), "cashInMinor"));
+        Assert.Equal("-20000", Money(moved.GetProperty("selected"), "netMinor"));
+        var august = Assert.Single(moved.GetProperty("months").EnumerateArray(),
+            value => value.GetProperty("month").GetString() == "2026-08");
+        Assert.Equal("130027", Money(august, "paycheckCashInMinor"));
+        Assert.Equal(1, august.GetProperty("editedPaycheckInflowCount").GetInt32());
+
+        db.AccountInflows.Remove(tracked);
+        await db.SaveChangesAsync();
+        var deleted = await ReadAsync(owner.Client);
+        Assert.All(deleted.GetProperty("months").EnumerateArray(),
+            value => Assert.Equal("0", Money(value, "cashInMinor")));
+        Assert.Empty(await db.PaycheckOccurrences.AsNoTracking().ToListAsync());
+        Assert.Equal(1, await db.PaycheckProfiles.CountAsync());
+    }
+
+    [PostgreSqlFact]
+    public async Task Concurrent_membership_and_record_edits_use_one_read_only_repeatable_snapshot()
+    {
+        var gate = new SnapshotGate();
+        await using var app = new InterceptedApplication(gate);
+        using var owner = await app.CreateAuthenticatedUserAsync("cash-flow-snapshot@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, "synthetic before deposit", 1000m, new(2026, 9, 1));
+        var expense = await app.SeedExpenseAsync(owner.Id, "synthetic before outflow", 250m, new(2026, 9, 2));
+        gate.Arm();
+        var request = ReadAsync(owner.Client);
+        try
+        {
+            await gate.Reached.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            using var scope = app.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+            var updated = await db.AccountInflows.SingleAsync(value => value.Id == inflow.Id);
+            updated.UpdateEvidence("synthetic after deposit", 2500m, new(2026, 9, 2));
+            var profile = NewProfile(owner.Id);
+            profile.FirstMonthAnchor = 2;
+            profile.ExpectedAmount = 2500m;
+            db.PaycheckProfiles.Add(profile);
+            db.PaycheckOccurrences.Add(Link(profile, updated));
+            (await db.Expenses.SingleAsync(value => value.Id == expense.Id)).Amount = 350m;
+            db.AccountInflows.Add(new AccountInflow
+            {
+                OwnerId = owner.Id, Description = "synthetic historical deposit",
+                Amount = 0.01m, Date = new(2026, 2, 1)
+            });
+            await db.SaveChangesAsync();
+        }
+        finally
+        {
+            gate.Release.TrySetResult();
+        }
+
+        var before = await request.WaitAsync(TimeSpan.FromSeconds(20));
+        var selected = before.GetProperty("selected");
+        Assert.Equal("100000", Money(selected, "cashInMinor"));
+        Assert.Equal("0", Money(selected, "paycheckCashInMinor"));
+        Assert.Equal("100000", Money(selected, "otherCashInMinor"));
+        Assert.Equal("25000", Money(selected, "spentMinor"));
+        Assert.Equal("75000", Money(selected, "netMinor"));
+        Assert.Equal(["2026-09"],
+            before.GetProperty("availableMonths").EnumerateArray().Select(value => value.GetString()));
+        Assert.Equal(IsolationLevel.RepeatableRead, gate.ObservedIsolation);
+        Assert.True(gate.SawReadOnly);
+        Assert.False(gate.SawTaggedWrite);
+
+        var after = await ReadAsync(owner.Client);
+        var next = after.GetProperty("selected");
+        Assert.Equal("250000", Money(next, "cashInMinor"));
+        Assert.Equal("250000", Money(next, "paycheckCashInMinor"));
+        Assert.Equal("0", Money(next, "otherCashInMinor"));
+        Assert.Equal("35000", Money(next, "spentMinor"));
+        Assert.Equal("215000", Money(next, "netMinor"));
+        Assert.Equal(["2026-09", "2026-02"],
+            after.GetProperty("availableMonths").EnumerateArray().Select(value => value.GetString()));
+    }
+
+    private static async Task<JsonElement> ReadAsync(HttpClient client)
+    {
+        using var response = await client.GetAsync(Route);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static string? Money(JsonElement element, string field)
+    {
+        Assert.Equal(JsonValueKind.String, element.GetProperty(field).ValueKind);
+        return element.GetProperty(field).GetString();
+    }
+
+    private static async Task<string> RecordStateAsync(BudgetContext db)
+    {
+        var inflows = await db.AccountInflows.AsNoTracking().OrderBy(value => value.Id).ToListAsync();
+        var expenses = await db.Expenses.AsNoTracking().OrderBy(value => value.Id).ToListAsync();
+        var profiles = await db.PaycheckProfiles.AsNoTracking().OrderBy(value => value.Id).ToListAsync();
+        var occurrences = await db.PaycheckOccurrences.AsNoTracking().OrderBy(value => value.AccountInflowId).ToListAsync();
+        return JsonSerializer.Serialize(new { inflows, expenses, profiles, occurrences });
+    }
+
+    private static PaycheckProfile NewProfile(string ownerId, PaycheckLifecycle lifecycle = PaycheckLifecycle.Active) => new()
+    {
+        Id = Guid.NewGuid(), OwnerId = ownerId, DisplayName = "Synthetic paycheck",
+        Lifecycle = lifecycle, Cadence = PaycheckCadence.Monthly, FirstMonthAnchor = 1,
+        AmountMode = PaycheckAmountMode.Fixed, ExpectedAmount = 1000m,
+        CreatedAt = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        UpdatedAt = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static PaycheckOccurrence Link(PaycheckProfile profile, AccountInflow inflow) => new()
+    {
+        OwnerId = inflow.OwnerId, PaycheckProfileId = profile.Id, AccountInflowId = inflow.Id,
+        Kind = PaycheckOccurrenceKind.ConfirmationEvidence,
+        EvidenceRevisionAtAssignment = inflow.PaycheckEvidenceRevision,
+        SlotAnchor = inflow.Date, TimingOffsetDays = 0,
+        LinkedAt = new(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private sealed class InterceptedApplication(SnapshotGate gate) : PostgreSqlFinancialApiTestApplication
+    {
+        protected override void ConfigureDatabase(IServiceCollection services) =>
+            services.AddDbContext<BudgetContext>(options => options
+                .UseNpgsql(Environment.GetEnvironmentVariable(ConnectionEnvironmentVariable))
+                .AddInterceptors(gate));
+    }
+
+    private sealed class SnapshotGate : DbCommandInterceptor
+    {
+        private int _armed;
+        public TaskCompletionSource Reached { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public IsolationLevel? ObservedIsolation { get; private set; }
+        public bool SawReadOnly { get; private set; }
+        public bool SawTaggedWrite { get; private set; }
+
+        public void Arm() => Interlocked.Exchange(ref _armed, 1);
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (command.CommandText.Contains("SET TRANSACTION READ ONLY", StringComparison.OrdinalIgnoreCase))
+                SawReadOnly = true;
+            if (command.CommandText.Contains("CashFlow:", StringComparison.Ordinal)) SawTaggedWrite = true;
+            return ValueTask.FromResult(result);
+        }
+
+        public override async ValueTask<DbDataReader> ReaderExecutedAsync(
+            DbCommand command, CommandExecutedEventData eventData, DbDataReader result,
+            CancellationToken cancellationToken = default)
+        {
+            if (command.CommandText.Contains("CashFlow:inflows", StringComparison.Ordinal)
+                && Interlocked.Exchange(ref _armed, 0) == 1)
+            {
+                ObservedIsolation = command.Transaction?.IsolationLevel;
+                Reached.TrySetResult();
+                await Release.Task.WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
+            }
+            return result;
+        }
+    }
+}

--- a/backend/Analytics/CashFlowAggregation.cs
+++ b/backend/Analytics/CashFlowAggregation.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using System.Numerics;
+using BudgetPlanner.Contracts.Analytics;
+
+namespace BudgetPlanner.Analytics;
+
+public sealed record CashFlowInflowRow(int Id, DateOnly Date, decimal Amount, Guid EvidenceRevision);
+public sealed record CashFlowExpenseRow(int Id, DateOnly Date, decimal Amount, string Category);
+public sealed record CashFlowMembershipRow(int AccountInflowId, Guid ProfileId, Guid EvidenceRevisionAtAssignment);
+
+public static class CashFlowAggregation
+{
+    public static CashFlowResponse Aggregate(
+        CashFlowPeriod period, IReadOnlyList<CashFlowInflowRow> inflows,
+        IReadOnlyList<CashFlowExpenseRow> expenses, IReadOnlyList<CashFlowMembershipRow> memberships,
+        IEnumerable<DateOnly> availableDates)
+    {
+        var buckets = new Dictionary<string, MonthTotals>(StringComparer.Ordinal);
+        for (var start = period.TrendFrom; ; start = start.AddMonths(1))
+        {
+            var end = CashFlowPeriod.MonthEnd(start);
+            if (end > period.To) end = period.To;
+            buckets.Add(CashFlowPeriod.MonthKey(start), new(start, end));
+            // Do not add a month beyond the representable calendar ceiling.
+            if (start == period.MonthStart) break;
+        }
+
+        var links = memberships.ToLookup(value => value.AccountInflowId);
+        foreach (var inflow in inflows)
+        {
+            if (inflow.Date < period.TrendFrom || inflow.Date > period.To) continue;
+            var bucket = buckets[CashFlowPeriod.MonthKey(inflow.Date)];
+            var amount = ToMinor(inflow.Amount);
+            bucket.CashIn += amount;
+            bucket.InflowCount++;
+            var assigned = links[inflow.Id].ToArray();
+            if (assigned.Length == 0) continue;
+            // Membership is a predicate, not another source of money. Even a repeated
+            // membership row must never multiply the underlying observed amount.
+            bucket.PaycheckCashIn += amount;
+            bucket.PaycheckInflowCount++;
+            foreach (var link in assigned) bucket.Profiles.Add(link.ProfileId);
+            if (assigned.Any(value => value.EvidenceRevisionAtAssignment != inflow.EvidenceRevision))
+                bucket.EditedPaycheckInflowCount++;
+        }
+
+        var categories = new Dictionary<string, BigInteger>(StringComparer.Ordinal);
+        foreach (var expense in expenses)
+        {
+            if (expense.Date < period.TrendFrom || expense.Date > period.To) continue;
+            var key = CashFlowPeriod.MonthKey(expense.Date);
+            var amount = ToMinor(expense.Amount);
+            buckets[key].Spent += amount;
+            buckets[key].ExpenseCount++;
+            if (key == period.Month)
+                categories[expense.Category] = categories.GetValueOrDefault(expense.Category) + amount;
+        }
+
+        var months = buckets.Values.Select(value => value.ToDto()).ToArray();
+        var availableMonths = availableDates.Where(value => value <= period.ThroughDate)
+            .Select(CashFlowPeriod.MonthKey).Append(CashFlowPeriod.MonthKey(period.ThroughDate))
+            .Distinct(StringComparer.Ordinal).OrderByDescending(value => value, StringComparer.Ordinal).ToArray();
+        return new(period.Month, period.ThroughDate, period.MonthStart, period.To,
+            availableMonths, months[^1], months,
+            categories.OrderByDescending(value => value.Value).ThenBy(value => value.Key, StringComparer.Ordinal)
+                .Select(value => new CashFlowCategoryDto(value.Key, Format(value.Value))).ToArray());
+    }
+
+    private static BigInteger ToMinor(decimal amount)
+    {
+        var minor = checked(amount * 100m);
+        if (amount <= 0m || minor != decimal.Truncate(minor))
+            throw new InvalidOperationException("A recorded cash-flow amount is invalid.");
+        return new BigInteger(minor);
+    }
+
+    private static string Format(BigInteger amount) => amount.ToString(CultureInfo.InvariantCulture);
+
+    private sealed class MonthTotals(DateOnly from, DateOnly to)
+    {
+        public BigInteger CashIn;
+        public BigInteger PaycheckCashIn;
+        public BigInteger Spent;
+        public int InflowCount;
+        public int PaycheckInflowCount;
+        public int ExpenseCount;
+        public int EditedPaycheckInflowCount;
+        public HashSet<Guid> Profiles { get; } = [];
+
+        public CashFlowMonthDto ToDto() => new(
+            CashFlowPeriod.MonthKey(from), from, to,
+            Format(CashIn), Format(PaycheckCashIn), Format(CashIn - PaycheckCashIn),
+            Format(Spent), Format(CashIn - Spent), InflowCount, PaycheckInflowCount,
+            InflowCount - PaycheckInflowCount, ExpenseCount, Profiles.Count, EditedPaycheckInflowCount);
+    }
+}

--- a/backend/Analytics/CashFlowPeriod.cs
+++ b/backend/Analytics/CashFlowPeriod.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+
+namespace BudgetPlanner.Analytics;
+
+public sealed record CashFlowPeriod
+{
+    public DateOnly MonthStart { get; }
+    public DateOnly ThroughDate { get; }
+    public DateOnly To { get; }
+    public DateOnly TrendFrom { get; }
+    public string Month => MonthKey(MonthStart);
+
+    private CashFlowPeriod(DateOnly monthStart, DateOnly throughDate)
+    {
+        MonthStart = monthStart;
+        ThroughDate = throughDate;
+        var monthEnd = MonthEnd(monthStart);
+        To = throughDate < monthEnd ? throughDate : monthEnd;
+        var monthsSinceMinimum = (monthStart.Year - 1) * 12 + monthStart.Month - 1;
+        TrendFrom = monthStart.AddMonths(-Math.Min(5, monthsSinceMinimum));
+    }
+
+    public static bool TryCreate(string? month, string? throughDate, out CashFlowPeriod? period)
+    {
+        period = null;
+        if (month?.Length != 7 || throughDate?.Length != 10
+            || !DateOnly.TryParseExact($"{month}-01", "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var monthStart)
+            || !DateOnly.TryParseExact(throughDate, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var cutoff)
+            || MonthKey(monthStart) != month
+            || cutoff.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) != throughDate
+            || monthStart > cutoff)
+            return false;
+
+        period = new(monthStart, cutoff);
+        return true;
+    }
+
+    public static string MonthKey(DateOnly date) => date.ToString("yyyy-MM", CultureInfo.InvariantCulture);
+
+    public static DateOnly MonthEnd(DateOnly date) =>
+        new(date.Year, date.Month, DateTime.DaysInMonth(date.Year, date.Month));
+}

--- a/backend/Analytics/CashFlowService.cs
+++ b/backend/Analytics/CashFlowService.cs
@@ -1,0 +1,56 @@
+using System.Data;
+using BudgetPlanner.Contracts.Analytics;
+using BudgetPlanner.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BudgetPlanner.Analytics;
+
+public interface ICashFlowService
+{
+    Task<CashFlowResponse> GetAsync(string ownerId, CashFlowPeriod period, CancellationToken cancellationToken);
+}
+
+public sealed class CashFlowService(BudgetContext context) : ICashFlowService
+{
+    public async Task<CashFlowResponse> GetAsync(
+        string ownerId, CashFlowPeriod period, CancellationToken cancellationToken)
+    {
+        await using var transaction = context.Database.IsRelational()
+            ? await context.Database.BeginTransactionAsync(IsolationLevel.RepeatableRead, cancellationToken)
+            : null;
+        if (context.Database.IsNpgsql())
+            await context.Database.ExecuteSqlRawAsync("SET TRANSACTION READ ONLY", cancellationToken);
+
+        // This first data read establishes the PostgreSQL snapshot used by every
+        // subsequent query, including the selectable-month metadata.
+        var inflows = await context.AccountInflows.AsNoTracking().TagWith("CashFlow:inflows")
+            .Where(value => value.OwnerId == ownerId
+                && value.Date >= period.TrendFrom && value.Date <= period.To)
+            .Select(value => new CashFlowInflowRow(value.Id, value.Date, value.Amount, value.PaycheckEvidenceRevision))
+            .ToListAsync(cancellationToken);
+        var expenses = await context.Expenses.AsNoTracking().TagWith("CashFlow:expenses")
+            .Where(value => value.UserId == ownerId
+                && value.Date >= period.TrendFrom && value.Date <= period.To)
+            .Select(value => new CashFlowExpenseRow(value.Id, value.Date, value.Amount, value.Category))
+            .ToListAsync(cancellationToken);
+        var memberships = await (
+            from occurrence in context.PaycheckOccurrences.AsNoTracking()
+            join profile in context.PaycheckProfiles.AsNoTracking() on occurrence.PaycheckProfileId equals profile.Id
+            join inflow in context.AccountInflows.AsNoTracking() on occurrence.AccountInflowId equals inflow.Id
+            where occurrence.OwnerId == ownerId && profile.OwnerId == ownerId && inflow.OwnerId == ownerId
+                && inflow.Date >= period.TrendFrom && inflow.Date <= period.To
+            select new CashFlowMembershipRow(inflow.Id, profile.Id, occurrence.EvidenceRevisionAtAssignment))
+            .TagWith("CashFlow:memberships").ToListAsync(cancellationToken);
+        var availableDates = await context.AccountInflows.AsNoTracking()
+            .Where(value => value.OwnerId == ownerId && value.Date <= period.ThroughDate)
+            .Select(value => value.Date)
+            .Union(context.Expenses.AsNoTracking()
+                .Where(value => value.UserId == ownerId && value.Date <= period.ThroughDate)
+                .Select(value => value.Date))
+            .TagWith("CashFlow:months").ToListAsync(cancellationToken);
+
+        var response = CashFlowAggregation.Aggregate(period, inflows, expenses, memberships, availableDates);
+        if (transaction is not null) await transaction.CommitAsync(cancellationToken);
+        return response;
+    }
+}

--- a/backend/Contracts/Analytics/CashFlowContracts.cs
+++ b/backend/Contracts/Analytics/CashFlowContracts.cs
@@ -1,0 +1,15 @@
+namespace BudgetPlanner.Contracts.Analytics;
+
+public sealed record CashFlowMonthDto(
+    string Month, DateOnly From, DateOnly To,
+    string CashInMinor, string PaycheckCashInMinor, string OtherCashInMinor,
+    string SpentMinor, string NetMinor,
+    int InflowCount, int PaycheckInflowCount, int OtherInflowCount,
+    int ExpenseCount, int PaycheckProfileCount, int EditedPaycheckInflowCount);
+
+public sealed record CashFlowCategoryDto(string Category, string AmountMinor);
+
+public sealed record CashFlowResponse(
+    string Month, DateOnly ThroughDate, DateOnly From, DateOnly To,
+    IReadOnlyList<string> AvailableMonths, CashFlowMonthDto Selected,
+    IReadOnlyList<CashFlowMonthDto> Months, IReadOnlyList<CashFlowCategoryDto> Categories);

--- a/backend/Controllers/AnalyticsController.cs
+++ b/backend/Controllers/AnalyticsController.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using BudgetPlanner.Analytics;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BudgetPlanner.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/analytics")]
+public sealed class AnalyticsController(ICashFlowService cashFlow) : ControllerBase
+{
+    [HttpGet("cash-flow")]
+    public async Task<IActionResult> GetCashFlow(
+        [FromQuery] string? month, [FromQuery] string? throughDate, CancellationToken cancellationToken)
+    {
+        var ownerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (ownerId is null) return Unauthorized();
+        if (!CashFlowPeriod.TryCreate(month, throughDate, out var period))
+            return BadRequest(new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest, Title = "Cash-flow request failed",
+                Detail = "Provide a calendar month and a through date on or after that month begins.",
+                Type = "https://ordo.invalid/problems/cash_flow_period_invalid",
+                Extensions = { ["code"] = "cash_flow_period_invalid" }
+            });
+        return Ok(await cashFlow.GetAsync(ownerId, period!, cancellationToken));
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -15,6 +15,7 @@ using BudgetPlanner.Import;
 using BudgetPlanner.Import.Sunflower;
 using BudgetPlanner.Commitments;
 using BudgetPlanner.Paychecks;
+using BudgetPlanner.Analytics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -46,6 +47,7 @@ builder.Services.AddScoped<ICommitmentService, CommitmentService>();
 builder.Services.AddSingleton<PaycheckCandidateDetector>();
 builder.Services.AddSingleton<PaycheckProjector>();
 builder.Services.AddScoped<IPaycheckService, PaycheckService>();
+builder.Services.AddScoped<ICashFlowService, CashFlowService>();
 
 builder.Services
     .AddOptions<EmailSettingsOptions>()

--- a/docs/financial-domain-invariants.md
+++ b/docs/financial-domain-invariants.md
@@ -171,6 +171,77 @@ authorize production application. Down removes occurrence links before decision
 and profile tables and would destroy durable decisions. Production Down or data
 cleanup requires separate explicit authorization and a retention/export decision.
 
+## Historical cash-flow analytics
+
+The [owner-approved issue #126 plan](https://github.com/OL1V3S/ordo/issues/126#issuecomment-5562641437)
+defines historical cash flow for the single tracked checking account:
+
+| Quantity | Meaning |
+| --- | --- |
+| Recorded cash in | Every owner-scoped `AccountInflow` in the period, once per stored ID |
+| Confirmed paychecks | The cash-in subset currently linked by `PaycheckOccurrence` to an owner-confirmed profile |
+| Other cash in | All remaining recorded inflows, exactly cash in minus the linked subset |
+| Spent | Every recorded Expense in the period |
+| Net recorded cash flow | Recorded cash in minus Spent; negative results are preserved |
+
+The two cash-in components partition both amounts and record counts. Confirming
+a paycheck changes the partition, never total cash in or net flow. Active,
+paused, and ended profiles contribute their linked evidence identically. Other
+cash in means not currently linked; it can contain an actual paycheck. It is
+not a non-paycheck-income classification. Refunds, reimbursements, transfers,
+and other recorded credits count as received cash without acquiring income
+meaning. A refund does not erase or reduce an Expense/category total.
+
+Manual and saved imported inflows count identically. Unsaved previews, manual
+expectations, candidate/projection amounts, budget limits, and future
+commitments add no money to historical totals. A candidate or dismissed
+candidate's saved inflows already count as other cash in. Later matching
+deposits count as cash in but do not automatically gain occurrence links.
+Distinct saved records remain distinct even when description/date/amount match;
+analytics introduces no economic-transaction deduplication.
+
+Use each surviving record's current amount and posted calendar date, not an
+expectation, slot anchor, or link timestamp. Edits can change historical totals
+or move a record between months. A retained linked edit remains in the paycheck
+subset, with its existing edited-evidence flag available in secondary detail.
+Deletion removes the contribution; profile lifecycle/expectation changes do not
+rewrite observed cash. These are current recorded observations, not immutable
+historical ledger snapshots.
+
+The UI supplies one browser-local calendar `throughDate` per request. This is
+an explicit read filter, not a timestamp or the paycheck projector's UTC
+evaluation date. A selected month spans its first date through the earlier of
+its last date and `throughDate`, inclusive. A selected month after the cutoff
+month is invalid. The trend contains six consecutive months ending with the
+selection, including empty buckets; at the calendar floor it begins at
+`0001-01`. Month discovery includes all inflow and Expense months through the
+cutoff plus the cutoff's month. Calendar values never undergo timezone shifts.
+
+Amounts cross the cash-flow API as canonical integer-cent strings, with a minus
+sign only for negative net flow. Exact arithmetic preserves the existing full
+monetary range and aggregate values; no lower ceiling is introduced. Only chart
+geometry may use approximate JavaScript numbers. Percentage spent is
+`100 * spent / cashIn`; cash-in shares use cash in as denominator, and Expense
+category shares use Spent. A zero denominator means not applicable. Percentages
+round to the nearest tenth with exact halfway values rounded upward; values
+above 100% are not capped. Rounded shares may not sum to exactly 100.0%.
+
+The authenticated read-only endpoint
+`GET /api/analytics/cash-flow?month=YYYY-MM&throughDate=YYYY-MM-DD` uses one
+repeatable-read, read-only PostgreSQL snapshot for amounts, membership, counts,
+categories, and available-month metadata. Ownership is checked across every
+source and membership relationship. The response excludes raw descriptions,
+authoritative owner IDs, import provenance, and projections. Invalid calendar
+filters return privacy-safe `400` ProblemDetails.
+
+The primary labels are Recorded cash in, Spent, and Net recorded cash flow.
+Coverage, record counts, and the precise paycheck-subset meaning belong in
+secondary disclosure. Zero recorded sums mean no cash in/spending recorded;
+neither zero nor positive sums prove complete account activity. Net flow is not
+current/available balance, savings, or safe-to-spend capacity. Paycheck cycles,
+expense-to-paycheck allocation, reconciliation, forecasts, and Safe-to-Spend
+remain deferred. This read model introduces no schema or migration.
+
 ## Description invariant
 
 An expense description is required. At the authoritative write boundary it is

--- a/frontend/src/features/analytics/api/cashFlowApi.js
+++ b/frontend/src/features/analytics/api/cashFlowApi.js
@@ -1,0 +1,8 @@
+import client from "../../../shared/api/client";
+
+export const cashFlowApi = {
+  get: (month, throughDate, signal) => client.get("/api/analytics/cash-flow", {
+    params: { month, throughDate },
+    signal,
+  }),
+};

--- a/frontend/src/features/analytics/api/cashFlowApi.test.js
+++ b/frontend/src/features/analytics/api/cashFlowApi.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+import client from "../../../shared/api/client";
+import { cashFlowApi } from "./cashFlowApi";
+
+vi.mock("../../../shared/api/client", () => ({ default: { get: vi.fn() } }));
+
+describe("cash-flow API", () => {
+  it("uses the authenticated shared client with explicit calendar filters and cancellation", async () => {
+    const data = { selected: { cashInMinor: "999999999999999999" } };
+    client.get.mockResolvedValue({ data });
+    const signal = new AbortController().signal;
+    expect(await cashFlowApi.get("2026-08", "2026-08-14", signal)).toEqual({ data });
+    expect(client.get).toHaveBeenCalledWith("/api/analytics/cash-flow", {
+      params: { month: "2026-08", throughDate: "2026-08-14" }, signal,
+    });
+  });
+});

--- a/frontend/src/features/analytics/components/CashFlowSummary.jsx
+++ b/frontend/src/features/analytics/components/CashFlowSummary.jsx
@@ -1,0 +1,60 @@
+import { useId } from "react";
+import { barWidth, cashDateLabel, cashMonthLabel, cashPercentage, formatCash, minorUnits } from "../utils/cashFlowPresentation";
+
+export default function CashFlowSummary({ data }) {
+  const headingId = useId();
+  const bucket = data.selected;
+  const maximum = minorUnits(bucket.cashInMinor) > minorUnits(bucket.spentMinor) ? bucket.cashInMinor : bucket.spentMinor;
+  const cashInSpent = cashPercentage(bucket.spentMinor, bucket.cashInMinor);
+  return (
+    <section className="card analytics-total cash-flow-summary" aria-labelledby={headingId}>
+      <p className="analytics-kicker">{cashMonthLabel(data.month)}</p>
+      <h2 id={headingId} className="h2">Recorded cash in vs Spent</h2>
+      {data.month === data.throughDate.slice(0, 7) && <p className="muted">Through {cashDateLabel(data.to)}</p>}
+      <p className="muted">Based on your recorded transactions.</p>
+      <div className="cash-flow-summary__comparison">
+        <div className="cash-flow-comparison">
+          <div className="cash-flow-comparison__row">
+            <div className="analytics-row"><strong>Recorded cash in</strong><strong>{formatCash(bucket.cashInMinor)}</strong></div>
+            <div className="cash-flow-bar" aria-hidden="true">
+              <span className="cash-flow-bar__paychecks" style={{ width: barWidth(bucket.paycheckCashInMinor, maximum) }} />
+              <span className="cash-flow-bar__other" style={{ width: barWidth(bucket.otherCashInMinor, maximum) }} />
+            </div>
+            {bucket.cashInMinor === "0" && <p className="muted">No cash in recorded</p>}
+          </div>
+          <div className="cash-flow-comparison__row">
+            <div className="analytics-row"><strong>Spent</strong><strong>{formatCash(bucket.spentMinor)}</strong></div>
+            <div className="cash-flow-bar" aria-hidden="true"><span className="cash-flow-bar__spent" style={{ width: barWidth(bucket.spentMinor, maximum) }} /></div>
+            {bucket.spentMinor === "0" && <p className="muted">No spending recorded</p>}
+          </div>
+          <ul className="cash-flow-legend cash-flow-legend--amounts" aria-label="Recorded cash in breakdown">
+            <li><span className="cash-flow-swatch cash-flow-bar__paychecks" aria-hidden="true" />Confirmed paychecks <strong>{formatCash(bucket.paycheckCashInMinor)}</strong></li>
+            <li><span className="cash-flow-swatch cash-flow-bar__other" aria-hidden="true" />Other cash in <strong>{formatCash(bucket.otherCashInMinor)}</strong></li>
+          </ul>
+        </div>
+        <div className="cash-flow-net">
+          <h3>Net recorded cash flow</h3>
+          <p className="analytics-total__value">{formatCash(bucket.netMinor, { signed: true })}</p>
+          <p className="muted">Recorded cash in minus Spent</p>
+        </div>
+      </div>
+      <details className="cash-flow-disclosure">
+        <summary>About these figures</summary>
+        <p>These figures reflect saved transactions and may not cover all account activity. Net recorded cash flow describes this period; it is not an account balance, savings, or money available to spend.</p>
+        <p>Confirmed paychecks are the recorded inflows linked to an owner-confirmed paycheck profile, including active, paused, and ended profiles. Other cash in is every remaining recorded inflow and can include unlinked paychecks, refunds, transfers, and reimbursements. Both parts count toward recorded cash in; receiving cash does not classify it as income.</p>
+        <p>Spent includes all recorded outflows, including purchases, transfers, debt payments, and investment funding. Refunds count as cash in without reducing their original spending category. Budgets, paycheck expectations, projections, and unsaved import previews do not add to these figures.</p>
+        <p>Amounts and dates reflect the current saved records. Editing or deleting a transaction can change these historical figures. Confirming a paycheck changes the cash-in breakdown, without changing total cash in or net flow.</p>
+        <dl className="cash-flow-facts">
+          <div><dt>Cash in spent</dt><dd>{cashInSpent ?? "Not applicable — no cash in recorded"}</dd></div>
+          <div><dt>Confirmed paycheck share</dt><dd>{cashPercentage(bucket.paycheckCashInMinor, bucket.cashInMinor) ?? "Not applicable — no cash in recorded"}</dd></div>
+          <div><dt>Other cash in share</dt><dd>{cashPercentage(bucket.otherCashInMinor, bucket.cashInMinor) ?? "Not applicable — no cash in recorded"}</dd></div>
+          <div><dt>Recorded inflows</dt><dd>{bucket.inflowCount} ({bucket.paycheckInflowCount} paycheck-linked, {bucket.otherInflowCount} other)</dd></div>
+          <div><dt>Recorded expenses</dt><dd>{bucket.expenseCount}</dd></div>
+          <div><dt>Contributing paycheck profiles</dt><dd>{bucket.paycheckProfileCount}</dd></div>
+          <div><dt>Edited linked inflows</dt><dd>{bucket.editedPaycheckInflowCount}</dd></div>
+        </dl>
+        <p className="muted">Edited linked inflows retain their assignment and use their current posted date and amount. Percentages round to the nearest tenth, with halfway values rounded upward; rounded shares may not sum to 100.0%.</p>
+      </details>
+    </section>
+  );
+}

--- a/frontend/src/features/analytics/components/CashFlowSummary.test.jsx
+++ b/frontend/src/features/analytics/components/CashFlowSummary.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CashFlowSummary from "./CashFlowSummary";
+import { cashFlowFixture } from "../testFixtures";
+
+describe("recorded cash-flow comparison", () => {
+  it("aligns the cash-in stack and spending with exact amounts and a signed net in the same card", () => {
+    const data = cashFlowFixture("2026-08", { spentMinor: "30000", netMinor: "-15000" });
+    const { container } = render(<CashFlowSummary data={data} />);
+    const card = screen.getByRole("region", { name: "Recorded cash in vs Spent" });
+    expect(card).toHaveTextContent("Recorded cash in$150.00");
+    expect(card).toHaveTextContent("Spent$300.00");
+    expect(within(card).getByRole("heading", { name: "Net recorded cash flow" })).toBeInTheDocument();
+    expect(card).toHaveTextContent("−$150.00");
+    const bars = container.querySelectorAll(".cash-flow-bar");
+    expect(bars[0]).toHaveAttribute("aria-hidden", "true");
+    expect(bars[0].children[0]).toHaveStyle({ width: "40%" });
+    expect(bars[0].children[1]).toHaveStyle({ width: "10%" });
+    expect(bars[1].children[0]).toHaveStyle({ width: "100%" });
+    const breakdown = screen.getByRole("list", { name: "Recorded cash in breakdown" });
+    expect(breakdown).toHaveTextContent("Confirmed paychecks $120.00");
+    expect(breakdown).toHaveTextContent("Other cash in $30.00");
+    expect(card).toHaveTextContent("Through August 14, 2026");
+    expect(card).toHaveTextContent("Cash in spent200.0%");
+  });
+  it("keeps secondary counts, shares and evidence explanations in a native closed disclosure", () => {
+    render(<CashFlowSummary data={cashFlowFixture("2026-08", { editedPaycheckInflowCount: 1 })} />);
+    const disclosure = screen.getByText("About these figures").closest("details");
+    expect(disclosure).not.toHaveAttribute("open");
+    expect(disclosure).toHaveTextContent("Other cash in is every remaining recorded inflow and can include unlinked paychecks");
+    expect(disclosure).toHaveTextContent("active, paused, and ended profiles");
+    expect(disclosure).toHaveTextContent("Edited linked inflows1");
+    expect(disclosure).toHaveTextContent("Recorded inflows3 (2 paycheck-linked, 1 other)");
+    expect(disclosure).toHaveTextContent("not an account balance");
+  });
+  it.each([
+    ["10000", "0", "10000", "0", "10000"],
+    ["10000", "10000", "0", "0", "10000"],
+    ["0", "0", "0", "10000", "-10000"],
+    ["0", "0", "0", "0", "0"],
+  ])("truthfully presents cash in %s linked %s other %s and spent %s", (cashInMinor, paycheckCashInMinor, otherCashInMinor, spentMinor, netMinor) => {
+    render(<CashFlowSummary data={cashFlowFixture("2026-08", { cashInMinor, paycheckCashInMinor, otherCashInMinor, spentMinor, netMinor })} />);
+    expect(screen.queryByText("No cash in recorded") !== null).toBe(cashInMinor === "0");
+    expect(screen.queryByText("No spending recorded") !== null).toBe(spentMinor === "0");
+    if (cashInMinor === "0") expect(screen.getAllByText("Not applicable — no cash in recorded")).toHaveLength(3);
+    expect(screen.queryByText(/missing income/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/CashFlowTrendChart.jsx
+++ b/frontend/src/features/analytics/components/CashFlowTrendChart.jsx
@@ -1,0 +1,78 @@
+import { useId } from "react";
+import { Bar } from "react-chartjs-2";
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from "chart.js";
+import { useCashFlowColors } from "../hooks/useCashFlowColors";
+import { cashMonthLabel, formatCash, periodNotes } from "../utils/cashFlowPresentation";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+export default function CashFlowTrendChart({ data }) {
+  const headingId = useId();
+  const tableId = useId();
+  const colors = useCashFlowColors();
+  const fields = ["paycheckCashInMinor", "otherCashInMinor", "spentMinor"];
+  const chartData = {
+    labels: data.months.map((bucket) => [...cashMonthLabel(bucket.month, { short: true }).split(" "),
+      ...(bucket.month === data.throughDate.slice(0, 7) ? ["MTD"] : [])]),
+    datasets: [
+      { label: "Confirmed paychecks", stack: "cash-in", backgroundColor: colors.paychecks, borderWidth: 1 },
+      { label: "Other cash in", stack: "cash-in", backgroundColor: colors.other, borderWidth: 3 },
+      { label: "Spent", stack: "spent", backgroundColor: colors.spent, borderWidth: 1 },
+    ].map((dataset, index) => ({ ...dataset,
+      // Numbers are used only by Chart.js for plotting. Tooltips/table use exact strings.
+      data: data.months.map((bucket) => Number(bucket[fields[index]]) / 100),
+      borderColor: colors.text,
+      borderSkipped: false,
+    })),
+  };
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    scales: {
+      x: { stacked: true, ticks: { color: colors.text, autoSkip: false, maxRotation: 0, minRotation: 0 }, grid: { display: false }, border: { color: colors.border } },
+      y: { stacked: true, beginAtZero: true, ticks: { color: colors.text }, grid: { color: colors.grid }, border: { color: colors.border }, title: { display: true, text: "USD", color: colors.text } },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        titleColor: colors.text, bodyColor: colors.text, backgroundColor: colors.surface,
+        borderColor: colors.border, borderWidth: 1,
+        callbacks: {
+          title: (items) => items.length ? cashMonthLabel(data.months[items[0].dataIndex].month) : "",
+          label: (context) => `${context.dataset.label}: ${formatCash(data.months[context.dataIndex][fields[context.datasetIndex]])}`,
+          footer: (items) => items.length ? `Recorded cash in: ${formatCash(data.months[items[0].dataIndex].cashInMinor)}` : "",
+        },
+      },
+    },
+  };
+
+  return (
+    <section className="card analytics-panel cash-flow-trend" aria-labelledby={headingId}>
+      <p className="analytics-kicker">{data.months.length === 6 ? "Six calendar months" : `${data.months.length} calendar ${data.months.length === 1 ? "month" : "months"} from January 0001`}</p>
+      <h2 id={headingId} className="h2">Cash in vs spending over time</h2>
+      <ul className="cash-flow-legend" aria-label="Chart legend">
+        <li><span className="cash-flow-swatch cash-flow-bar__paychecks" aria-hidden="true" />Confirmed paychecks</li>
+        <li><span className="cash-flow-swatch cash-flow-bar__other" aria-hidden="true" />Other cash in</li>
+        <li><span className="cash-flow-swatch cash-flow-bar__spent" aria-hidden="true" />Spent</li>
+      </ul>
+      <div className="cash-flow-trend__canvas" aria-hidden="true"><Bar data={chartData} options={options} /></div>
+      {data.months.some((bucket) => bucket.month === data.throughDate.slice(0, 7)) && <p className="muted cash-flow-trend__note">MTD: month to date</p>}
+      <details className="cash-flow-disclosure">
+        <summary>View chart data</summary>
+        <div className="cash-flow-table-scroll" role="region" aria-labelledby={tableId} tabIndex={0}>
+          <table className="cash-flow-table">
+            <caption id={tableId}>Monthly recorded cash flow in US dollars</caption>
+            <thead><tr><th scope="col">Month</th><th scope="col">Recorded cash in</th><th scope="col">Confirmed paychecks</th><th scope="col">Other cash in</th><th scope="col">Spent</th><th scope="col">Net recorded cash flow</th><th scope="col">Period note</th></tr></thead>
+            <tbody>{data.months.map((bucket) => <tr key={bucket.month}>
+              <th scope="row">{cashMonthLabel(bucket.month)}</th>
+              <td>{formatCash(bucket.cashInMinor)}</td><td>{formatCash(bucket.paycheckCashInMinor)}</td>
+              <td>{formatCash(bucket.otherCashInMinor)}</td><td>{formatCash(bucket.spentMinor)}</td>
+              <td>{formatCash(bucket.netMinor, { signed: true })}</td><td>{periodNotes(bucket, data.throughDate)}</td>
+            </tr>)}</tbody>
+          </table>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/frontend/src/features/analytics/components/CashFlowTrendChart.test.jsx
+++ b/frontend/src/features/analytics/components/CashFlowTrendChart.test.jsx
@@ -1,0 +1,78 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CashFlowTrendChart from "./CashFlowTrendChart";
+import { cashFlowFixture } from "../testFixtures";
+
+let renderedChart;
+vi.mock("react-chartjs-2", () => ({
+  Bar: (props) => { renderedChart = props; return <canvas data-testid="trend-canvas" />; },
+}));
+
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); document.documentElement.removeAttribute("data-theme"); });
+
+describe("cash-flow monthly grouped stacks", () => {
+  it("has six explicit monthly groups with the two cash-in datasets sharing a stack and no animations", () => {
+    render(<CashFlowTrendChart data={cashFlowFixture()} />);
+    expect(renderedChart.data.labels).toEqual([
+      ["Mar", "2026"], ["Apr", "2026"], ["May", "2026"], ["Jun", "2026"], ["Jul", "2026"], ["Aug", "2026", "MTD"],
+    ]);
+    expect(renderedChart.data.datasets).toMatchObject([
+      { label: "Confirmed paychecks", stack: "cash-in", data: [0, 0, 0, 0, 0, 120], borderWidth: 1 },
+      { label: "Other cash in", stack: "cash-in", data: [0, 0, 0, 0, 0, 30], borderWidth: 3 },
+      { label: "Spent", stack: "spent", data: [0, 0, 0, 0, 0, 100], borderWidth: 1 },
+    ]);
+    expect(renderedChart.options.animation).toBe(false);
+    expect(renderedChart.options.scales.y).toMatchObject({ stacked: true, beginAtZero: true });
+    expect(renderedChart.options.scales.x.ticks.autoSkip).toBe(false);
+    expect(screen.getByTestId("trend-canvas").parentElement).toHaveAttribute("aria-hidden", "true");
+  });
+  it("provides exact complete table data without hovering, including all empty buckets and period notes", () => {
+    render(<CashFlowTrendChart data={cashFlowFixture()} />);
+    const disclosure = screen.getByText("View chart data").closest("details");
+    expect(disclosure).not.toHaveAttribute("open");
+    const table = within(disclosure).getByRole("table", { hidden: true });
+    const rows = within(table).getAllByRole("row", { hidden: true });
+    expect(rows).toHaveLength(7);
+    expect(rows[0]).toHaveTextContent("Recorded cash inConfirmed paychecksOther cash inSpentNet recorded cash flowPeriod note");
+    expect(rows[1]).toHaveTextContent("No cash in recorded · No spending recorded");
+    expect(rows[6]).toHaveTextContent("August 2026$150.00$120.00$30.00$100.00+$50.00Through August 14, 2026");
+    expect(table.parentElement).toHaveAttribute("tabindex", "0");
+  });
+  it("formats tooltip values from exact strings instead of rounded chart numbers", () => {
+    const data = cashFlowFixture("2026-08", { cashInMinor: "999999999999999999", otherCashInMinor: "999999999999999999", paycheckCashInMinor: "0" });
+    render(<CashFlowTrendChart data={data} />);
+    const callbacks = renderedChart.options.plugins.tooltip.callbacks;
+    expect(callbacks.label({ dataset: { label: "Other cash in" }, datasetIndex: 1, dataIndex: 5 }))
+      .toBe("Other cash in: $9,999,999,999,999,999.99");
+    expect(callbacks.footer([{ dataIndex: 5 }])).toBe("Recorded cash in: $9,999,999,999,999,999.99");
+  });
+  it("labels a shorter representable-calendar-floor range", () => {
+    const data = cashFlowFixture();
+    data.months = [{ ...data.selected, month: "0001-01", from: "0001-01-01", to: "0001-01-31" }];
+    render(<CashFlowTrendChart data={data} />);
+    expect(screen.getByText("1 calendar month from January 0001")).toBeInTheDocument();
+    expect(renderedChart.data.labels).toEqual([["Jan", "0001"]]);
+  });
+  it("updates light/dark/system palette and removes theme listeners without changing data", async () => {
+    const listeners = new Set();
+    let systemDark = false;
+    const query = { addEventListener: vi.fn((_, listener) => listeners.add(listener)), removeEventListener: vi.fn((_, listener) => listeners.delete(listener)) };
+    vi.stubGlobal("matchMedia", vi.fn(() => query));
+    vi.spyOn(window, "getComputedStyle").mockImplementation(() => ({
+      getPropertyValue: (name) => name === "--chart-paychecks" ? ((document.documentElement.dataset.theme === "dark" || (!document.documentElement.dataset.theme && systemDark)) ? "#69c5b1" : "#24776a") : "",
+    }));
+    const { unmount } = render(<CashFlowTrendChart data={cashFlowFixture()} />);
+    await waitFor(() => expect(renderedChart.data.datasets[0].backgroundColor).toBe("#24776a"));
+    const before = renderedChart.data.datasets.map(({ data }) => data);
+    act(() => { document.documentElement.dataset.theme = "dark"; });
+    await waitFor(() => expect(renderedChart.data.datasets[0].backgroundColor).toBe("#69c5b1"));
+    act(() => { document.documentElement.removeAttribute("data-theme"); systemDark = false; listeners.forEach((listener) => listener()); });
+    await waitFor(() => expect(renderedChart.data.datasets[0].backgroundColor).toBe("#24776a"));
+    act(() => { systemDark = true; listeners.forEach((listener) => listener()); });
+    await waitFor(() => expect(renderedChart.data.datasets[0].backgroundColor).toBe("#69c5b1"));
+    expect(renderedChart.data.datasets.map(({ data }) => data)).toEqual(before);
+    unmount();
+    expect(query.removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/frontend/src/features/analytics/hooks/useCashFlow.js
+++ b/frontend/src/features/analytics/hooks/useCashFlow.js
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { getSessionSnapshot, subscribeToSession } from "../../../shared/auth/session";
+import { cashFlowApi } from "../api/cashFlowApi";
+import { localThroughDate } from "../utils/cashFlowPresentation";
+
+export function useCashFlow(month) {
+  const session = useSyncExternalStore(subscribeToSession, getSessionSnapshot);
+  const [state, setState] = useState(null);
+  const [attempt, setAttempt] = useState(0);
+  const latest = useRef(0);
+  const refresh = useCallback(() => setAttempt((value) => value + 1), []);
+
+  useEffect(() => {
+    const id = ++latest.current;
+    const controller = new AbortController();
+    const throughDate = localThroughDate();
+    const current = () => id === latest.current && session === getSessionSnapshot();
+    setState((previous) => ({
+      month, session, attempt, loading: true, data: null, error: null,
+      availableMonths: previous?.session === session ? previous.availableMonths : [],
+    }));
+
+    if (!session.token) {
+      setState({ month, session, attempt, loading: false, data: null, availableMonths: [], error: "Sign in to view recorded cash flow." });
+      return () => { latest.current += 1; controller.abort(); };
+    }
+
+    cashFlowApi.get(month, throughDate, controller.signal).then(({ data }) => {
+      if (!current()) return;
+      // A response for another period must never be presented under this filter.
+      if (data.month !== month || data.throughDate !== throughDate) throw new Error("Cash-flow period mismatch");
+      setState({ month, session, attempt, loading: false, data, error: null, availableMonths: data.availableMonths });
+    }).catch(() => {
+      if (!current()) return;
+      setState((previous) => ({ ...previous, loading: false, data: null,
+        error: "We couldn’t load recorded cash flow. Try again." }));
+    });
+
+    return () => { latest.current += 1; controller.abort(); };
+  }, [month, session, attempt]);
+
+  // Hide the old snapshot on the very first render of a new month/session/refresh.
+  const matches = state?.month === month && state?.session === session && state?.attempt === attempt;
+  return {
+    data: matches ? state.data : null,
+    loading: !matches || state.loading,
+    error: matches ? state.error : null,
+    availableMonths: state?.session === session ? state.availableMonths : [],
+    refresh,
+  };
+}

--- a/frontend/src/features/analytics/hooks/useCashFlow.test.jsx
+++ b/frontend/src/features/analytics/hooks/useCashFlow.test.jsx
@@ -1,0 +1,104 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { establishSession, clearSession } from "../../../shared/auth/session";
+import { cashFlowApi } from "../api/cashFlowApi";
+import { cashFlowFixture } from "../testFixtures";
+import { useCashFlow } from "./useCashFlow";
+
+vi.mock("../api/cashFlowApi", () => ({ cashFlowApi: { get: vi.fn() } }));
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+function response(month = "2026-08") {
+  return { data: { ...cashFlowFixture(month), throughDate: "2026-08-14" } };
+}
+
+describe("cash-flow snapshot lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 7, 14, 12));
+    establishSession("owner-a", "a@example.test");
+    cashFlowApi.get.mockReset();
+  });
+  afterEach(() => { clearSession(); vi.useRealTimers(); });
+
+  it("starts loading without zero data, then publishes the single whole response", async () => {
+    const request = deferred();
+    cashFlowApi.get.mockReturnValue(request.promise);
+    const { result } = renderHook(() => useCashFlow("2026-08"));
+    expect(result.current).toMatchObject({ loading: true, data: null, error: null });
+    expect(cashFlowApi.get).toHaveBeenCalledWith("2026-08", "2026-08-14", expect.any(AbortSignal));
+    await act(() => request.resolve(response()));
+    expect(result.current).toMatchObject({ loading: false, data: response().data, availableMonths: ["2026-08", "2026-07"] });
+  });
+  it("discards older month responses, even when cancellation is ignored", async () => {
+    const old = deferred();
+    const recent = deferred();
+    cashFlowApi.get.mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    const { result, rerender } = renderHook(({ month }) => useCashFlow(month), { initialProps: { month: "2026-08" } });
+    rerender({ month: "2026-07" });
+    expect(result.current.data).toBeNull();
+    await act(() => recent.resolve(response("2026-07")));
+    await act(() => old.resolve(response()));
+    expect(result.current.data.month).toBe("2026-07");
+  });
+  it("does not relabel prior complete results while another month loads or fails", async () => {
+    cashFlowApi.get.mockResolvedValueOnce(response()).mockRejectedValueOnce(new Error("failed"));
+    const { result, rerender } = renderHook(({ month }) => useCashFlow(month), { initialProps: { month: "2026-08" } });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    rerender({ month: "2026-07" });
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.error).toContain("couldn’t load"));
+    expect(result.current.data).toBeNull();
+  });
+  it("fails unavailable and retries with a newly captured local cutoff", async () => {
+    cashFlowApi.get.mockRejectedValueOnce(new Error("failed"));
+    const { result } = renderHook(() => useCashFlow("2026-08"));
+    await waitFor(() => expect(result.current.error).toContain("couldn’t load"));
+    const next = deferred();
+    cashFlowApi.get.mockReturnValueOnce(next.promise);
+    vi.setSystemTime(new Date(2026, 7, 15, 0, 1));
+    act(() => result.current.refresh());
+    expect(result.current).toMatchObject({ loading: true, data: null });
+    expect(cashFlowApi.get).toHaveBeenLastCalledWith("2026-08", "2026-08-15", expect.any(AbortSignal));
+    await act(() => next.resolve({ data: { ...response().data, throughDate: "2026-08-15", to: "2026-08-15" } }));
+    expect(result.current.data.throughDate).toBe("2026-08-15");
+  });
+  it("removes a successful snapshot when a refresh fails instead of retaining unlabeled stale figures", async () => {
+    cashFlowApi.get.mockResolvedValueOnce(response()).mockRejectedValueOnce(new Error("failed"));
+    const { result } = renderHook(() => useCashFlow("2026-08"));
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    act(() => result.current.refresh());
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.data).toBeNull();
+  });
+  it("clears owner data and ignores old-session completion on a same-page session change", async () => {
+    const old = deferred();
+    const recent = deferred();
+    cashFlowApi.get.mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    const { result } = renderHook(() => useCashFlow("2026-08"));
+    act(() => establishSession("owner-b", "b@example.test"));
+    expect(result.current.data).toBeNull();
+    await act(() => old.resolve(response()));
+    expect(result.current.data).toBeNull();
+    await act(() => recent.resolve(response()));
+    expect(result.current.data).not.toBeNull();
+    act(() => clearSession());
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toContain("Sign in");
+  });
+  it("rejects mismatched echoed periods and aborts on unmount", async () => {
+    cashFlowApi.get.mockResolvedValueOnce(response("2026-07"));
+    const { result, unmount } = renderHook(() => useCashFlow("2026-08"));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.data).toBeNull();
+    const signal = cashFlowApi.get.mock.calls[0][2];
+    unmount();
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/frontend/src/features/analytics/hooks/useCashFlowColors.js
+++ b/frontend/src/features/analytics/hooks/useCashFlowColors.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+const fallbackColors = {
+  paychecks: "#24776a", other: "#9b6525", spent: "#5458c9", text: "#181a20",
+  grid: "#e7e8ec", border: "#8b8d94", surface: "#ffffff",
+};
+
+export function useCashFlowColors() {
+  const [colors, setColors] = useState(fallbackColors);
+  useEffect(() => {
+    const root = document.documentElement;
+    const systemTheme = window.matchMedia?.("(prefers-color-scheme: dark)");
+    let active = true;
+    const update = () => queueMicrotask(() => {
+      if (!active) return;
+      const styles = window.getComputedStyle(root);
+      const next = Object.fromEntries(Object.entries(fallbackColors).map(([key, fallback]) => [
+        key, styles.getPropertyValue(`--chart-${key}`).trim() || fallback,
+      ]));
+      setColors((previous) => Object.keys(next).every((key) => next[key] === previous[key]) ? previous : next);
+    });
+    const observer = new MutationObserver(update);
+    observer.observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    systemTheme?.addEventListener("change", update);
+    update();
+    return () => {
+      active = false;
+      observer.disconnect();
+      systemTheme?.removeEventListener("change", update);
+    };
+  }, []);
+  return colors;
+}

--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -3,7 +3,10 @@ import { Link } from "react-router-dom";
 import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
 import { useExpenses } from "../../expenses/hooks/useExpenses";
 import { formatExpenseDate } from "../../expenses/utils/calendarDate";
-import { getMonthYear } from "../../../shared/utils/monthYear";
+import { useCashFlow } from "../hooks/useCashFlow";
+import CashFlowSummary from "../components/CashFlowSummary";
+import CashFlowTrendChart from "../components/CashFlowTrendChart";
+import { barWidth, cashMonthLabel, cashPercentage, formatCash, localThroughDate, minorUnits } from "../utils/cashFlowPresentation";
 import { displayText } from "../../../utils/text";
 import Card from "../../../shared/ui/Card";
 import FormField from "../../../shared/ui/FormField";
@@ -12,7 +15,6 @@ import {
   buildBudgetStatuses,
   buildMonthlySpendingInsights,
   formatMonthLabel,
-  getAvailableMonths,
 } from "../utils/monthlySpendingInsights";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
@@ -24,7 +26,8 @@ function formatPercentage(value, { signed = false } = {}) {
 }
 
 export default function AnalyticsPage() {
-  const [selectedMonth, setSelectedMonth] = useState(getMonthYear(new Date()));
+  const [selectedMonth, setSelectedMonth] = useState(() => localThroughDate().slice(0, 7));
+  const cashFlow = useCashFlow(selectedMonth);
   const {
     expenses, loading: expensesLoading, error: expensesError, refresh: refreshExpenses,
   } = useExpenses();
@@ -32,7 +35,11 @@ export default function AnalyticsPage() {
     budgetLimits, loading: limitsLoading, error: limitsError, refresh: refreshLimits,
   } = useBudgetLimits(selectedMonth);
 
-  const availableMonths = useMemo(() => getAvailableMonths(expenses), [expenses]);
+  const availableMonths = [...new Set([localThroughDate().slice(0, 7), selectedMonth, ...cashFlow.availableMonths])].sort().reverse();
+  const categories = useMemo(() => [...(cashFlow.data?.categories ?? [])].sort((left, right) => {
+    const difference = minorUnits(right.amountMinor) - minorUnits(left.amountMinor);
+    return difference > 0n ? 1 : difference < 0n ? -1 : left.category.localeCompare(right.category, "en");
+  }), [cashFlow.data]);
   const insights = useMemo(
     () => buildMonthlySpendingInsights(expenses, selectedMonth),
     [expenses, selectedMonth]
@@ -54,15 +61,15 @@ export default function AnalyticsPage() {
     <div className="container analytics-page">
       <header className="page-header analytics-page__header">
         <div>
-          <p className="page-header__eyebrow">Understand your spending</p>
+          <p className="page-header__eyebrow">Understand your cash flow</p>
           <h1>Analytics</h1>
-          <p className="muted">See what happened with your recorded spending, month by month.</p>
+          <p className="muted">See recorded cash in and spending, month by month.</p>
         </div>
         <FormField label="Month">
           {(id) => (
             <select id={id} value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value)}>
               {availableMonths.map((month) => (
-                <option key={month} value={month}>{formatMonthLabel(month)}</option>
+                <option key={month} value={month}>{cashMonthLabel(month)}</option>
               ))}
             </select>
           )}
@@ -77,42 +84,51 @@ export default function AnalyticsPage() {
         </Card>
       ) : null}
 
-      {!expensesLoading && !expensesError ? (
-        <>
-          <Card as="section" className="analytics-total" aria-labelledby="monthly-total-heading">
-            <p className="analytics-kicker">{formatMonthLabel(selectedMonth)}</p>
-            <h2 id="monthly-total-heading" className="h2">Monthly recorded spending</h2>
-            <p className="analytics-total__value">{currencyFormatter.format(insights.total)}</p>
-            <p className="muted">Total of recorded Expenses for the selected calendar month.</p>
-          </Card>
-
-          <div className="analytics-grid">
-            <Card as="section" className="analytics-panel" aria-labelledby="category-breakdown-heading">
+      <section className="cash-flow-region" aria-label="Recorded cash flow" aria-busy={cashFlow.loading}>
+        {cashFlow.loading ? <StatusMessage>Loading recorded cash flow...</StatusMessage> : null}
+        {!cashFlow.loading && cashFlow.error ? (
+          <div className="card analytics-panel">
+            <StatusMessage tone="danger">{cashFlow.error}</StatusMessage>
+            <button type="button" onClick={cashFlow.refresh}>Retry cash flow</button>
+          </div>
+        ) : null}
+        {!cashFlow.loading && cashFlow.data ? (
+          <>
+            <CashFlowSummary data={cashFlow.data} />
+            <section className="card analytics-panel cash-flow-categories" aria-labelledby="category-breakdown-heading">
               <div className="analytics-panel__header">
                 <div>
                   <p className="analytics-kicker">Ranked by amount</p>
-                  <h2 id="category-breakdown-heading" className="h2">Where the money went</h2>
+                  <h2 id="category-breakdown-heading" className="h2">Where it went</h2>
                 </div>
               </div>
-              {insights.categories.length === 0 ? (
-                <StatusMessage>No recorded spending for this month.</StatusMessage>
+              {categories.length === 0 ? (
+                <StatusMessage>No spending recorded</StatusMessage>
               ) : (
                 <ol className="analytics-list analytics-category-list">
-                  {insights.categories.map((category) => (
+                  {categories.map((category) => (
                     <li key={category.category} className="analytics-list__item">
                       <div className="analytics-row">
                         <strong>{displayText(category.category)}</strong>
-                        <span>{currencyFormatter.format(category.amount)} · {formatPercentage(category.percentage)}</span>
+                        <span>{formatCash(category.amountMinor)} · {cashPercentage(category.amountMinor, cashFlow.data.selected.spentMinor) ?? "Not applicable"}</span>
                       </div>
                       <div className="analytics-bar" aria-hidden="true">
-                        <span style={{ width: `${Math.max(0, Math.min(category.percentage ?? 0, 100))}%` }} />
+                        <span style={{ width: barWidth(category.amountMinor, cashFlow.data.selected.spentMinor) }} />
                       </div>
                     </li>
                   ))}
                 </ol>
               )}
-            </Card>
+            </section>
+            <CashFlowTrendChart data={cashFlow.data} />
+            <button type="button" className="cash-flow-refresh" onClick={cashFlow.refresh}>Refresh cash flow</button>
+          </>
+        ) : null}
+      </section>
 
+      {!expensesLoading && !expensesError ? (
+        <>
+          <div className="analytics-grid">
             <Card as="section" className="analytics-panel" aria-labelledby="budget-status-heading">
               <div className="analytics-panel__header">
                 <div>

--- a/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
@@ -4,12 +4,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AnalyticsPage from "./AnalyticsPage";
 import { useExpenses } from "../../expenses/hooks/useExpenses";
 import { useBudgetLimits } from "../../budgetLimits/hooks/useBudgetLimits";
+import { useCashFlow } from "../hooks/useCashFlow";
+import { cashFlowFixture } from "../testFixtures";
 
+vi.mock("../hooks/useCashFlow", () => ({ useCashFlow: vi.fn() }));
+vi.mock("react-chartjs-2", () => ({ Bar: () => <canvas data-testid="cash-flow-chart" /> }));
 vi.mock("../../expenses/hooks/useExpenses", () => ({ useExpenses: vi.fn() }));
 vi.mock("../../budgetLimits/hooks/useBudgetLimits", () => ({ useBudgetLimits: vi.fn() }));
 
 const refreshExpenses = vi.fn();
 const refreshLimits = vi.fn();
+const refreshCashFlow = vi.fn();
+
+function loadedCashFlow(month = "2026-08", overrides = {}) {
+  const data = cashFlowFixture(month, month === "2026-07" ? { spentMinor: "7500", netMinor: "7500" } : {});
+  if (month === "2026-07") data.categories = [{ category: "bills", amountMinor: "7500" }];
+  return { data, loading: false, error: null, availableMonths: data.availableMonths, refresh: refreshCashFlow, ...overrides };
+}
 
 function renderPage() {
   return render(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
@@ -19,6 +30,7 @@ describe("monthly spending insights page", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0));
+    useCashFlow.mockImplementation((month) => loadedCashFlow(month));
     useExpenses.mockReturnValue({
       expenses: [
         { id: 1, description: "Groceries", category: "food", amount: 90, date: "2026-08-02" },
@@ -50,9 +62,9 @@ describe("monthly spending insights page", () => {
 
     expect(screen.getByLabelText("Month")).toHaveValue("2026-08");
     expect(useBudgetLimits).toHaveBeenLastCalledWith("2026-08");
-    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" }).closest("section")).toHaveTextContent("$100.00");
 
-    const breakdown = screen.getByRole("heading", { name: "Where the money went" }).closest("section");
+    const breakdown = screen.getByRole("heading", { name: "Where it went" }).closest("section");
     const rows = within(breakdown).getAllByRole("listitem");
     expect(rows[0]).toHaveTextContent("Food");
     expect(rows[0]).toHaveTextContent("$90.00 · 90.0%");
@@ -76,7 +88,7 @@ describe("monthly spending insights page", () => {
 
     fireEvent.change(selector, { target: { value: "2026-07" } });
     expect(useBudgetLimits).toHaveBeenLastCalledWith("2026-07");
-    expect(screen.getByRole("heading", { name: "Monthly recorded spending" }).closest("section"))
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" }).closest("section"))
       .toHaveTextContent("$75.00");
   });
 
@@ -84,7 +96,8 @@ describe("monthly spending insights page", () => {
     useExpenses.mockReturnValue({ expenses: [], loading: true, error: null, refresh: refreshExpenses });
     const { rerender } = renderPage();
     expect(screen.getByText("Loading spending insights...")).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Monthly recorded spending" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Largest expenses" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" })).toBeInTheDocument();
 
     useExpenses.mockReturnValue({ expenses: [], loading: false, error: new Error("failed"), refresh: refreshExpenses });
     rerender(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
@@ -99,22 +112,70 @@ describe("monthly spending insights page", () => {
     });
     renderPage();
 
-    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" }).closest("section")).toHaveTextContent("$100.00");
     expect(screen.getByRole("alert")).toHaveTextContent("Budget limits are unavailable");
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
     expect(refreshLimits).toHaveBeenCalledOnce();
   });
 
   it("shows honest empty states for a month without expenses or limits", () => {
+    const empty = cashFlowFixture("2026-08", { cashInMinor: "0", paycheckCashInMinor: "0", otherCashInMinor: "0", spentMinor: "0", netMinor: "0" });
+    empty.categories = [];
+    useCashFlow.mockReturnValue(loadedCashFlow("2026-08", { data: empty }));
     useExpenses.mockReturnValue({ expenses: [], loading: false, error: null, refresh: refreshExpenses });
     useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false, error: null, refresh: refreshLimits });
     renderPage();
 
-    expect(screen.getAllByText("$0.00")).toHaveLength(2);
-    expect(screen.getByText("No recorded spending for this month.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Month-over-month change" }).closest("section")).toHaveTextContent("$0.00");
+    expect(screen.getAllByText("No spending recorded").length).toBeGreaterThan(0);
+    expect(screen.getByText("No cash in recorded")).toBeInTheDocument();
     expect(screen.getByText("No budget limits are set for this month.")).toBeInTheDocument();
     expect(screen.getByText("No category changes to show between these months.")).toBeInTheDocument();
     expect(screen.getByText("No expenses to rank for this month.")).toBeInTheDocument();
     expect(screen.getByText("Neither month has recorded spending.")).toBeInTheDocument();
   });
+  it("offers historical months represented only by other recorded inflows", () => {
+    useCashFlow.mockReturnValue(loadedCashFlow("2026-08", { availableMonths: ["2026-08", "2026-07", "2026-02"] }));
+    renderPage();
+    expect(within(screen.getByLabelText("Month")).getAllByRole("option").map(({ value }) => value))
+      .toEqual(["2026-08", "2026-07", "2026-02"]);
+    fireEvent.change(screen.getByLabelText("Month"), { target: { value: "2026-02" } });
+    expect(useCashFlow).toHaveBeenLastCalledWith("2026-02");
+  });
+
+  it("keeps all four cash-flow views unavailable during initial loading and retryable failure", () => {
+    useCashFlow.mockReturnValue(loadedCashFlow("2026-08", { data: null, loading: true }));
+    const { rerender } = renderPage();
+    expect(screen.getByRole("region", { name: "Recorded cash flow" })).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading recorded cash flow...")).toHaveAttribute("role", "status");
+    expect(screen.queryByRole("heading", { name: "Recorded cash in vs Spent" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Where it went" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("cash-flow-chart")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Largest expenses" })).toBeInTheDocument();
+    useCashFlow.mockReturnValue(loadedCashFlow("2026-08", { data: null, error: "We couldn’t load recorded cash flow. Try again." }));
+    rerender(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
+    expect(screen.getByRole("region", { name: "Recorded cash flow" })).toHaveAttribute("aria-busy", "false");
+    expect(screen.getByRole("alert")).toHaveTextContent("couldn’t load recorded cash flow");
+    fireEvent.click(screen.getByRole("button", { name: "Retry cash flow" }));
+    expect(refreshCashFlow).toHaveBeenCalledOnce();
+  });
+
+  it("shows exact custom and uncategorized amounts sorted before rounding with lexical ties", () => {
+    const data = cashFlowFixture();
+    data.selected.spentMinor = "2999999999999999996";
+    data.categories = [
+      { category: "uncategorized", amountMinor: "999999999999999999" },
+      { category: "a custom category", amountMinor: "999999999999999999" },
+      { category: "other custom", amountMinor: "999999999999999998" },
+    ];
+    useCashFlow.mockReturnValue(loadedCashFlow("2026-08", { data }));
+    renderPage();
+    const panel = screen.getByRole("heading", { name: "Where it went" }).closest("section");
+    const rows = within(panel).getAllByRole("listitem");
+    expect(rows[0]).toHaveTextContent("A Custom Category");
+    expect(rows[0]).toHaveTextContent("$9,999,999,999,999,999.99 · 33.3%");
+    expect(rows[1]).toHaveTextContent("Uncategorized");
+    expect(rows[2]).toHaveTextContent("$9,999,999,999,999,999.98");
+  });
+
 });

--- a/frontend/src/features/analytics/testFixtures.js
+++ b/frontend/src/features/analytics/testFixtures.js
@@ -1,0 +1,34 @@
+export function cashFlowFixture(month = "2026-08", overrides = {}) {
+  const bucket = {
+    month, from: `${month}-01`, to: month === "2026-08" ? "2026-08-14" : `${month}-31`,
+    cashInMinor: "15000", paycheckCashInMinor: "12000", otherCashInMinor: "3000", spentMinor: "10000", netMinor: "5000",
+    inflowCount: 3, paycheckInflowCount: 2, otherInflowCount: 1, expenseCount: 2,
+    paycheckProfileCount: 1, editedPaycheckInflowCount: 0,
+    ...overrides,
+  };
+  if (overrides.netMinor === undefined) bucket.netMinor = (BigInt(bucket.cashInMinor) - BigInt(bucket.spentMinor)).toString();
+  if (bucket.paycheckCashInMinor === "0") {
+    bucket.paycheckInflowCount = 0;
+    bucket.paycheckProfileCount = 0;
+    bucket.editedPaycheckInflowCount = 0;
+  }
+  if (bucket.otherCashInMinor === "0") bucket.otherInflowCount = 0;
+  bucket.inflowCount = bucket.paycheckInflowCount + bucket.otherInflowCount;
+  if (bucket.spentMinor === "0") bucket.expenseCount = 0;
+  const index = Number(month.slice(0, 4)) * 12 + Number(month.slice(5)) - 1;
+  const first = Math.max(12, index - 5);
+  const months = Array.from({ length: index - first + 1 }, (_, offset) => {
+    const value = first + offset;
+    return `${String(Math.floor(value / 12)).padStart(4, "0")}-${String(value % 12 + 1).padStart(2, "0")}`;
+  })
+    .map((value) => value === month ? bucket : {
+      ...bucket, month: value, from: `${value}-01`, to: `${value}-${["04", "06"].includes(value.slice(5)) ? "30" : "31"}`,
+      cashInMinor: "0", paycheckCashInMinor: "0", otherCashInMinor: "0", spentMinor: "0", netMinor: "0",
+      inflowCount: 0, paycheckInflowCount: 0, otherInflowCount: 0, expenseCount: 0, paycheckProfileCount: 0,
+    });
+  return {
+    month, throughDate: "2026-08-14", from: bucket.from, to: bucket.to,
+    availableMonths: ["2026-08", "2026-07"], selected: bucket, months,
+    categories: [{ category: "food", amountMinor: "9000" }, { category: "transport", amountMinor: "1000" }],
+  };
+}

--- a/frontend/src/features/analytics/utils/cashFlowPresentation.js
+++ b/frontend/src/features/analytics/utils/cashFlowPresentation.js
@@ -1,0 +1,54 @@
+const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+export function minorUnits(value) {
+  if (typeof value !== "string" || !/^(0|-?[1-9]\d*)$/.test(value)) {
+    throw new Error("Invalid cash-flow amount");
+  }
+  return BigInt(value);
+}
+
+export function formatCash(value, { signed = false } = {}) {
+  const amount = minorUnits(value);
+  const absolute = amount < 0n ? -amount : amount;
+  const dollars = (absolute / 100n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const sign = amount < 0n ? "−" : signed && amount > 0n ? "+" : "";
+  return `${sign}$${dollars}.${(absolute % 100n).toString().padStart(2, "0")}`;
+}
+
+// Round the exact ratio to one percentage decimal, with halfway values upward.
+// Never convert a financial amount or ratio intermediate to Number.
+export function cashPercentage(numerator, denominator) {
+  const part = minorUnits(numerator);
+  const whole = minorUnits(denominator);
+  if (whole <= 0n) return null;
+  const tenths = (part * 2000n + whole) / (whole * 2n);
+  return `${tenths / 10n}.${tenths % 10n}%`;
+}
+
+// Approximation is exclusively for decorative chart/bar geometry.
+export function barWidth(amount, maximum) {
+  const part = minorUnits(amount);
+  const whole = minorUnits(maximum);
+  return whole > 0n ? `${Number((part * 10000n) / whole) / 100}%` : "0%";
+}
+
+export function localThroughDate(now = new Date()) {
+  return `${String(now.getFullYear()).padStart(4, "0")}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+export function cashMonthLabel(month, { short = false } = {}) {
+  const name = monthNames[Number(month.slice(5, 7)) - 1];
+  return `${short ? name.slice(0, 3) : name} ${month.slice(0, 4)}`;
+}
+
+export function cashDateLabel(date) {
+  return `${monthNames[Number(date.slice(5, 7)) - 1]} ${Number(date.slice(8, 10))}, ${date.slice(0, 4)}`;
+}
+
+export function periodNotes(bucket, throughDate) {
+  const notes = [];
+  if (bucket.month === throughDate.slice(0, 7)) notes.push(`Through ${cashDateLabel(bucket.to)}`);
+  if (bucket.cashInMinor === "0") notes.push("No cash in recorded");
+  if (bucket.spentMinor === "0") notes.push("No spending recorded");
+  return notes.join(" · ") || "—";
+}

--- a/frontend/src/features/analytics/utils/cashFlowPresentation.test.js
+++ b/frontend/src/features/analytics/utils/cashFlowPresentation.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { barWidth, cashDateLabel, cashMonthLabel, cashPercentage, formatCash, localThroughDate, minorUnits, periodNotes } from "./cashFlowPresentation";
+
+describe("exact cash-flow presentation", () => {
+  it.each([
+    ["0", "$0.00"], ["1", "$0.01"], ["-1", "−$0.01"],
+    ["999999999999999999", "$9,999,999,999,999,999.99"],
+    ["2999999999999999997", "$29,999,999,999,999,999.97"],
+  ])("formats %s without losing cents", (value, expected) => expect(formatCash(value)).toBe(expected));
+  it("preserves signed net without calling zero positive", () => {
+    expect(formatCash("100", { signed: true })).toBe("+$1.00");
+    expect(formatCash("-100", { signed: true })).toBe("−$1.00");
+    expect(formatCash("0", { signed: true })).toBe("$0.00");
+  });
+  it.each(["01", "-0", "+1", "1.2", "1e2", 100, null])("rejects noncanonical cent input %s", (value) => {
+    expect(() => minorUnits(value)).toThrow("Invalid cash-flow amount");
+  });
+  it("rounds exact percentages halfway up and keeps overspending and tiny denominators", () => {
+    expect(cashPercentage("1", "16")).toBe("6.3%");
+    expect(cashPercentage("1", "3")).toBe("33.3%");
+    expect(cashPercentage("151", "100")).toBe("151.0%");
+    expect(cashPercentage("999999999999999999", "1")).toBe("99999999999999999900.0%");
+    expect(cashPercentage("0", "100")).toBe("0.0%");
+    expect(cashPercentage("100", "0")).toBeNull();
+    expect(cashPercentage("0", "0")).toBeNull();
+  });
+  it("scales both stacked components against the same maximum", () => {
+    expect(barWidth("12000", "30000")).toBe("40%");
+    expect(barWidth("3000", "30000")).toBe("10%");
+    expect(barWidth("30000", "30000")).toBe("100%");
+    expect(barWidth("0", "0")).toBe("0%");
+  });
+  it("uses local calendar fields, never UTC serialization", () => {
+    const date = { getFullYear: () => 2026, getMonth: () => 7, getDate: () => 14,
+      toISOString: () => { throw new Error("UTC conversion must not run"); } };
+    expect(localThroughDate(date)).toBe("2026-08-14");
+  });
+  it("formats representable calendar edges without the Date constructor year remapping", () => {
+    expect(cashMonthLabel("0001-01")).toBe("January 0001");
+    expect(cashDateLabel("0001-01-01")).toBe("January 1, 0001");
+    expect(cashMonthLabel("9999-12", { short: true })).toBe("Dec 9999");
+    expect(cashDateLabel("2024-02-29")).toBe("February 29, 2024");
+  });
+  it("reports only factual period notes", () => {
+    expect(periodNotes({ month: "2026-08", to: "2026-08-14", cashInMinor: "0", spentMinor: "0" }, "2026-08-14"))
+      .toBe("Through August 14, 2026 · No cash in recorded · No spending recorded");
+    expect(periodNotes({ month: "2026-07", cashInMinor: "100", spentMinor: "100" }, "2026-08-14")).toBe("—");
+  });
+});

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -147,6 +147,49 @@ input:disabled, select:disabled, textarea:disabled { color: var(--color-disabled
 .analytics-change-grid h3 { margin-bottom: var(--space-2); font-size: var(--text-base); }
 .analytics-change-grid ul { display: grid; gap: var(--space-2); margin: 0; padding-left: 1.25rem; }
 .analytics-panel > button { margin-top: var(--space-3); }
+.cash-flow-region { min-width: 0; margin-bottom: var(--space-4); }
+.cash-flow-summary__comparison { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr); gap: var(--space-5); margin-top: var(--space-5); }
+.cash-flow-comparison { display: grid; gap: var(--space-4); min-width: 0; }
+.cash-flow-comparison__row .analytics-row, .cash-flow-categories .analytics-row { flex-wrap: wrap; }
+.cash-flow-comparison__row .analytics-row > :last-child { max-width: 100%; flex-shrink: 1; }
+.cash-flow-comparison__row strong, .cash-flow-net { min-width: 0; overflow-wrap: anywhere; font-variant-numeric: tabular-nums; }
+.cash-flow-comparison__row .muted { margin: var(--space-1) 0 0; font-size: var(--text-sm); }
+.cash-flow-bar { display: flex; height: 1.15rem; margin-top: var(--space-2); background: var(--color-divider); border-radius: var(--radius-sm); overflow: hidden; }
+.cash-flow-bar > span { display: block; height: 100%; flex: 0 0 auto; transition: none; animation: none; }
+.cash-flow-bar__paychecks { background: var(--chart-paychecks); }
+.cash-flow-bar__other { background: repeating-linear-gradient(135deg, transparent 0, transparent 3px, var(--chart-text) 3px, var(--chart-text) 4px), var(--chart-other); }
+.cash-flow-bar__spent { background: var(--chart-spent); }
+.cash-flow-net { align-self: center; padding: var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface); }
+.cash-flow-net h3 { margin: 0; font-size: var(--text-base); }
+.cash-flow-net .analytics-total__value { font-size: clamp(1.7rem, 4vw, 3rem); }
+.cash-flow-net .muted { margin-bottom: 0; }
+.cash-flow-legend { display: flex; gap: var(--space-3); flex-wrap: wrap; margin: var(--space-4) 0; padding: 0; list-style: none; font-size: var(--text-sm); }
+.cash-flow-legend li { display: flex; align-items: center; gap: var(--space-2); min-width: 0; flex-wrap: wrap; overflow-wrap: anywhere; }
+.cash-flow-legend--amounts { display: grid; margin: 0; }
+.cash-flow-legend--amounts strong { margin-left: auto; font-variant-numeric: tabular-nums; }
+.cash-flow-swatch { display: inline-block; flex: 0 0 1rem; width: 1rem; height: 1rem; border: 1px solid var(--chart-text); }
+.cash-flow-swatch.cash-flow-bar__other { border-width: 3px; }
+.cash-flow-disclosure { margin-top: var(--space-4); border-top: 1px solid var(--color-border); padding-top: var(--space-3); }
+.cash-flow-disclosure summary { cursor: pointer; font-weight: 700; width: fit-content; padding: var(--space-2) 0; }
+.cash-flow-disclosure summary:focus-visible, .cash-flow-table-scroll:focus-visible { outline: 3px solid var(--color-primary); outline-offset: 3px; border-radius: var(--radius-sm); }
+.cash-flow-disclosure p { max-width: 85ch; }
+.cash-flow-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); }
+.cash-flow-facts dt { color: var(--color-text-muted); font-size: var(--text-sm); }
+.cash-flow-facts dd { margin: var(--space-1) 0 0; font-weight: 700; overflow-wrap: anywhere; }
+.cash-flow-categories, .cash-flow-trend { margin-bottom: var(--space-4); }
+.cash-flow-categories .analytics-bar span { transition: none; animation: none; background: var(--chart-spent); }
+.cash-flow-categories .analytics-row > :last-child { flex: 0 1 auto; }
+.cash-flow-trend__canvas { position: relative; width: 100%; height: 310px; }
+.cash-flow-trend__note { font-size: var(--text-xs); margin: var(--space-1) 0 0; }
+.cash-flow-table-scroll { max-width: 100%; overflow-x: auto; }
+.cash-flow-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); font-variant-numeric: tabular-nums; }
+.cash-flow-table caption { text-align: left; font-weight: 700; margin: var(--space-3) 0; }
+.cash-flow-table th, .cash-flow-table td { padding: var(--space-3); text-align: left; border-bottom: 1px solid var(--color-border); vertical-align: top; }
+.cash-flow-table td { white-space: nowrap; }
+.cash-flow-table td:last-child { white-space: normal; min-width: 150px; }
+.cash-flow-refresh { margin-bottom: var(--space-4); }
+@media (max-width: 820px) { .cash-flow-summary__comparison { grid-template-columns: 1fr; } }
+@media (max-width: 600px) { .cash-flow-facts { grid-template-columns: 1fr; } .cash-flow-trend__canvas { height: 270px; } }
 .mt-2 { margin-top: var(--space-4); }
 @media (min-width: 900px) { .mobile-parent-link { display: none; } }
 @media (max-width: 820px) { .overview-grid, .overview-metrics, .settings-grid, .investing-capabilities__grid, .analytics-grid { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--activity, .overview-module--plan, .overview-module--insights { grid-column: auto; } .overview-hero, .overview-module--activity { min-height: 220px; } }

--- a/frontend/src/styles/themes.css
+++ b/frontend/src/styles/themes.css
@@ -30,6 +30,8 @@
   --color-info: #566a7a;
   --color-info-soft: #edf2f5;
   --color-focus: #5458c9;
+  --chart-paychecks: #24776a;
+  --chart-other: #9b6525;
   --chart-spent: #5458c9;
   --chart-limit: #666873;
   --chart-text: #181a20;
@@ -72,6 +74,8 @@
   --color-info: #91aab9;
   --color-info-soft: #1b272e;
   --color-focus: #8d91ff;
+  --chart-paychecks: #69c5b1;
+  --chart-other: #e1ad69;
   --chart-spent: #8d91ff;
   --chart-limit: #a1a4ad;
   --chart-text: #f3f3f0;
@@ -115,6 +119,8 @@
     --color-info: #91aab9;
     --color-info-soft: #1b272e;
     --color-focus: #8d91ff;
+    --chart-paychecks: #69c5b1;
+    --chart-other: #e1ad69;
     --chart-spent: #8d91ff;
     --chart-limit: #a1a4ad;
     --chart-text: #f3f3f0;


### PR DESCRIPTION
## Summary

Analytics now compares all recorded cash in with recorded spending for a selected month and the six months ending there. Cash in is split into confirmed-paycheck-linked deposits and its exact remaining complement; net recorded cash flow remains period arithmetic and makes no balance or spendability claim.

Closes #126. Risk: **HIGH**, within the [revised plan](https://github.com/OL1V3S/ordo/issues/126#issuecomment-5562625827) and [explicit owner approval](https://github.com/OL1V3S/ordo/issues/126#issuecomment-5562641437). Base: `3eedef1a6a882c24e7c49e1cf65875b893b2190f`.

## Implementation

- Add authenticated `GET /api/analytics/cash-flow?month=YYYY-MM&throughDate=YYYY-MM-DD`. Owner-filtered inflows, expenses, paycheck membership, and available-month metadata share one read-only repeatable-read PostgreSQL snapshot.
- Preserve exact money across the full existing range with integer-cent strings, backend `BigInteger` totals, and frontend `BigInt` display/ratio arithmetic. Approximate numbers are used only for chart geometry.
- Show stacked selected-month cash in versus spending, signed net, ranked categories, and six monthly comparisons. Keyboard-accessible disclosures and tables provide exact values; requests are isolated by month and session, with explicit loading/error/empty states.
- Document the approved semantics and read boundary. Existing spending/budget drilldowns remain in place.

No schema, migration, backfill, existing API/write-contract, dependency, or navigation changes. Safe-to-Spend, balances/reconciliation, projections, paycheck cycles, new credit classification, Home summaries, and production operations remain excluded.

## Verification

- **Passed locally:** `./scripts/verify.sh frontend` — 46 files / 416 tests, lint, production build. Existing bundle-size warning remains.
- **Passed locally:** `./scripts/verify.sh postgresql` — migration-chain test plus 43 integration tests on a guarded disposable local PostgreSQL database. Includes exact persisted arithmetic, ownership isolation, edit/delete behavior, no writes on reads, and deterministic concurrent snapshot verification.
- **Passed locally:** focused non-PostgreSQL cash-flow tests — 40/40; focused PostgreSQL cash-flow tests — 3/3.
- **Local backend lane had one failure:** `./scripts/verify.sh backend` built successfully and passed 496/497 tests. The unchanged `PdfTextExtractorTests.Representative_pdf_extracts_ordered_pages` failed after about 10 seconds; its single targeted retry passed in 495 ms. A worker startup/extraction deadline is plausible but was not proven by the assertion output. The full local lane is not claimed as passed.
- **Passed locally:** `./scripts/verify.sh container` — production publish, contained PDF-worker artifact, Docker build, entrypoint, and startup smoke checks.
- **Passed locally:** browser smoke against the real local backend and disposable synthetic PostgreSQL records: exact September totals/split, June zero-cash/negative-net behavior, month selection, keyboard disclosures and chart table, desktop/light and mobile/dark layouts, long category wrapping, no page-wide overflow at 390 px, and no browser console warnings/errors. The temporary frontend configuration disabled file watching after filesystem events caused repeated reloads. Chart animation is disabled and covered by component tests; no production environment was used.
- **Proven by CI on `5c2f30b45e569de8a064a19f60e09f76ba8f0f7f`:** [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/34068827524/job/101582310451), [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/34068827445/job/101582310112) (full backend suite and container verification), and [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/34068827445/job/101582310263) all succeeded. Independent review of this draft PR and its final CI evidence remains required.

## Scope, risks, and rollback

The main risks are interpreting all cash in as earnings, treating “Other” as definitely non-paycheck, mistaking net flow for a balance, incomplete/edited evidence, precision loss, and mixed read snapshots. Labels/disclosures, exact arithmetic, and relational tests address these within the approved historical-record semantics.

Read-only review identified pre-existing legacy drilldown limitations: initial empty paint and brief stale budget limits during month changes, plus year 0001–0099/date-constructor and JavaScript-number precision limitations. They are unchanged and outside this bounded slice; the new cash-flow panels have separate period/session/exact-money handling.

Context remained scoped to analytics, inflow/expense/paycheck contracts and persistence, chart/theme/session integration, and required verification fixtures. Inspection expanded to the unchanged PDF worker/test only to diagnose the local verification failure.

Rollback is application-only: restore spending-only Analytics, then retire the additive endpoint if needed. Deploy the backend endpoint before its frontend consumer. No financial-data reversal or production migration is involved. No production access, migration, deployment, or merge was performed.
