### PR TITLE
Refine V3 shared shell and auth presentation

### DIFF
--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -56,8 +56,9 @@ silently treating every detected pattern as a financial fact.
   email. Settings currently provides email display and appearance controls,
   rather than a full account-management area.
 
-On smaller screens, navigation groups these areas under Home, Activity, Plan,
-Insights, and More. The underlying financial workflows are the same.
+Navigation uses Home, Activity, and Insights consistently across screen sizes.
+On smaller screens, Plan groups Budgets, Commitments, and Paychecks, while More
+contains secondary destinations. The underlying financial workflows are the same.
 
 ## What the figures mean
 

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -134,11 +134,17 @@ describe('application routes and shell', () => {
     expect(screen.getByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument()
   })
 
-  it('marks the current destination in desktop and mobile navigation', () => {
+  it.each([
+    ['/overview', 'Home'], ['/transactions', 'Activity'], ['/analytics', 'Insights'],
+  ])('uses the same customer label in both navigation surfaces and the pagebar for %s', (path, label) => {
     localStorage.setItem('token', 'jwt-value')
-    renderAt('/transactions')
-    expect(within(screen.getByRole('navigation', { name: 'Primary navigation' })).getByRole('link', { name: /Transactions/ })).toHaveAttribute('aria-current', 'page')
-    expect(within(screen.getByRole('navigation', { name: 'Mobile navigation' })).getByRole('link', { name: 'Activity' })).toHaveAttribute('aria-current', 'page')
+    renderAt(path)
+    for (const name of ['Primary navigation', 'Mobile navigation']) {
+      const link = within(screen.getByRole('navigation', { name })).getByRole('link', { name: new RegExp(label) })
+      expect(link).toHaveAttribute('href', path)
+      expect(link).toHaveAttribute('aria-current', 'page')
+    }
+    expect(within(screen.getByRole('banner')).getByText(label)).toBeVisible()
   })
 
   it('provides a keyboard skip link to the main content', () => {

--- a/frontend/src/app/navigation.js
+++ b/frontend/src/app/navigation.js
@@ -11,10 +11,10 @@ import {
 } from "lucide-react";
 
 export const APP_DESTINATIONS = [
-  { to: "/overview", label: "Overview", icon: LayoutDashboard },
-  { to: "/transactions", label: "Transactions", icon: ReceiptText },
+  { to: "/overview", label: "Home", icon: LayoutDashboard },
+  { to: "/transactions", label: "Activity", icon: ReceiptText },
   { to: "/budgets", label: "Budgets", icon: BarChart3, description: "Set and review monthly category limits." },
-  { to: "/analytics", label: "Analytics", icon: ChartNoAxesCombined },
+  { to: "/analytics", label: "Insights", icon: ChartNoAxesCombined },
   { to: "/commitments", label: "Commitments", icon: Repeat2, description: "Review recurring expenses and manage saved commitments." },
   { to: "/paychecks", label: "Paychecks", icon: WalletCards, description: "Review deposits and manage saved paycheck expectations." },
   { to: "/investing", label: "Investing", icon: Landmark, description: "Unavailable today. View the planned investing workspace." },

--- a/frontend/src/features/auth/components/AuthFlows.test.jsx
+++ b/frontend/src/features/auth/components/AuthFlows.test.jsx
@@ -24,7 +24,10 @@ function renderAt(ui, initialEntry = '/') {
 }
 
 describe('existing authentication flows', () => {
-  beforeEach(() => localStorage.clear())
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
 
   it('stores the login token and email using the existing keys', async () => {
     const user = userEvent.setup()
@@ -32,7 +35,10 @@ describe('existing authentication flows', () => {
     authApi.login.mockResolvedValue({ data: { token: 'jwt-value', email: 'person@example.com' } })
     renderAt(<AuthPage onLogin={onLogin} />)
 
-    expect(screen.getByRole('heading', { name: 'ordo', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Log in', level: 1 })).toBeInTheDocument()
+    expect(screen.getByText('ordo')).not.toHaveRole('heading')
+    expect(screen.getByText('Email', { selector: 'label' })).toBeVisible()
+    expect(screen.getByText('Password', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('Email')).toBe(screen.getByPlaceholderText('Email'))
     expect(screen.getByLabelText('Password')).toBe(screen.getByPlaceholderText('Password'))
     await user.type(screen.getByPlaceholderText('Email'), 'person@example.com')
@@ -68,7 +74,10 @@ describe('existing authentication flows', () => {
     await user.type(screen.getByLabelText('Email'), 'person@example.invalid')
     await user.type(screen.getByLabelText('Password'), 'Synthetic1!')
     await user.click(screen.getByRole('button', { name: 'Log In' }))
-    await waitFor(() => expect(alert).toHaveBeenCalledWith('Invalid credentials'))
+    const error = await screen.findByRole('alert')
+    expect(error).toHaveTextContent('Invalid credentials')
+    expect(error).toHaveFocus()
+    expect(alert).not.toHaveBeenCalled()
     expect(onLogin).not.toHaveBeenCalled()
     expect(localStorage.getItem('token')).toBeNull()
     expect(localStorage.getItem('email')).toBeNull()
@@ -91,32 +100,37 @@ describe('existing authentication flows', () => {
     renderAt(<AuthPage onLogin={vi.fn()} />)
 
     await user.click(screen.getByRole('button', { name: 'Need an account? Register' }))
+    expect(screen.getByRole('heading', { name: 'Create account', level: 1 })).toBeInTheDocument()
+    expect(screen.getByText('Confirm password', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('Confirm password')).toBe(screen.getByPlaceholderText('Confirm Password'))
     await user.type(screen.getByPlaceholderText('Email'), 'person@example.com')
     await user.type(screen.getByPlaceholderText('Password'), 'Secret1!')
     await user.type(screen.getByPlaceholderText('Confirm Password'), 'Secret1!')
     await user.click(screen.getByRole('button', { name: 'Register' }))
 
-    expect(await screen.findByText("Your account was created, but we couldn't send the confirmation email.")).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Check your email', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent("Your account was created, but we couldn't send the confirmation email.")
     await user.click(screen.getByRole('button', { name: 'Resend confirmation email' }))
-    expect(await screen.findByText('Too many requests. Please wait before trying again.')).toBeInTheDocument()
+    expect(await screen.findByRole('alert')).toHaveTextContent('Too many requests. Please wait before trying again.')
   })
 
   it('forwards confirmation query parameters unchanged', async () => {
     authApi.confirmEmail.mockResolvedValue({ data: { message: 'ok' } })
     renderAt(<ConfirmEmailPage />, '/confirm-email?userId=user-123&token=a%2Bb_c')
 
-    expect(screen.getByRole('heading', { name: 'ordo', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Confirming email', level: 1 })).toBeInTheDocument()
     await waitFor(() => expect(authApi.confirmEmail).toHaveBeenCalledWith({
       userId: 'user-123',
       token: 'a+b_c',
     }))
-    expect(await screen.findByText('Email Confirmed')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Email confirmed', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('You can now log in.')
   })
 
   it('does not call confirmation without both required query parameters', async () => {
     renderAt(<ConfirmEmailPage />, '/confirm-email?userId=user-123')
-    expect(await screen.findByText('Unable to Confirm Email')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Unable to confirm email', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('invalid, expired, or already used')
     expect(authApi.confirmEmail).not.toHaveBeenCalled()
   })
 
@@ -125,7 +139,8 @@ describe('existing authentication flows', () => {
     authApi.resetPassword.mockResolvedValue({ data: { message: 'ok' } })
     renderAt(<ResetPasswordPage />, '/reset-password?email=person%40example.com&token=reset%2Btoken')
 
-    expect(screen.getByRole('heading', { name: 'ordo', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Reset password', level: 1 })).toBeInTheDocument()
+    expect(screen.getByText('New password', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('New password')).toBe(screen.getByPlaceholderText('New password'))
     await user.type(screen.getByPlaceholderText('New password'), 'NewSecret1!')
     await user.click(screen.getByRole('button', { name: 'Reset Password' }))
@@ -144,11 +159,143 @@ describe('existing authentication flows', () => {
     })
     renderAt(<ForgotPasswordPage />, '/forgot-password')
 
-    expect(screen.getByRole('heading', { name: 'ordo', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Forgot password', level: 1 })).toBeInTheDocument()
+    expect(screen.getByText('Email', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('Email')).toBe(screen.getByPlaceholderText('Email'))
     await user.type(screen.getByPlaceholderText('Email'), 'unknown@example.com')
     await user.click(screen.getByRole('button', { name: 'Send Reset Link' }))
 
-    expect(await screen.findByText('If the email exists, a reset link was sent.')).toBeInTheDocument()
+    expect(await screen.findByRole('status')).toHaveTextContent('If the email exists, a reset link was sent.')
+  })
+
+  it('exposes password visibility as a pressed toggle without changing the password', async () => {
+    const user = userEvent.setup()
+    renderAt(<AuthPage onLogin={vi.fn()} />)
+
+    const password = screen.getByLabelText('Password')
+    const reveal = screen.getByRole('button', { name: 'Show password' })
+    await user.type(password, 'Secret1!')
+
+    expect(password).toHaveAttribute('type', 'password')
+    expect(reveal).toHaveAttribute('aria-pressed', 'false')
+    await user.click(reveal)
+    expect(password).toHaveAttribute('type', 'text')
+    expect(password).toHaveValue('Secret1!')
+    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('keeps registration requirements visible and associated with the password field', async () => {
+    const user = userEvent.setup()
+    renderAt(<AuthPage onLogin={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'Need an account? Register' }))
+
+    const password = screen.getByLabelText('Password')
+    expect(screen.getByText('Password must include:')).toBeVisible()
+    expect(screen.getByText('At least 6 characters')).toBeVisible()
+    expect(password).toHaveAccessibleDescription(/At least 6 characters/)
+    expect(screen.getByRole('button', { name: 'Show confirm password' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('reports a password mismatch inline and does not submit registration', async () => {
+    const user = userEvent.setup()
+    const alert = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    renderAt(<AuthPage onLogin={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'Need an account? Register' }))
+    await user.type(screen.getByLabelText('Email'), 'person@example.com')
+    await user.type(screen.getByLabelText('Password'), 'Secret1!')
+    await user.type(screen.getByLabelText('Confirm password'), 'Different1!')
+    const registerButton = screen.getByRole('button', { name: 'Register' })
+    await user.click(registerButton)
+
+    const error = await screen.findByRole('alert')
+    expect(error).toHaveTextContent('Passwords do not match.')
+    expect(error).toHaveFocus()
+
+    registerButton.focus()
+    expect(registerButton).toHaveFocus()
+    await user.click(registerButton)
+    expect(error).toHaveFocus()
+
+    expect(authApi.register).not.toHaveBeenCalled()
+    expect(alert).not.toHaveBeenCalled()
+    alert.mockRestore()
+  })
+
+  it('preserves native required and email validation before login submission', async () => {
+    const user = userEvent.setup()
+    renderAt(<AuthPage onLogin={vi.fn()} />)
+
+    const email = screen.getByLabelText('Email')
+    const password = screen.getByLabelText('Password')
+    expect(email).toBeRequired()
+    expect(password).toBeRequired()
+
+    await user.click(screen.getByRole('button', { name: 'Log In' }))
+    expect(authApi.login).not.toHaveBeenCalled()
+
+    await user.type(email, 'not-an-email')
+    await user.type(password, 'Secret1!')
+    expect(email).toBeInvalid()
+    await user.click(screen.getByRole('button', { name: 'Log In' }))
+    expect(authApi.login).not.toHaveBeenCalled()
+  })
+
+  it('registers with the existing payload and moves to check-email without establishing a session', async () => {
+    const user = userEvent.setup()
+    const onLogin = vi.fn()
+    authApi.register.mockResolvedValue({ data: {} })
+    renderAt(<AuthPage onLogin={onLogin} />)
+
+    await user.click(screen.getByRole('button', { name: 'Need an account? Register' }))
+    await user.type(screen.getByLabelText('Email'), 'person@example.com')
+    await user.type(screen.getByLabelText('Password'), 'Secret1!')
+    await user.type(screen.getByLabelText('Confirm password'), 'Secret1!')
+    await user.click(screen.getByRole('button', { name: 'Register' }))
+
+    await waitFor(() => expect(authApi.register).toHaveBeenCalledWith({
+      email: 'person@example.com',
+      password: 'Secret1!',
+    }))
+    expect(await screen.findByRole('heading', { name: 'Check your email', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('A confirmation link was sent to person@example.com.')
+    expect(screen.getByText('person@example.com', { selector: 'strong' })).toBeVisible()
+    expect(onLogin).not.toHaveBeenCalled()
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('email')).toBeNull()
+  })
+
+  it('keeps a confirmation resend result visible after its recovery disclosure closes', async () => {
+    const user = userEvent.setup()
+    authApi.resendConfirmation.mockResolvedValue({
+      data: { message: 'If the account exists, a confirmation email was sent.' },
+    })
+    renderAt(<ForgotPasswordPage />, '/forgot-password')
+
+    await user.type(screen.getByLabelText('Email'), 'unknown@example.com')
+    const recovery = screen.getByText('Need a new confirmation email?', { selector: 'summary' })
+    await user.click(recovery)
+    await user.click(screen.getByRole('button', { name: 'Resend confirmation email' }))
+
+    await waitFor(() => expect(authApi.resendConfirmation).toHaveBeenCalledWith({
+      email: 'unknown@example.com',
+    }))
+    const result = await screen.findByRole('status')
+    expect(result).toHaveTextContent('If the account exists, a confirmation email was sent.')
+    await user.click(recovery)
+    expect(result).toBeVisible()
+  })
+
+  it('keeps reset failure inline with the recovery action available', async () => {
+    const user = userEvent.setup()
+    authApi.resetPassword.mockRejectedValue(new Error('synthetic failure'))
+    renderAt(<ResetPasswordPage />, '/reset-password?email=person%40example.com&token=reset%2Btoken')
+
+    await user.type(screen.getByLabelText('New password'), 'NewSecret1!')
+    await user.click(screen.getByRole('button', { name: 'Reset Password' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Error resetting password.')
+    expect(screen.getByRole('button', { name: 'Back to login' })).toBeVisible()
   })
 })

--- a/frontend/src/features/auth/components/AuthPage.jsx
+++ b/frontend/src/features/auth/components/AuthPage.jsx
@@ -1,8 +1,9 @@
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { authApi } from "../../../shared/api/authApi";
 import { establishSession } from "../../../shared/auth/session";
-import { Eye, EyeOff } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import AuthShell from "./AuthShell";
+import PasswordField from "./PasswordField";
 
 export default function AuthPage({ onLogin }) {
   const [mode, setMode] = useState("login");
@@ -13,17 +14,26 @@ export default function AuthPage({ onLogin }) {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [confirmationMessage, setConfirmationMessage] = useState("");
   const [resendMessage, setResendMessage] = useState("");
+  const [resendTone, setResendTone] = useState("info");
+  const [formError, setFormError] = useState(null);
   const [isResending, setIsResending] = useState(false);
   const emailId = useId();
   const passwordId = useId();
   const confirmPasswordId = useId();
+  const passwordRequirementsId = useId();
+  const formErrorRef = useRef(null);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (formError) formErrorRef.current?.focus();
+  }, [formError]);
 
   async function handleSubmit(e) {
     e.preventDefault();
+    setFormError(null);
 
     if (mode === "register" && password !== confirmPassword) {
-      alert("Passwords do not match.");
+      setFormError({ message: "Passwords do not match." });
       return;
     }
 
@@ -58,13 +68,15 @@ export default function AuthPage({ onLogin }) {
       }
 
       if (Array.isArray(errorData)) {
-        alert(errorData.map((e) => e.description).join("\n"));
+        setFormError({
+          message: errorData.map((error) => error.description).join("\n"),
+        });
       } else if (typeof errorData === "string") {
-        alert(errorData);
+        setFormError({ message: errorData });
       } else if (typeof errorData?.message === "string") {
-        alert(errorData.message);
+        setFormError({ message: errorData.message });
       } else {
-        alert(err.message || "Something went wrong.");
+        setFormError({ message: err.message || "Something went wrong." });
       }
     }
   }
@@ -77,8 +89,10 @@ export default function AuthPage({ onLogin }) {
 
     try {
       const response = await authApi.resendConfirmation({ email });
+      setResendTone("success");
       setResendMessage(response.data.message);
     } catch (err) {
+      setResendTone("danger");
       if (err.response?.status === 429) {
         setResendMessage("Too many requests. Please wait before trying again.");
       } else {
@@ -93,6 +107,7 @@ export default function AuthPage({ onLogin }) {
     setMode(mode === "login" ? "register" : "login");
     setConfirmationMessage("");
     setResendMessage("");
+    setFormError(null);
     setPassword("");
     setConfirmPassword("");
   }
@@ -101,46 +116,56 @@ export default function AuthPage({ onLogin }) {
     setMode("login");
     setConfirmationMessage("");
     setResendMessage("");
+    setFormError(null);
   }
 
+  if (mode === "check-email") {
+    return (
+      <AuthShell title="Check your email">
+        <p className="auth-status auth-status--info" role="status">
+          {confirmationMessage}
+        </p>
+        <p className="auth-help">
+          Confirm <strong>{email}</strong> before logging in.
+        </p>
+        {resendMessage && (
+          <p
+            className={`auth-status auth-status--${resendTone}`}
+            role={resendTone === "danger" ? "alert" : "status"}
+          >
+            {resendMessage}
+          </p>
+        )}
+        <div className="auth-actions">
+          <button
+            type="button"
+            className="auth-primary-action"
+            onClick={handleResendConfirmation}
+            disabled={!email || isResending}
+          >
+            {isResending ? "Requesting..." : "Resend confirmation email"}
+          </button>
+          <button
+            type="button"
+            className="button-ghost auth-text-action"
+            onClick={returnToLogin}
+          >
+            Back to login
+          </button>
+        </div>
+      </AuthShell>
+    );
+  }
+
+  const isLogin = mode === "login";
+
   return (
-    <div className="auth-page">
-      <div className="auth-card">
-        <h1>ordo</h1>
-        {mode === "check-email" ? (
-          <>
-            <h2 className="h2">Check your email</h2>
-            <p className="auth-help">{confirmationMessage}</p>
-            <p className="auth-help mt-2">
-              Confirm <strong>{email}</strong> before logging in.
-            </p>
-
-            {resendMessage && <p className="auth-help mt-2">{resendMessage}</p>}
-
-            <button
-              type="button"
-              className="mt-2"
-              onClick={handleResendConfirmation}
-              disabled={!email || isResending}
-            >
-              {isResending ? "Requesting..." : "Resend confirmation email"}
-            </button>
-            <button
-              type="button"
-              className="button-ghost"
-              onClick={returnToLogin}
-            >
-              Back to login
-            </button>
-          </>
-        ) : (
-          <>
-            <h2 className="h2">
-              {mode === "login" ? "Log In" : "Create Account"}
-            </h2>
-
-            <form onSubmit={handleSubmit} className="auth-form">
-          <label className="sr-only" htmlFor={emailId}>Email</label>
+    <AuthShell title={isLogin ? "Log in" : "Create account"}>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <div className="auth-field">
+          <label className="auth-field__label" htmlFor={emailId}>
+            Email
+          </label>
           <input
             id={emailId}
             type="email"
@@ -149,87 +174,84 @@ export default function AuthPage({ onLogin }) {
             onChange={(e) => setEmail(e.target.value)}
             required
           />
-
-        <label className="sr-only" htmlFor={passwordId}>Password</label>
-        <div className="password-field">
-        <input
-            id={passwordId}
-            type={showPassword ? "text" : "password"}
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-        />
-        <button
-            type="button"
-            className="password-toggle"
-            aria-label={showPassword ? "Hide password" : "Show password"}
-            onClick={() => setShowPassword((prev) => !prev)}
-        >
-            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-        </button>
         </div>
 
-        {mode === "login" && (
-            <button
+        <PasswordField
+          id={passwordId}
+          label="Password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          isRevealed={showPassword}
+          onToggle={() => setShowPassword((previous) => !previous)}
+          describedBy={isLogin ? undefined : passwordRequirementsId}
+        />
+
+        {isLogin && (
+          <button
             type="button"
-            className="button-ghost"
+            className="button-ghost auth-text-action"
             onClick={() => navigate("/forgot-password")}
-            >
+          >
             Forgot password?
-            </button>
+          </button>
         )}
 
+        {!isLogin && (
+          <>
+            <PasswordField
+              id={confirmPasswordId}
+              label="Confirm password"
+              placeholder="Confirm Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              isRevealed={showConfirmPassword}
+              onToggle={() => setShowConfirmPassword((previous) => !previous)}
+            />
 
-          {mode === "register" && (
-            <>
-              <label className="sr-only" htmlFor={confirmPasswordId}>Confirm password</label>
-              <div className="password-field">
-                <input
-                    id={confirmPasswordId}
-                    type={showConfirmPassword ? "text" : "password"}
-                    placeholder="Confirm Password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    required
-                />
-                <button
-                    type="button"
-                    className="password-toggle"
-                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
-                    onClick={() => setShowConfirmPassword((prev) => !prev)}
-                >
-                    {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                </button>
-               </div>
-
-            <p className="auth-help">Password must include:</p>
-            <ul className="auth-help">
-            <li>At least 6 characters</li>
-            <li>One uppercase letter</li>
-            <li>One lowercase letter</li>
-            <li>One number</li>
-            <li>One special character</li>
-            </ul>
-            </>
-          )}
-
-          <button type="submit">
-            {mode === "login" ? "Log In" : "Register"}
-          </button>
-            </form>
-
-            <button
-              className="button-ghost"
-              onClick={switchMode}
+            <div
+              id={passwordRequirementsId}
+              className="auth-password-requirements auth-help"
             >
-              {mode === "login"
-                ? "Need an account? Register"
-                : "Already have an account? Log in"}
-            </button>
+              <p>Password must include:</p>
+              <ul>
+                <li>At least 6 characters</li>
+                <li>One uppercase letter</li>
+                <li>One lowercase letter</li>
+                <li>One number</li>
+                <li>One special character</li>
+              </ul>
+            </div>
           </>
         )}
+
+        {formError && (
+          <p
+            ref={formErrorRef}
+            className="auth-status auth-status--danger"
+            role="alert"
+            tabIndex="-1"
+          >
+            {formError.message}
+          </p>
+        )}
+
+        <button type="submit" className="auth-primary-action">
+          {isLogin ? "Log In" : "Register"}
+        </button>
+      </form>
+
+      <div className="auth-actions auth-actions--secondary">
+        <button
+          type="button"
+          className="button-ghost auth-text-action"
+          onClick={switchMode}
+        >
+          {isLogin
+            ? "Need an account? Register"
+            : "Already have an account? Log in"}
+        </button>
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/frontend/src/features/auth/components/AuthShell.jsx
+++ b/frontend/src/features/auth/components/AuthShell.jsx
@@ -1,0 +1,18 @@
+import { useId } from "react";
+
+export default function AuthShell({ title, description, children }) {
+  const titleId = useId();
+
+  return (
+    <div className="auth-page">
+      <main className="auth-card" aria-labelledby={titleId}>
+        <p className="auth-shell__brand">ordo</p>
+        <header className="auth-shell__header">
+          <h1 id={titleId}>{title}</h1>
+          {description && <p className="auth-help">{description}</p>}
+        </header>
+        <div className="auth-shell__content">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/components/ConfirmEmailPage.jsx
+++ b/frontend/src/features/auth/components/ConfirmEmailPage.jsx
@@ -1,6 +1,26 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { authApi } from "../../../shared/api/authApi";
+import AuthShell from "./AuthShell";
+
+const confirmationCopy = {
+  loading: {
+    title: "Confirming email",
+    message: "Please wait...",
+    tone: "info",
+  },
+  success: {
+    title: "Email confirmed",
+    message: "You can now log in.",
+    tone: "success",
+  },
+  error: {
+    title: "Unable to confirm email",
+    message:
+      "This confirmation link is invalid, expired, or already used. Try logging in or request a new confirmation email.",
+    tone: "danger",
+  },
+};
 
 export default function ConfirmEmailPage() {
   const [searchParams] = useSearchParams();
@@ -28,43 +48,27 @@ export default function ConfirmEmailPage() {
     else setStatus("error");
   }, [searchParams]);
 
+  const content = confirmationCopy[status];
+
   return (
-    <div className="auth-page">
-      <div className="auth-card">
-        <h1>ordo</h1>
+    <AuthShell title={content.title}>
+      <p
+        className={`auth-status auth-status--${content.tone}`}
+        role={content.tone === "danger" ? "alert" : "status"}
+        aria-live={content.tone === "danger" ? "assertive" : "polite"}
+      >
+        {content.message}
+      </p>
 
-        {status === "loading" && (
-          <>
-            <h2 className="h2">Confirming Email</h2>
-            <p className="auth-help">Please wait...</p>
-          </>
-        )}
-
-        {status === "success" && (
-          <>
-            <h2 className="h2">Email Confirmed</h2>
-            <p className="auth-help">You can now log in.</p>
-          </>
-        )}
-
-        {status === "error" && (
-          <>
-            <h2 className="h2">Unable to Confirm Email</h2>
-            <p className="auth-help">
-              This confirmation link is invalid, expired, or already used. Try
-              logging in or request a new confirmation email.
-            </p>
-          </>
-        )}
-
+      <div className="auth-actions auth-actions--secondary">
         <button
           type="button"
-          className="button-ghost mt-2"
+          className="button-ghost auth-text-action"
           onClick={() => navigate("/")}
         >
           Back to login
         </button>
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/frontend/src/features/auth/components/ForgotPasswordPage.jsx
+++ b/frontend/src/features/auth/components/ForgotPasswordPage.jsx
@@ -1,11 +1,14 @@
 import { useId, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { authApi } from "../../../shared/api/authApi";
+import AuthShell from "./AuthShell";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
+  const [messageTone, setMessageTone] = useState("info");
   const [resendMessage, setResendMessage] = useState("");
+  const [resendTone, setResendTone] = useState("info");
   const [isResending, setIsResending] = useState(false);
   const emailId = useId();
   const navigate = useNavigate();
@@ -15,8 +18,10 @@ export default function ForgotPasswordPage() {
 
     try {
       const res = await authApi.forgotPassword({ email });
+      setMessageTone("info");
       setMessage(res.data.message);
     } catch {
+      setMessageTone("danger");
       setMessage("Something went wrong.");
     }
   }
@@ -29,8 +34,10 @@ export default function ForgotPasswordPage() {
 
     try {
       const response = await authApi.resendConfirmation({ email });
+      setResendTone("success");
       setResendMessage(response.data.message);
     } catch (err) {
+      setResendTone("danger");
       if (err.response?.status === 429) {
         setResendMessage("Too many requests. Please wait before trying again.");
       } else {
@@ -42,17 +49,15 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="auth-page">
-      <div className="auth-card">
-        <h1>ordo</h1>
-        <h2 className="h2">Forgot Password</h2>
-
-        <p className="auth-help">
-          Enter your email and we’ll send you a reset link.
-        </p>
-
-        <form onSubmit={handleSubmit} className="auth-form mt-2">
-          <label className="sr-only" htmlFor={emailId}>Email</label>
+    <AuthShell
+      title="Forgot password"
+      description="Enter your email and we’ll send you a reset link."
+    >
+      <form onSubmit={handleSubmit} className="auth-form">
+        <div className="auth-field">
+          <label className="auth-field__label" htmlFor={emailId}>
+            Email
+          </label>
           <input
             id={emailId}
             type="email"
@@ -61,33 +66,60 @@ export default function ForgotPasswordPage() {
             onChange={(e) => setEmail(e.target.value)}
             required
           />
+        </div>
 
-          <button type="submit">Send Reset Link</button>
-        </form>
+        <button type="submit" className="auth-primary-action">
+          Send Reset Link
+        </button>
+      </form>
 
-        {message && <p className="auth-help">{message}</p>}
+      {message && (
+        <p
+          className={`auth-status auth-status--${messageTone}`}
+          role={messageTone === "danger" ? "alert" : "status"}
+        >
+          {message}
+        </p>
+      )}
 
-        <section className="auth-secondary">
-          <p className="auth-help">Didn't receive your account confirmation?</p>
-          <button
-            type="button"
-            className="button-ghost"
-            onClick={handleResendConfirmation}
-            disabled={!email || isResending}
+      <section className="auth-secondary" aria-label="Account confirmation help">
+        <details className="auth-disclosure">
+          <summary className="auth-disclosure__summary">
+            Need a new confirmation email?
+          </summary>
+          <div className="auth-actions">
+            <p className="auth-help">
+              Enter your account email above, then request another confirmation link.
+            </p>
+            <button
+              type="button"
+              className="button-ghost auth-text-action"
+              onClick={handleResendConfirmation}
+              disabled={!email || isResending}
+            >
+              {isResending ? "Requesting..." : "Resend confirmation email"}
+            </button>
+          </div>
+        </details>
+        {resendMessage && (
+          <p
+            className={`auth-status auth-status--${resendTone}`}
+            role={resendTone === "danger" ? "alert" : "status"}
           >
-            {isResending ? "Requesting..." : "Resend confirmation email"}
-          </button>
-          {resendMessage && <p className="auth-help">{resendMessage}</p>}
-        </section>
+            {resendMessage}
+          </p>
+        )}
+      </section>
 
+      <div className="auth-actions auth-actions--secondary">
         <button
           type="button"
-          className="button-ghost"
+          className="button-ghost auth-text-action"
           onClick={() => navigate("/")}
         >
           Back to login
         </button>
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/frontend/src/features/auth/components/PasswordField.jsx
+++ b/frontend/src/features/auth/components/PasswordField.jsx
@@ -1,0 +1,40 @@
+import { Eye, EyeOff } from "lucide-react";
+
+export default function PasswordField({
+  id,
+  label,
+  placeholder,
+  value,
+  onChange,
+  isRevealed,
+  onToggle,
+  describedBy,
+}) {
+  return (
+    <div className="auth-field">
+      <label className="auth-field__label" htmlFor={id}>
+        {label}
+      </label>
+      <div className="password-field">
+        <input
+          id={id}
+          type={isRevealed ? "text" : "password"}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          aria-describedby={describedBy}
+          required
+        />
+        <button
+          type="button"
+          className="password-toggle"
+          aria-label={isRevealed ? `Hide ${label.toLowerCase()}` : `Show ${label.toLowerCase()}`}
+          aria-pressed={isRevealed}
+          onClick={onToggle}
+        >
+          {isRevealed ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/components/ResetPasswordPage.jsx
+++ b/frontend/src/features/auth/components/ResetPasswordPage.jsx
@@ -1,7 +1,8 @@
 import { useId, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Eye, EyeOff } from "lucide-react";
 import { authApi } from "../../../shared/api/authApi";
+import AuthShell from "./AuthShell";
+import PasswordField from "./PasswordField";
 
 export default function ResetPasswordPage() {
   const [searchParams] = useSearchParams();
@@ -10,6 +11,7 @@ export default function ResetPasswordPage() {
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [message, setMessage] = useState("");
+  const [messageTone, setMessageTone] = useState("info");
   const passwordId = useId();
 
   const email = searchParams.get("email");
@@ -25,53 +27,50 @@ export default function ResetPasswordPage() {
         newPassword: password,
       });
 
+      setMessageTone("success");
       setMessage("Password reset successful. You can now log in.");
     } catch {
+      setMessageTone("danger");
       setMessage("Error resetting password.");
     }
   }
 
   return (
-    <div className="auth-page">
-      <div className="auth-card">
-        <h1>ordo</h1>
-        <h2 className="h2">Reset Password</h2>
+    <AuthShell title="Reset password">
+      <form onSubmit={handleSubmit} className="auth-form">
+        <PasswordField
+          id={passwordId}
+          label="New password"
+          placeholder="New password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          isRevealed={showPassword}
+          onToggle={() => setShowPassword((previous) => !previous)}
+        />
 
-        <form onSubmit={handleSubmit} className="auth-form">
-          <label className="sr-only" htmlFor={passwordId}>New password</label>
-          <div className="password-field">
-            <input
-              id={passwordId}
-              type={showPassword ? "text" : "password"}
-              placeholder="New password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
+        <button type="submit" className="auth-primary-action">
+          Reset Password
+        </button>
+      </form>
 
-            <button
-              type="button"
-              className="password-toggle"
-              aria-label={showPassword ? "Hide new password" : "Show new password"}
-              onClick={() => setShowPassword((prev) => !prev)}
-            >
-              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-            </button>
-          </div>
+      {message && (
+        <p
+          className={`auth-status auth-status--${messageTone}`}
+          role={messageTone === "danger" ? "alert" : "status"}
+        >
+          {message}
+        </p>
+      )}
 
-          <button type="submit">Reset Password</button>
-        </form>
-
-        {message && <p className="auth-help">{message}</p>}
-
+      <div className="auth-actions auth-actions--secondary">
         <button
           type="button"
-          className="button-ghost"
+          className="button-ghost auth-text-action"
           onClick={() => navigate("/")}
         >
           Back to login
         </button>
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,6 +1,6 @@
 .card { padding: var(--space-5); border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--color-surface) 98%, transparent); box-shadow: var(--shadow-md); }
 .card--subtle { background: var(--color-surface-subtle); box-shadow: var(--shadow-sm); }
-button, .button { min-height: 42px; padding: .65rem 1rem; border: 1px solid transparent; border-radius: var(--radius-md); color: var(--color-on-primary); background: var(--color-primary); cursor: pointer; font-weight: 700; transition: transform var(--duration-fast) var(--ease-standard), background var(--duration-normal) var(--ease-standard), box-shadow var(--duration-normal) var(--ease-standard); }
+button, .button { min-height: 44px; padding: .65rem 1rem; border: 1px solid transparent; border-radius: var(--radius-md); color: var(--color-on-primary); background: var(--color-primary); cursor: pointer; font-weight: 700; transition: transform var(--duration-fast) var(--ease-standard), background var(--duration-normal) var(--ease-standard), box-shadow var(--duration-normal) var(--ease-standard); }
 button:hover { background: var(--color-primary-hover); box-shadow: var(--shadow-sm); transform: translateY(-1px); }
 button:active { transform: translateY(0); }
 button:disabled { cursor: not-allowed; box-shadow: none; transform: none; }
@@ -10,17 +10,18 @@ button:disabled { cursor: not-allowed; box-shadow: none; transform: none; }
 .button-danger:hover { background: color-mix(in srgb, var(--color-danger) 82%, black); }
 button:disabled,
 button:disabled:hover { color: var(--color-disabled-text); border-color: var(--color-disabled-border); background: var(--color-disabled-surface); box-shadow: none; transform: none; }
-.icon-button { width: 42px; padding: 0; display: inline-grid; place-items: center; }
+.icon-button { width: 44px; padding: 0; display: inline-grid; place-items: center; }
 .field { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
 .field__label { color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
-input, select, textarea { width: 100%; min-height: 42px; padding: .65rem .75rem; border: 1px solid var(--color-control-border); border-radius: var(--radius-md); outline: none; color: var(--color-text); background: var(--color-surface-raised); }
+input, select, textarea { width: 100%; min-height: 44px; padding: .65rem .75rem; border: 1px solid var(--color-control-border); border-radius: var(--radius-md); outline: none; color: var(--color-text); background: var(--color-surface-raised); }
 input::placeholder, textarea::placeholder { color: var(--color-placeholder); opacity: 1; }
 input:focus, select:focus, textarea:focus { border-color: var(--color-focus); outline: 3px solid var(--color-focus); outline-offset: 1px; box-shadow: none; }
 input:disabled, select:disabled, textarea:disabled { color: var(--color-disabled-text); border-color: var(--color-disabled-border); background: var(--color-disabled-surface); opacity: 1; }
-.password-field { position: relative; }
-.password-field input { padding-right: 3rem; }
-.password-toggle { position: absolute; top: 50%; right: .35rem; width: 36px; min-height: 36px; padding: 0; transform: translateY(-50%); color: var(--color-text-muted); background: transparent; }
-.password-toggle:hover { color: var(--color-text); background: var(--color-surface-subtle); transform: translateY(-50%); }
+.password-field { display: grid; grid-template-columns: minmax(0, 1fr) 44px; gap: var(--space-2); align-items: stretch; }
+.password-field input { min-width: 0; }
+.password-toggle { display: inline-grid; place-items: center; width: 44px; min-height: 44px; padding: 0; color: var(--color-text-muted); background: transparent; }
+.password-toggle:hover { color: var(--color-text); background: var(--color-surface-subtle); transform: none; }
+summary { min-height: 44px; padding-block: .625rem; cursor: pointer; }
 .status-message, .empty-state { padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); color: var(--color-text-muted); background: var(--color-surface-subtle); }
 .status-message--success { color: var(--color-success); border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border)); background: var(--color-success-soft); }
 .status-message--danger { color: var(--color-danger); border-color: color-mix(in srgb, var(--color-danger) 35%, var(--color-border)); background: var(--color-danger-soft); }
@@ -39,7 +40,7 @@ input:disabled, select:disabled, textarea:disabled { color: var(--color-disabled
 .auth-help { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); }
 .theme-control { display: inline-flex; align-items: center; gap: var(--space-2); }
 .theme-control label { color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
-.theme-control select { width: auto; min-height: 38px; padding-block: .45rem; }
+.theme-control select { width: auto; min-height: 44px; padding-block: .45rem; }
 .theme-control--settings { align-items: stretch; flex-direction: column; }
 .theme-control--settings select { width: min(100%, 280px); }
 .empty-state-card__icon { display: inline-grid; place-items: center; color: var(--color-on-primary); background: var(--color-primary); }
@@ -53,9 +54,11 @@ input:disabled, select:disabled, textarea:disabled { color: var(--color-disabled
 .mobile-nav .app-nav__link:hover { transform: none; }
 .mobile-nav .app-nav__link--active::before { top: 0; right: 30%; bottom: auto; left: 30%; width: auto; height: 3px; }
 .app-sidebar .app-nav { align-items: stretch; flex-direction: column; }
-.app-sidebar .app-nav__link { justify-content: flex-start; min-height: 42px; padding-inline: var(--space-3); }
+.app-sidebar .app-nav__link { justify-content: flex-start; gap: 8px; min-height: 44px; padding-inline: 12px; }
+.app-sidebar .app-nav__link > svg { flex: 0 0 auto; }
+.app-sidebar .app-nav__link > span:not(.sr-only) { min-width: 0; overflow-wrap: anywhere; }
 .app-sidebar .app-nav__link--active::before { top: 8px; right: auto; bottom: 8px; left: -1px; width: 3px; height: auto; }
-.button-link { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); min-height: 42px; margin-top: var(--space-2); padding: .65rem 1rem; border-radius: var(--radius-md); color: var(--color-on-primary); background: var(--color-primary); font-weight: 700; text-decoration: none; }
+.button-link { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); min-height: 44px; margin-top: var(--space-2); padding: .65rem 1rem; border-radius: var(--radius-md); color: var(--color-on-primary); background: var(--color-primary); font-weight: 700; text-decoration: none; }
 .button-link:hover { background: var(--color-primary-hover); }
 .button-link--quiet { color: var(--color-primary); border: 1px solid var(--color-control-border); background: transparent; }
 .button-link--quiet:hover { color: var(--color-on-primary); }

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -7,10 +7,32 @@
 .cluster, .inline-actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
 .grid { display: grid; gap: var(--space-4); }
 .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); align-items: end; gap: var(--space-3); }
-.auth-page { min-height: 100vh; display: grid; place-items: center; padding: var(--space-5); }
-.auth-card { width: min(100%, 440px); }
-.auth-form, .auth-secondary { display: flex; flex-direction: column; gap: var(--space-3); }
-.auth-secondary { margin-top: var(--space-5); padding-top: var(--space-5); border-top: 1px solid var(--color-divider); }
+.auth-page { min-height: 100vh; min-height: 100svh; display: flex; flex-direction: column; align-items: center; padding: clamp(1.5rem, 6vh, 4rem) 16px; }
+.auth-card { width: min(100%, 30rem); min-width: 0; margin-block: auto; padding: clamp(16px, 4vw, 32px); border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); box-shadow: var(--shadow-sm); overflow-wrap: anywhere; }
+.auth-shell__brand { display: block; margin-bottom: var(--space-6); color: var(--color-primary); font-size: var(--text-lg); font-weight: 900; letter-spacing: .08em; }
+.auth-shell__header { margin-bottom: var(--space-5); }
+.auth-shell__header h1 { margin-bottom: 0; }
+.auth-shell__header .auth-help { margin-top: var(--space-3); }
+.auth-shell__content { display: grid; gap: var(--space-5); }
+.auth-form, .auth-secondary { display: flex; flex-direction: column; gap: var(--space-4); }
+.auth-secondary { padding-top: var(--space-5); border-top: 1px solid var(--color-divider); }
+.auth-actions { display: grid; gap: var(--space-3); }
+.auth-actions--secondary { justify-items: center; padding-top: var(--space-5); border-top: 1px solid var(--color-divider); }
+.auth-field { display: grid; min-width: 0; gap: var(--space-2); }
+.auth-field__label { color: var(--color-text); font-size: var(--text-sm); font-weight: 700; }
+.auth-card .auth-primary-action { width: 100%; }
+.auth-card .auth-text-action { display: inline-flex; align-items: center; justify-content: center; justify-self: center; width: auto; max-width: 100%; min-height: 44px; padding: var(--space-2) var(--space-3); border-color: transparent; color: var(--color-primary); background: transparent; line-height: 1.5; text-align: center; text-decoration: underline; text-underline-offset: .2em; }
+.auth-card .auth-text-action:hover { background: var(--color-surface-subtle); box-shadow: none; transform: none; }
+.auth-card .auth-text-action:disabled { color: var(--color-disabled-text); text-decoration: none; }
+.auth-password-requirements { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); }
+.auth-status { white-space: pre-line; margin: 0; padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); color: var(--color-text-muted); background: var(--color-surface-subtle); overflow-wrap: anywhere; }
+.auth-status--danger { color: var(--color-danger); border-color: color-mix(in srgb, var(--color-danger) 35%, var(--color-border)); background: var(--color-danger-soft); }
+.auth-status--success { color: var(--color-success); border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border)); background: var(--color-success-soft); }
+.auth-status--info { color: var(--color-info); background: var(--color-info-soft); }
+.auth-disclosure { min-width: 0; border-top: 1px solid var(--color-divider); padding-top: var(--space-3); }
+.auth-secondary > .auth-disclosure { border-top: 0; padding-top: 0; }
+.auth-disclosure__summary { color: var(--color-primary); font-weight: 700; }
+.auth-disclosure[open] .auth-disclosure__summary { margin-bottom: var(--space-3); }
 .filters { display: grid; grid-template-columns: 2fr repeat(2, minmax(150px, 1fr)); gap: var(--space-3); align-items: end; }
 .chart-frame { min-height: 280px; }
 .app-shell { min-height: 100vh; }
@@ -22,17 +44,17 @@
 .app-pagebar { position: sticky; top: 0; z-index: 15; display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); min-height: 60px; padding: var(--space-2) var(--space-4); border-bottom: 1px solid var(--color-border); background: var(--color-surface); box-shadow: var(--shadow-sm); }
 .app-pagebar__desktop-title { display: none; color: var(--color-text); font-size: var(--text-lg); font-weight: 800; }
 .app-pagebar__actions { display: flex; align-items: center; gap: var(--space-2); }
-.app-pagebar__settings .app-nav__link { min-width: 40px; min-height: 40px; padding: var(--space-2); }
+.app-pagebar__settings .app-nav__link { min-width: 44px; min-height: 44px; padding: var(--space-2); }
 .app-pagebar__settings .app-nav__link > span:not(.sr-only) { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
 .mobile-account { position: relative; }
-.mobile-account__trigger { min-width: 40px; min-height: 40px; }
+.mobile-account__trigger { min-width: 44px; min-height: 44px; }
 .mobile-account__menu { position: absolute; top: calc(100% + var(--space-2)); right: 0; z-index: 30; width: min(260px, calc(100vw - 2rem)); padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface-raised); box-shadow: var(--shadow-md); }
 .mobile-account__label { margin: 0 0 var(--space-1); color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 700; }
 .mobile-account__email { margin: 0 0 var(--space-3); overflow-wrap: anywhere; color: var(--color-text); font-size: var(--text-sm); font-weight: 700; }
 .mobile-account__logout { display: flex; align-items: center; justify-content: flex-start; gap: var(--space-2); width: 100%; }
 .app-sidebar__utilities { display: flex; align-items: stretch; flex-direction: column; gap: var(--space-3); margin-top: auto; padding-top: var(--space-4); border-top: 1px solid var(--color-divider); }
 .app-sidebar__identity { overflow: hidden; color: var(--color-text-muted); font-size: var(--text-xs); text-overflow: ellipsis; white-space: nowrap; }
-.app-sidebar__logout { display: inline-flex; align-items: center; justify-content: flex-start; gap: var(--space-2); width: 100%; }
+.app-sidebar__logout { display: inline-flex; align-items: center; justify-content: flex-start; gap: 8px; width: 100%; padding-inline: 12px; }
 .app-content { min-width: 0; padding: var(--space-4); padding-bottom: calc(4.75rem + env(safe-area-inset-bottom, 0px)); }
 .app-content > .container { width: 100%; max-width: none; margin: 0; padding: 0; }
 .shell-page { width: 100%; padding-block: var(--space-2) var(--space-6); animation: page-enter var(--duration-normal) var(--ease-standard); }
@@ -40,7 +62,7 @@
 @keyframes page-enter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 @media (min-width: 900px) {
   .app-shell { display: grid; grid-template-columns: 200px minmax(0, 1fr); }
-  .app-sidebar { position: sticky; top: 0; display: flex; align-items: stretch; flex-direction: column; height: 100vh; padding: var(--space-5) var(--space-3) var(--space-4); border-right: 1px solid var(--color-border); background: var(--color-surface); }
+  .app-sidebar { position: sticky; top: 0; display: flex; align-items: stretch; flex-direction: column; height: 100vh; overflow-y: auto; padding: var(--space-5) 12px var(--space-4); border-right: 1px solid var(--color-border); background: var(--color-surface); }
   .app-sidebar > .app-wordmark { margin: 0 var(--space-2) var(--space-6); }
   .app-pagebar { min-height: 58px; padding-inline: clamp(var(--space-5), 2.5vw, var(--space-6)); box-shadow: none; }
   .app-pagebar__desktop-title { display: block; }
@@ -51,5 +73,5 @@
 @media (max-width: 720px) { .page-header { align-items: start; flex-direction: column; } .filters { grid-template-columns: 1fr; } }
 @media (max-width: 620px) { .app-pagebar .theme-control label { display: none; } .app-pagebar { padding-inline: var(--space-3); } }
 @media (max-width: 520px) { .chart-frame .section__header { align-items: stretch; flex-direction: column; } }
-@media (max-width: 430px) { .app-content { padding-inline: var(--space-4); } .app-pagebar__actions { flex-wrap: wrap; justify-content: flex-end; gap: var(--space-1); } .app-pagebar .theme-control select { max-width: 100%; } }
+@media (max-width: 430px) { .app-content { padding-inline: var(--space-4); } .app-pagebar__actions { flex-wrap: wrap; justify-content: flex-end; gap: var(--space-2); } .app-pagebar .theme-control select { max-width: 100%; } }
 @media (max-width: 360px) { .app-wordmark--mobile { display: none; } .app-pagebar { justify-content: flex-end; } }

--- a/frontend/src/styles/paychecks.css
+++ b/frontend/src/styles/paychecks.css
@@ -32,7 +32,7 @@
 .paycheck-projection__date { font-size: var(--text-xl); font-weight: 800; font-variant-numeric: tabular-nums; }
 .paycheck-inactive { padding: var(--space-3); margin: 0; border: 1px solid var(--color-divider); color: var(--color-text-muted); border-radius: var(--radius-sm); }
 .paycheck-evidence { min-width: 0; border-block: 1px solid var(--color-divider); padding-block: var(--space-3); }
-.paycheck-evidence summary { width: fit-content; max-width: 100%; min-height: 32px; cursor: pointer; font-weight: 700; }
+.paycheck-evidence summary { width: fit-content; max-width: 100%; min-height: 44px; cursor: pointer; font-weight: 700; }
 .paycheck-evidence__list { display: grid; gap: var(--space-3); margin: var(--space-3) 0 0; padding: 0; list-style: none; }
 .paycheck-evidence__row { display: flex; justify-content: space-between; gap: var(--space-3); padding: var(--space-3); border-radius: var(--radius-sm); background: var(--color-surface-subtle); overflow-wrap: anywhere; }
 .paycheck-evidence__row > div { display: grid; min-width: 0; gap: var(--space-1); }


### PR DESCRIPTION
## Summary

Auth forms currently crowd adjacent actions and rely on hidden labels, while desktop and mobile navigation use different names. This first UX V3 slice adds a consistent auth shell with visible labels, separated actions, inline status messages, and larger practical targets, and uses Home / Activity / Insights across navigation surfaces.

Related to #127 — **slice 1 of 7**, not completion of V3. Implements the [approved plan](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563926559) under [explicit owner approval](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563943900). Risk: **MEDIUM**, frontend presentation only. Base: `00fcd35b305d85dd4d3d88341876c3da8c6d9261`.

## Changes and boundaries

- Share AuthShell and PasswordField across login, registration, check-email, recovery, reset, and confirmation states. Task titles are h1s; password requirements remain visible and associated with the field; reveal controls expose their pressed state.
- Present existing login/registration errors inline with focus, including repeated identical mismatches. Recovery resend is disclosed on demand, while its result stays visible when the disclosure closes.
- Set shared controls and disclosure targets to at least 44px; separate auth actions and utility controls. Preserve the 200px sidebar and five mobile destinations; wrap enlarged sidebar labels and allow vertical scrolling.
- Preserve native required/email validation, password matching, existing error mappings and privacy wording, request payloads, routes/query decoding, session/token behavior, resend gating, and confirmation handling.
- Update the high-level navigation description in PRODUCT_OVERVIEW. RECENT_CHANGES remains untouched until completed V3 provides its first entry.

No financial semantics, auth/session behavior, backend/API/schema/migration, dependency, or production changes. Remaining page redesigns stay in slices 2–7. The two reported untracked Desktop files remain untouched; implementation used a fresh isolated checkout.

## Verification

**Passed locally:**

- `./scripts/verify.sh frontend`: 46 test files / 425 tests, ESLint, and production build.
- Final `npm run verify`: 425 tests, lint, and build; production build rerun after the final CSS-only text-enlargement adjustment.
- `git diff --check` and complete diff review. Focused coverage includes 66 shell tests and 15 auth-flow tests.
- Chromium browser inspection using synthetic localhost fixtures: auth/recovery/check-email/reset/confirmation states, keyboard disclosure and account-menu Escape/focus, password reveal, and persistent visible recovery results. Checked login at 320/375/768/1280px, auth states at 375px, light/dark/system presentation, reduced motion, 320px root-text enlargement to 200%, and desktop sidebar text enlargement. Checked controls met the 44px target; tested layouts had no horizontal overflow or Vite/page errors.

**Verification limitations:** native screen-reader output and native browser zoom were not tested; accessibility-tree, keyboard, and root-text enlargement checks are the available local evidence. Browser auth responses were synthetic, not a real backend/email or deployed-auth smoke test. Backend/container tests were not run locally for this frontend-only slice; disposable local PostgreSQL is unavailable. No hosted database was used. The existing Vite large-chunk advisory remains.

**Proven by CI on `7ff554e26c7d5d1327dcca9f4a5f255357a5ff71`:** [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/34075899793/job/101601818140), [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/34075899731/job/101601818170), and [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/34075899731/job/101601818044) all passed. Vercel reports successful preview deployment. The public-preview inspection encountered Vercel login protection, so the deployed auth shell was not verified. Independent command-center review remains required; local/subagent review is development evidence only.

Context expanded only to shared auth API/session contracts and theme styles to preserve behavior and validate layout; no unrelated backend or financial implementation was inspected for modification.

Rollback is a reviewed revert of this frontend/documentation slice. No data rollback is needed.
