### PR TITLE
Prioritize Insights visuals and disclose spending detail

### DIFF
--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -41,8 +41,9 @@ silently treating every detected pattern as a financial fact.
   guaranteed deposits or employer-verified earnings.
 - **Insights / Analytics:** Compare recorded cash in with spending for a selected
   month and see the difference as net recorded cash flow. Explore a six-month
-  trend, spending categories, budget usage, month-over-month category changes,
-  and the largest expenses. Cash in is split into amounts linked to confirmed
+  trend and ranked spending categories, with budget usage, month-over-month
+  category changes, and largest expenses available under More spending detail.
+  Cash in is split into amounts linked to confirmed
   paychecks and all other recorded inflows.
 - **Statement import:** Upload a supported, text-extractable Sunflower Bank PDF,
   review parsed rows, edit eligible expense rows, inspect possible-duplicate

--- a/frontend/src/features/analytics/components/CashFlowCategories.jsx
+++ b/frontend/src/features/analytics/components/CashFlowCategories.jsx
@@ -1,0 +1,40 @@
+import { useId, useMemo } from "react";
+import { displayText } from "../../../utils/text";
+import StatusMessage from "../../../shared/ui/StatusMessage";
+import { barWidth, cashPercentage, formatCash, minorUnits } from "../utils/cashFlowPresentation";
+
+export default function CashFlowCategories({ data }) {
+  const headingId = useId();
+  const categories = useMemo(() => [...(data.categories ?? [])].sort((left, right) => {
+    const difference = minorUnits(right.amountMinor) - minorUnits(left.amountMinor);
+    return difference > 0n ? 1 : difference < 0n ? -1 : left.category.localeCompare(right.category, "en");
+  }), [data]);
+
+  return (
+    <section className="card analytics-panel cash-flow-categories" aria-labelledby={headingId}>
+      <div className="analytics-panel__header">
+        <div>
+          <p className="analytics-kicker">Ranked by amount</p>
+          <h2 id={headingId} className="h2">Where it went</h2>
+        </div>
+      </div>
+      {categories.length === 0 ? (
+        <StatusMessage>No spending recorded</StatusMessage>
+      ) : (
+        <ol className="analytics-list analytics-category-list">
+          {categories.map((category) => (
+            <li key={category.category} className="analytics-list__item">
+              <div className="analytics-row">
+                <strong>{displayText(category.category)}</strong>
+                <span>{formatCash(category.amountMinor)} · {cashPercentage(category.amountMinor, data.selected.spentMinor) ?? "Not applicable"}</span>
+              </div>
+              <div className="analytics-bar" aria-hidden="true">
+                <span style={{ width: barWidth(category.amountMinor, data.selected.spentMinor) }} />
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/analytics/components/CashFlowCategories.test.jsx
+++ b/frontend/src/features/analytics/components/CashFlowCategories.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CashFlowCategories from "./CashFlowCategories";
+import { cashFlowFixture } from "../testFixtures";
+
+describe("cash-flow category ranking", () => {
+  it("uses unique accessible headings and keeps a zero spending denominator honest", () => {
+    const data = cashFlowFixture("2026-08", { spentMinor: "0" });
+    data.categories = [{ category: "food", amountMinor: "1" }];
+
+    render(<><CashFlowCategories data={data} /><CashFlowCategories data={data} /></>);
+
+    const regions = screen.getAllByRole("region", { name: "Where it went" });
+    expect(regions).toHaveLength(2);
+    expect(regions[0]).not.toHaveAttribute("aria-labelledby", regions[1].getAttribute("aria-labelledby"));
+    regions.forEach((region) => {
+      const heading = within(region).getByRole("heading", { level: 2, name: "Where it went" });
+      expect(region).toHaveAttribute("aria-labelledby", heading.id);
+      expect(within(region).getByRole("listitem")).toHaveTextContent("Food$0.01 · Not applicable");
+      expect(region.querySelector(".analytics-bar > span")).toHaveStyle({ width: "0%" });
+    });
+  });
+});

--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -5,10 +5,10 @@ import { useExpenses } from "../../expenses/hooks/useExpenses";
 import { formatExpenseDate } from "../../expenses/utils/calendarDate";
 import { useCashFlow } from "../hooks/useCashFlow";
 import CashFlowSummary from "../components/CashFlowSummary";
+import CashFlowCategories from "../components/CashFlowCategories";
 import CashFlowTrendChart from "../components/CashFlowTrendChart";
-import { barWidth, cashMonthLabel, cashPercentage, formatCash, localThroughDate, minorUnits } from "../utils/cashFlowPresentation";
+import { cashMonthLabel, localThroughDate } from "../utils/cashFlowPresentation";
 import { displayText } from "../../../utils/text";
-import Card from "../../../shared/ui/Card";
 import FormField from "../../../shared/ui/FormField";
 import StatusMessage from "../../../shared/ui/StatusMessage";
 import {
@@ -36,10 +36,6 @@ export default function AnalyticsPage() {
   } = useBudgetLimits(selectedMonth);
 
   const availableMonths = [...new Set([localThroughDate().slice(0, 7), selectedMonth, ...cashFlow.availableMonths])].sort().reverse();
-  const categories = useMemo(() => [...(cashFlow.data?.categories ?? [])].sort((left, right) => {
-    const difference = minorUnits(right.amountMinor) - minorUnits(left.amountMinor);
-    return difference > 0n ? 1 : difference < 0n ? -1 : left.category.localeCompare(right.category, "en");
-  }), [cashFlow.data]);
   const insights = useMemo(
     () => buildMonthlySpendingInsights(expenses, selectedMonth),
     [expenses, selectedMonth]
@@ -61,28 +57,24 @@ export default function AnalyticsPage() {
     <div className="container analytics-page">
       <header className="page-header analytics-page__header">
         <div>
-          <p className="page-header__eyebrow">Understand your cash flow</p>
-          <h1>Analytics</h1>
+          <h1>Insights</h1>
           <p className="muted">See recorded cash in and spending, month by month.</p>
         </div>
-        <FormField label="Month">
-          {(id) => (
-            <select id={id} value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value)}>
-              {availableMonths.map((month) => (
-                <option key={month} value={month}>{cashMonthLabel(month)}</option>
-              ))}
-            </select>
-          )}
-        </FormField>
+        <div className="analytics-page__controls">
+          <FormField label="Month">
+            {(id) => (
+              <select id={id} value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value)}>
+                {availableMonths.map((month) => (
+                  <option key={month} value={month}>{cashMonthLabel(month)}</option>
+                ))}
+              </select>
+            )}
+          </FormField>
+          {!cashFlow.loading && cashFlow.data ? (
+            <button type="button" className="button-ghost" onClick={cashFlow.refresh}>Refresh cash flow</button>
+          ) : null}
+        </div>
       </header>
-
-      {expensesLoading ? <StatusMessage>Loading spending insights...</StatusMessage> : null}
-      {!expensesLoading && expensesError ? (
-        <Card as="section" className="section">
-          <StatusMessage tone="danger">We couldn’t load recorded expenses.</StatusMessage>
-          <button type="button" onClick={retryExpenses}>Try again</button>
-        </Card>
-      ) : null}
 
       <section className="cash-flow-region" aria-label="Recorded cash flow" aria-busy={cashFlow.loading}>
         {cashFlow.loading ? <StatusMessage>Loading recorded cash flow...</StatusMessage> : null}
@@ -95,48 +87,62 @@ export default function AnalyticsPage() {
         {!cashFlow.loading && cashFlow.data ? (
           <>
             <CashFlowSummary data={cashFlow.data} />
-            <section className="card analytics-panel cash-flow-categories" aria-labelledby="category-breakdown-heading">
-              <div className="analytics-panel__header">
-                <div>
-                  <p className="analytics-kicker">Ranked by amount</p>
-                  <h2 id="category-breakdown-heading" className="h2">Where it went</h2>
-                </div>
-              </div>
-              {categories.length === 0 ? (
-                <StatusMessage>No spending recorded</StatusMessage>
-              ) : (
-                <ol className="analytics-list analytics-category-list">
-                  {categories.map((category) => (
-                    <li key={category.category} className="analytics-list__item">
-                      <div className="analytics-row">
-                        <strong>{displayText(category.category)}</strong>
-                        <span>{formatCash(category.amountMinor)} · {cashPercentage(category.amountMinor, cashFlow.data.selected.spentMinor) ?? "Not applicable"}</span>
-                      </div>
-                      <div className="analytics-bar" aria-hidden="true">
-                        <span style={{ width: barWidth(category.amountMinor, cashFlow.data.selected.spentMinor) }} />
-                      </div>
-                    </li>
-                  ))}
-                </ol>
-              )}
-            </section>
-            <CashFlowTrendChart data={cashFlow.data} />
-            <button type="button" className="cash-flow-refresh" onClick={cashFlow.refresh}>Refresh cash flow</button>
+            <div className="cash-flow-visuals">
+              <CashFlowCategories data={cashFlow.data} />
+              <CashFlowTrendChart data={cashFlow.data} />
+            </div>
           </>
         ) : null}
       </section>
 
-      {!expensesLoading && !expensesError ? (
-        <>
-          <div className="analytics-grid">
-            <Card as="section" className="analytics-panel" aria-labelledby="budget-status-heading">
-              <div className="analytics-panel__header">
-                <div>
-                  <p className="analytics-kicker">Configured limits</p>
-                  <h2 id="budget-status-heading" className="h2">Budget status by category</h2>
+      <section className="analytics-more" aria-labelledby="more-spending-heading">
+        <header className="analytics-more__header">
+          <h2 id="more-spending-heading" className="h2">More spending detail</h2>
+        </header>
+        {expensesLoading ? <StatusMessage>Loading spending insights...</StatusMessage> : null}
+        {!expensesLoading && expensesError ? (
+          <div className="analytics-load-state">
+            <StatusMessage tone="danger">We couldn’t load recorded expenses.</StatusMessage>
+            <button type="button" onClick={retryExpenses}>Try again</button>
+          </div>
+        ) : null}
+
+        {!expensesLoading && !expensesError ? (
+          <div className="analytics-details">
+            <section className="analytics-detail" aria-labelledby="budget-status-heading">
+              <details>
+                <summary><h3 id="budget-status-heading">Budget status by category</h3></summary>
+                <div className="analytics-detail__content">
+                  <div className="analytics-panel__header">
+                    <div>
+                      <p className="analytics-kicker">Configured limits</p>
+                    </div>
+                    <Link to="/budgets">Manage budgets</Link>
+                  </div>
+                  {!limitsLoading && !limitsError && budgetStatuses.length === 0 ? (
+                    <StatusMessage>No budget limits are set for this month.</StatusMessage>
+                  ) : null}
+                  {!limitsLoading && !limitsError && budgetStatuses.length > 0 ? (
+                    <ul className="analytics-list">
+                      {budgetStatuses.map((budget) => (
+                        <li key={budget.id ?? budget.category} className="analytics-list__item analytics-budget-row">
+                          <div className="analytics-row">
+                            <strong>{displayText(budget.category)}</strong>
+                            <span className={`analytics-status analytics-status--${budget.status.replace(" ", "-")}`}>{displayText(budget.status)}</span>
+                          </div>
+                          <p>{currencyFormatter.format(budget.spent)} spent of {currencyFormatter.format(budget.limitAmount)}</p>
+                          <p>{budget.over !== null
+                            ? `${currencyFormatter.format(budget.over)} over`
+                            : `${currencyFormatter.format(budget.remaining)} remaining`}</p>
+                          <p>{budget.percentage === null
+                            ? "Percentage used: Not applicable for a $0 limit"
+                            : `${formatPercentage(budget.percentage)} used`}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
                 </div>
-                <Link to="/budgets">Manage budgets</Link>
-              </div>
+              </details>
               {limitsLoading ? <StatusMessage>Loading budget limits...</StatusMessage> : null}
               {!limitsLoading && limitsError ? (
                 <>
@@ -144,87 +150,73 @@ export default function AnalyticsPage() {
                   <button type="button" onClick={refreshLimits}>Try again</button>
                 </>
               ) : null}
-              {!limitsLoading && !limitsError && budgetStatuses.length === 0 ? (
-                <StatusMessage>No budget limits are set for this month.</StatusMessage>
-              ) : null}
-              {!limitsLoading && !limitsError && budgetStatuses.length > 0 ? (
-                <ul className="analytics-list">
-                  {budgetStatuses.map((budget) => (
-                    <li key={budget.id ?? budget.category} className="analytics-list__item analytics-budget-row">
-                      <div className="analytics-row">
-                        <strong>{displayText(budget.category)}</strong>
-                        <span className={`analytics-status analytics-status--${budget.status.replace(" ", "-")}`}>{displayText(budget.status)}</span>
+            </section>
+
+            <section className="analytics-detail" aria-labelledby="comparison-heading">
+              <details>
+                <summary><h3 id="comparison-heading">Month-over-month change</h3></summary>
+                <div className="analytics-detail__content">
+                  <p className="analytics-kicker">Compared with {formatMonthLabel(insights.previousMonth)}</p>
+                  <p className="analytics-comparison__value">
+                    {insights.comparison.difference > 0 ? "+" : ""}{currencyFormatter.format(insights.comparison.difference)}
+                  </p>
+                  {insights.comparison.previousTotal === 0 && insights.total === 0 ? (
+                    <p className="muted">Neither month has recorded spending.</p>
+                  ) : insights.comparison.percentage === null ? (
+                    <p className="muted">Percentage comparison is unavailable because the previous month had $0.00 recorded spending.</p>
+                  ) : (
+                    <p className="muted">{formatPercentage(insights.comparison.percentage, { signed: true })} from {currencyFormatter.format(insights.comparison.previousTotal)}</p>
+                  )}
+                  {insights.increases.length === 0 && insights.decreases.length === 0 ? (
+                    <StatusMessage>No category changes to show between these months.</StatusMessage>
+                  ) : (
+                    <div className="analytics-change-grid">
+                      <div>
+                        <h4>Largest increases</h4>
+                        {insights.increases.length === 0 ? <p className="muted">No increases.</p> : (
+                          <ul>{insights.increases.map((change) => <li key={change.category}>{displayText(change.category)} <strong>+{currencyFormatter.format(change.difference)}</strong></li>)}</ul>
+                        )}
                       </div>
-                      <p>{currencyFormatter.format(budget.spent)} spent of {currencyFormatter.format(budget.limitAmount)}</p>
-                      <p>{budget.over !== null
-                        ? `${currencyFormatter.format(budget.over)} over`
-                        : `${currencyFormatter.format(budget.remaining)} remaining`}</p>
-                      <p>{budget.percentage === null
-                        ? "Percentage used: Not applicable for a $0 limit"
-                        : `${formatPercentage(budget.percentage)} used`}</p>
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-            </Card>
-
-            <Card as="section" className="analytics-panel" aria-labelledby="comparison-heading">
-              <p className="analytics-kicker">Compared with {formatMonthLabel(insights.previousMonth)}</p>
-              <h2 id="comparison-heading" className="h2">Month-over-month change</h2>
-              <p className="analytics-comparison__value">
-                {insights.comparison.difference > 0 ? "+" : ""}{currencyFormatter.format(insights.comparison.difference)}
-              </p>
-              {insights.comparison.previousTotal === 0 && insights.total === 0 ? (
-                <p className="muted">Neither month has recorded spending.</p>
-              ) : insights.comparison.percentage === null ? (
-                <p className="muted">Percentage comparison is unavailable because the previous month had $0.00 recorded spending.</p>
-              ) : (
-                <p className="muted">{formatPercentage(insights.comparison.percentage, { signed: true })} from {currencyFormatter.format(insights.comparison.previousTotal)}</p>
-              )}
-              {insights.increases.length === 0 && insights.decreases.length === 0 ? (
-                <StatusMessage>No category changes to show between these months.</StatusMessage>
-              ) : (
-                <div className="analytics-change-grid">
-                  <div>
-                    <h3>Largest increases</h3>
-                    {insights.increases.length === 0 ? <p className="muted">No increases.</p> : (
-                      <ul>{insights.increases.map((change) => <li key={change.category}>{displayText(change.category)} <strong>+{currencyFormatter.format(change.difference)}</strong></li>)}</ul>
-                    )}
-                  </div>
-                  <div>
-                    <h3>Largest decreases</h3>
-                    {insights.decreases.length === 0 ? <p className="muted">No decreases.</p> : (
-                      <ul>{insights.decreases.map((change) => <li key={change.category}>{displayText(change.category)} <strong>{currencyFormatter.format(change.difference)}</strong></li>)}</ul>
-                    )}
-                  </div>
+                      <div>
+                        <h4>Largest decreases</h4>
+                        {insights.decreases.length === 0 ? <p className="muted">No decreases.</p> : (
+                          <ul>{insights.decreases.map((change) => <li key={change.category}>{displayText(change.category)} <strong>{currencyFormatter.format(change.difference)}</strong></li>)}</ul>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              )}
-            </Card>
+              </details>
+            </section>
 
-            <Card as="section" className="analytics-panel" aria-labelledby="largest-expenses-heading">
-              <div className="analytics-panel__header">
-                <div>
-                  <p className="analytics-kicker">Top five</p>
-                  <h2 id="largest-expenses-heading" className="h2">Largest expenses</h2>
+            <section className="analytics-detail" aria-labelledby="largest-expenses-heading">
+              <details>
+                <summary><h3 id="largest-expenses-heading">Largest expenses</h3></summary>
+                <div className="analytics-detail__content">
+                  <div className="analytics-panel__header">
+                    <div>
+                      <p className="analytics-kicker">Top five</p>
+                    </div>
+                    <Link to="/transactions">Review transactions</Link>
+                  </div>
+                  {insights.largestExpenses.length === 0 ? (
+                    <StatusMessage>No expenses to rank for this month.</StatusMessage>
+                  ) : (
+                    <ol className="analytics-list">
+                      {insights.largestExpenses.map((expense) => (
+                        <li key={expense.id} className="analytics-list__item analytics-row">
+                          <span><strong>{expense.description}</strong><small>{displayText(expense.category)} · {formatExpenseDate(expense.date)}</small></span>
+                          <strong>{currencyFormatter.format(expense.amount)}</strong>
+                        </li>
+                      ))}
+                    </ol>
+                  )}
                 </div>
-                <Link to="/transactions">Review transactions</Link>
-              </div>
-              {insights.largestExpenses.length === 0 ? (
-                <StatusMessage>No expenses to rank for this month.</StatusMessage>
-              ) : (
-                <ol className="analytics-list">
-                  {insights.largestExpenses.map((expense) => (
-                    <li key={expense.id} className="analytics-list__item analytics-row">
-                      <span><strong>{expense.description}</strong><small>{displayText(expense.category)} · {formatExpenseDate(expense.date)}</small></span>
-                      <strong>{currencyFormatter.format(expense.amount)}</strong>
-                    </li>
-                  ))}
-                </ol>
-              )}
-            </Card>
+              </details>
+            </section>
           </div>
-        </>
-      ) : null}
+        ) : null}
+      </section>
     </div>
   );
 }

--- a/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
@@ -26,6 +26,19 @@ function renderPage() {
   return render(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
 }
 
+function detailNamed(name) {
+  const heading = screen.getByRole("heading", { level: 3, name });
+  const summary = heading.closest("summary");
+  return { summary, detail: summary.closest("details") };
+}
+
+function openDetail(name) {
+  const disclosure = detailNamed(name);
+  fireEvent.click(disclosure.summary);
+  expect(disclosure.detail).toHaveAttribute("open");
+  return disclosure.detail;
+}
+
 describe("monthly spending insights page", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -60,9 +73,13 @@ describe("monthly spending insights page", () => {
   it("shows the selected total, ranked categories, budgets, comparison, and largest expenses", () => {
     renderPage();
 
+    expect(screen.getByRole("heading", { level: 1, name: "Insights" })).toBeInTheDocument();
     expect(screen.getByLabelText("Month")).toHaveValue("2026-08");
     expect(useBudgetLimits).toHaveBeenLastCalledWith("2026-08");
-    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" }).closest("section")).toHaveTextContent("$100.00");
+    const cashFlowSummary = screen.getByRole("heading", { name: "Recorded cash in vs Spent" }).closest("section");
+    const refresh = screen.getByRole("button", { name: "Refresh cash flow" });
+    expect(cashFlowSummary).toHaveTextContent("$100.00");
+    expect(refresh.compareDocumentPosition(cashFlowSummary) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     const breakdown = screen.getByRole("heading", { name: "Where it went" }).closest("section");
     const rows = within(breakdown).getAllByRole("listitem");
@@ -70,15 +87,36 @@ describe("monthly spending insights page", () => {
     expect(rows[0]).toHaveTextContent("$90.00 · 90.0%");
     expect(rows[1]).toHaveTextContent("Transport");
 
-    const budget = screen.getByRole("heading", { name: "Budget status by category" }).closest("section");
+    const budget = openDetail("Budget status by category");
     expect(budget).toHaveTextContent("Near Limit");
     expect(budget).toHaveTextContent("Percentage used: Not applicable for a $0 limit");
 
-    expect(screen.getByRole("heading", { name: "Month-over-month change" }).closest("section"))
-      .toHaveTextContent("+$25.00");
-    expect(screen.getByRole("heading", { name: "Largest expenses" }).closest("section"))
-      .toHaveTextContent("Groceries");
+    expect(openDetail("Month-over-month change")).toHaveTextContent("+$25.00");
+    expect(openDetail("Largest expenses")).toHaveTextContent("Groceries");
     expect(screen.getByRole("link", { name: "Review transactions" })).toHaveAttribute("href", "/transactions");
+  });
+
+  it("keeps spending detail closed by default, keyboard reachable, and open across page state updates", () => {
+    const { rerender } = renderPage();
+
+    expect(screen.getByRole("heading", { level: 2, name: "More spending detail" })).toBeInTheDocument();
+    const disclosures = [
+      detailNamed("Budget status by category"),
+      detailNamed("Month-over-month change"),
+      detailNamed("Largest expenses"),
+    ];
+    disclosures.forEach(({ detail }) => expect(detail).not.toHaveAttribute("open"));
+
+    expect(disclosures[0].summary).toHaveProperty("tabIndex", 0);
+    disclosures[0].summary.focus();
+    expect(disclosures[0].summary).toHaveFocus();
+    fireEvent.click(disclosures[0].summary);
+    expect(disclosures[0].detail).toHaveAttribute("open");
+    expect(within(disclosures[0].detail).getByRole("heading", { level: 3, name: "Budget status by category" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Month"), { target: { value: "2026-07" } });
+    rerender(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
+    expect(detailNamed("Budget status by category").detail).toHaveAttribute("open");
   });
 
   it("offers current and represented historical months and updates selected-month limits", () => {
@@ -95,26 +133,44 @@ describe("monthly spending insights page", () => {
   it("renders expense loading and blocking error states without transient insights", () => {
     useExpenses.mockReturnValue({ expenses: [], loading: true, error: null, refresh: refreshExpenses });
     const { rerender } = renderPage();
-    expect(screen.getByText("Loading spending insights...")).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Largest expenses" })).not.toBeInTheDocument();
+    expect(screen.getByText("Loading spending insights...").closest("details")).toBeNull();
+    expect(screen.queryByRole("heading", { level: 3, name: "Largest expenses" })).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" })).toBeInTheDocument();
 
     useExpenses.mockReturnValue({ expenses: [], loading: false, error: new Error("failed"), refresh: refreshExpenses });
     rerender(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
-    expect(screen.getByRole("alert")).toHaveTextContent("couldn’t load recorded expenses");
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    const alert = screen.getByRole("alert");
+    const retry = screen.getByRole("button", { name: "Try again" });
+    expect(alert).toHaveTextContent("couldn’t load recorded expenses");
+    expect(alert.closest("details")).toBeNull();
+    expect(retry.closest("details")).toBeNull();
+    fireEvent.click(retry);
     expect(refreshExpenses).toHaveBeenCalledOnce();
   });
 
-  it("keeps expense insights visible when budget limits fail", () => {
+  it("keeps budget loading and retry failures visible while its spending detail stays closed", () => {
+    useBudgetLimits.mockReturnValue({
+      budgetLimits: [], loading: true, error: null, refresh: refreshLimits,
+    });
+    const { rerender } = renderPage();
+
+    const disclosure = detailNamed("Budget status by category").detail;
+    expect(disclosure).not.toHaveAttribute("open");
+    expect(screen.getByText("Loading budget limits...").closest("details")).toBeNull();
+
     useBudgetLimits.mockReturnValue({
       budgetLimits: [], loading: false, error: new Error("failed"), refresh: refreshLimits,
     });
-    renderPage();
+    rerender(<MemoryRouter><AnalyticsPage /></MemoryRouter>);
 
     expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" }).closest("section")).toHaveTextContent("$100.00");
-    expect(screen.getByRole("alert")).toHaveTextContent("Budget limits are unavailable");
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    const alert = screen.getByRole("alert");
+    const retry = screen.getByRole("button", { name: "Try again" });
+    expect(alert).toHaveTextContent("Budget limits are unavailable");
+    expect(alert.closest("details")).toBeNull();
+    expect(retry.closest("details")).toBeNull();
+    expect(detailNamed("Budget status by category").detail).not.toHaveAttribute("open");
+    fireEvent.click(retry);
     expect(refreshLimits).toHaveBeenCalledOnce();
   });
 
@@ -126,7 +182,9 @@ describe("monthly spending insights page", () => {
     useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false, error: null, refresh: refreshLimits });
     renderPage();
 
-    expect(screen.getByRole("heading", { name: "Month-over-month change" }).closest("section")).toHaveTextContent("$0.00");
+    expect(openDetail("Month-over-month change")).toHaveTextContent("$0.00");
+    openDetail("Budget status by category");
+    openDetail("Largest expenses");
     expect(screen.getAllByText("No spending recorded").length).toBeGreaterThan(0);
     expect(screen.getByText("No cash in recorded")).toBeInTheDocument();
     expect(screen.getByText("No budget limits are set for this month.")).toBeInTheDocument();

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -124,7 +124,30 @@ summary { min-height: 44px; padding-block: .625rem; cursor: pointer; }
 .chart-summary h3 { margin-bottom: var(--space-3); font-size: var(--text-lg); }
 .chart-summary__list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 190px), 1fr)); gap: var(--space-3); margin: 0; padding: 0; list-style: none; }
 .chart-summary__item { display: flex; min-width: 0; padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-md); flex-direction: column; gap: var(--space-1); background: var(--color-surface-subtle); font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
-.analytics-page__header .field { width: min(100%, 240px); }
+.analytics-page__header { align-items: start; flex-wrap: wrap; }
+.analytics-page__header > div { min-width: 0; }
+.analytics-page__header .muted { margin-bottom: 0; }
+.analytics-page__controls { display: flex; flex-wrap: wrap; align-items: end; gap: var(--space-3); max-width: 100%; }
+.analytics-page__controls .field { flex: 1 1 12rem; width: min(100%, 240px); }
+.cash-flow-visuals { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 26rem), 1fr)); align-items: start; gap: var(--space-4); }
+.cash-flow-visuals > .analytics-panel { margin-bottom: 0; }
+.analytics-more { min-width: 0; margin-top: var(--space-6); }
+.analytics-more__header { margin-bottom: var(--space-3); }
+.analytics-more__header h2 { margin: 0; }
+.analytics-detail { min-width: 0; padding-block: var(--space-2); border-top: 1px solid var(--color-divider); }
+.analytics-detail:last-child { border-bottom: 1px solid var(--color-divider); }
+.analytics-detail summary { min-height: 44px; padding: var(--space-3) var(--space-2); overflow-wrap: anywhere; border-radius: var(--radius-sm); }
+.analytics-detail summary::marker { color: var(--color-primary); }
+.analytics-detail summary:hover { background: var(--color-surface-subtle); }
+.analytics-detail summary h3 { display: inline; margin: 0; font-size: var(--text-lg); font-weight: 700; }
+.analytics-detail__content { min-width: 0; padding: var(--space-3) var(--space-2) var(--space-4); overflow-wrap: anywhere; }
+.analytics-detail .analytics-row { flex-wrap: wrap; }
+.analytics-detail .analytics-row > :last-child { min-width: 0; max-width: 100%; flex-shrink: 1; }
+.analytics-detail .analytics-comparison__value { font-size: var(--text-xl); }
+.analytics-detail .analytics-panel__header a { display: inline-flex; align-items: center; min-height: 44px; max-width: 100%; }
+.analytics-detail .analytics-change-grid h4 { margin: 0 0 var(--space-2); font-size: var(--text-base); }
+.analytics-load-state { margin-block: var(--space-4); }
+
 .analytics-total { margin-bottom: var(--space-4); border-color: color-mix(in srgb, var(--color-primary) 32%, var(--color-border)); background: var(--color-bg-accent); box-shadow: none; }
 .analytics-kicker { margin: 0 0 var(--space-1); color: var(--color-primary); font-size: var(--text-xs); font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 .analytics-total h2, .analytics-panel h2 { margin: 0; }
@@ -190,7 +213,6 @@ summary { min-height: 44px; padding-block: .625rem; cursor: pointer; }
 .cash-flow-table th, .cash-flow-table td { padding: var(--space-3); text-align: left; border-bottom: 1px solid var(--color-border); vertical-align: top; }
 .cash-flow-table td { white-space: nowrap; }
 .cash-flow-table td:last-child { white-space: normal; min-width: 150px; }
-.cash-flow-refresh { margin-bottom: var(--space-4); }
 @media (max-width: 820px) { .cash-flow-summary__comparison { grid-template-columns: 1fr; } }
 @media (max-width: 600px) { .cash-flow-facts { grid-template-columns: 1fr; } .cash-flow-trend__canvas { height: 270px; } }
 .mt-2 { margin-top: var(--space-4); }


### PR DESCRIPTION
## Summary

Related to #127 (UX V3 slice 2 of 7).

This MEDIUM-risk slice gives Insights a calmer hierarchy while preserving its existing financial behavior. The page now leads with recorded cash-flow summary, ranked categories, and the six-month trend; places the month selector and refresh action together at the top; and moves budget status, month-over-month change, and largest expenses into three named, default-closed native disclosures under “More spending detail.” Expense and budget loading, error, and retry states remain visible outside those disclosures.

The ranked-category markup is extracted into a reusable presentation component without changing the existing exact-cent sorting, formatting, percentage, or bar-width calculations. Existing panel content, month/date handling, API and hook behavior, cash-flow partitioning, session-staleness protections, empty states, and retry semantics remain intact. `PRODUCT_OVERVIEW.md` now reflects the shipped Insights hierarchy; `RECENT_CHANGES.md` remains unchanged until the final V3 completion slice.

Authority:

- [UX V3 plan](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563926559) and [explicit owner approval](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563943900)
- [Authorized slice 2 implementation](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5564237098)
- Base: `main` at `35743d8bae577ca634b53ef87da9a77ee073e087`

## Verification

- `./scripts/verify.sh frontend` passed: 47 test files and 427 tests, plus ESLint and production build.
- Regression coverage verifies the new heading/order, all three default-closed disclosures, native summary focusability, disclosure-state preservation, error/loading/retry visibility, accessible category heading IDs, zero-denominator presentation, and the existing exact-money/category-order contracts.
- Isolated localhost browser checks passed with synthetic read-only fixtures: 320/375/768/1280px layout without document overflow; desktop side-by-side/mobile stacked chart order; all three disclosures reachable and operable with the keyboard, including Enter/Space and retained focus; light/dark/system themes and reduced motion; selected-month updates and successful refresh clearing old charts; cash-flow, expense, and budget failures with visible working retries; empty states; large exact-cent values, long labels, and 200% root text at 320px; accessible, focusable chart-data region. No browser JavaScript errors. Private screenshots were inspected locally and are not published.
- Vercel preview deployment succeeded. A credential-free request to the deployed Insights route redirects to Vercel login protection, so deployed-page smoke verification was unavailable; no authentication bypass or real-account session was used.
- Manual screen-reader and native browser zoom checks were not run locally and remain disclosed gaps; automated browser checks used native keyboard controls/accessibility structure and 200% root text resizing.

## Scope boundaries

No backend, API, schema, migration, dependency, authentication/session, or financial-rule changes. No production operations. The two previously reported untracked files in the Desktop checkout remain untouched; work is isolated in `/tmp/ordo-127-v3`. Context expansion was limited to the existing cash-flow component/helper contracts, legacy selectors, and their tests to verify extraction and disclosure preservation.

Backend code is unchanged; backend verification was not rerun locally. Disposable local PostgreSQL is unavailable. Required CI passed on `e0d00604dc5acdbc05b6dbbe09a457f1f102a9b7`: [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/34077913876/job/101607528440), [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/34077913874/job/101607528537), and [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/34077913874/job/101607528467). Independent actual-PR review and resolution of any blocking findings remain required before merge; Codex has not approved or merged this PR.
