### PR TITLE
Show the Home financial snapshot and independent feature summaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,8 +42,10 @@ constants, theme, UI, and utilities live under
 Below the desktop sidebar breakpoint, the shell exposes Home, Activity, Plan,
 Insights, and More. The protected `/plan` and `/more` pages group links to the
 existing feature URLs without owning feature data or changing their workflows.
-Desktop retains individual destinations. Home preserves the recorded-spending
-summary and offers direct links to the planning features. Theme tokens also
+Desktop retains individual destinations. Home composes existing cash-flow and
+feature list reads with independent loading/error states and session-staleness
+protection. Its financial summary reuses Analytics' exact-cent response; paycheck
+and commitment lists do not invoke candidate or change detection. Theme tokens also
 drive chart presentation in explicit and system appearance modes.
 
 Analytics combines historical cash in and Expenses through an analytics-local

--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -20,9 +20,10 @@ silently treating every detected pattern as a financial fact.
 
 ## What you can do today
 
-- **Home / Overview:** See the current month's recorded spending, how many
-  categories have spending, and how many category limits are at or above 90%
-  used. Follow links into activity, planning, and insights.
+- **Home / Overview:** Compare this month's recorded cash in, spending, and net
+  recorded cash flow. See expected paycheck windows, category limits at or above
+  90% used, active commitments, and recent spending, with links to each workflow.
+  Each section shows its own loading or retry state when a read is unavailable.
 - **Activity / Transactions:** Add, edit, and delete expenses. Search descriptions
   and categories, filter by category or date range, and review the underlying
   records behind spending summaries.

--- a/frontend/src/app/hooks/useHomeRead.js
+++ b/frontend/src/app/hooks/useHomeRead.js
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { getSessionSnapshot, subscribeToSession } from "../../shared/auth/session";
+
+export function useHomeRead(load, key = null) {
+  const session = useSyncExternalStore(subscribeToSession, getSessionSnapshot);
+  const [state, setState] = useState(null);
+  const [attempt, setAttempt] = useState(0);
+  const latest = useRef(0);
+  const refresh = useCallback(() => setAttempt((value) => value + 1), []);
+
+  useEffect(() => {
+    const id = ++latest.current;
+    const current = () => id === latest.current && session === getSessionSnapshot();
+    const identity = { load, key, session, attempt };
+    const fail = () => {
+      if (current()) setState({ ...identity, loading: false, data: null, error: true });
+    };
+
+    setState({ ...identity, loading: true, data: null, error: false });
+
+    if (!session.token) {
+      setState({ ...identity, loading: false, data: null, error: false });
+      return () => { latest.current += 1; };
+    }
+
+    let request;
+    try {
+      request = load(key);
+    } catch {
+      fail();
+      return () => { latest.current += 1; };
+    }
+
+    Promise.resolve(request).then(({ data }) => {
+      if (current()) setState({ ...identity, loading: false, data, error: false });
+    }).catch(fail);
+
+    return () => { latest.current += 1; };
+  }, [load, key, session, attempt]);
+
+  const matches = state?.load === load
+    && state?.key === key
+    && state?.session === session
+    && state?.attempt === attempt;
+
+  return {
+    data: matches ? state.data : null,
+    loading: !matches || state.loading,
+    error: matches ? state.error : false,
+    refresh,
+  };
+}

--- a/frontend/src/app/hooks/useHomeRead.test.jsx
+++ b/frontend/src/app/hooks/useHomeRead.test.jsx
@@ -1,0 +1,160 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSession, establishSession } from "../../shared/auth/session";
+import { useHomeRead } from "./useHomeRead";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+describe("Home read lifecycle", () => {
+  beforeEach(() => {
+    establishSession("owner-a", "a@example.test");
+  });
+
+  afterEach(() => {
+    clearSession();
+  });
+
+  it("keeps data unavailable while loading and preserves a successful empty array", async () => {
+    const request = deferred();
+    const load = vi.fn(() => request.promise);
+    const { result } = renderHook(() => useHomeRead(load));
+
+    expect(result.current).toMatchObject({ data: null, loading: true, error: false });
+    expect(load).toHaveBeenCalledWith(null);
+
+    await act(() => request.resolve({ data: [] }));
+
+    expect(result.current).toMatchObject({ data: [], loading: false, error: false });
+  });
+
+  it("reports a failed read without substituting empty data", async () => {
+    const load = vi.fn().mockRejectedValue(new Error("unavailable"));
+    const { result } = renderHook(() => useHomeRead(load));
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    expect(result.current).toMatchObject({ data: null, loading: false });
+  });
+
+  it("clears stale success and failure state synchronously when retrying", async () => {
+    const retry = deferred();
+    const load = vi.fn()
+      .mockResolvedValueOnce({ data: ["old"] })
+      .mockRejectedValueOnce(new Error("failed"))
+      .mockReturnValueOnce(retry.promise);
+    const { result } = renderHook(() => useHomeRead(load));
+
+    await waitFor(() => expect(result.current.data).toEqual(["old"]));
+
+    act(() => result.current.refresh());
+    expect(result.current).toMatchObject({ data: null, loading: true, error: false });
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    act(() => result.current.refresh());
+    expect(result.current).toMatchObject({ data: null, loading: true, error: false });
+
+    await act(() => retry.resolve({ data: ["current"] }));
+    expect(result.current).toMatchObject({ data: ["current"], loading: false, error: false });
+  });
+
+  it("keeps the latest retry when an older request settles last", async () => {
+    const old = deferred();
+    const recent = deferred();
+    const load = vi.fn().mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    const { result } = renderHook(() => useHomeRead(load));
+
+    act(() => result.current.refresh());
+    await act(() => recent.resolve({ data: ["current"] }));
+    await act(() => old.resolve({ data: ["stale"] }));
+
+    expect(result.current.data).toEqual(["current"]);
+  });
+
+  it("hides the prior result when the key changes and ignores its late completion", async () => {
+    const old = deferred();
+    const recent = deferred();
+    const load = vi.fn().mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    const { result, rerender } = renderHook(
+      ({ key }) => useHomeRead(load, key),
+      { initialProps: { key: "2026-08" } },
+    );
+
+    rerender({ key: "2026-07" });
+    expect(result.current).toMatchObject({ data: null, loading: true, error: false });
+    expect(load).toHaveBeenLastCalledWith("2026-07");
+
+    await act(() => recent.resolve({ data: ["July"] }));
+    await act(() => old.resolve({ data: ["August"] }));
+    expect(result.current.data).toEqual(["July"]);
+  });
+
+  it("hides the prior result when the loader changes and ignores its late completion", async () => {
+    const old = deferred();
+    const recent = deferred();
+    const oldLoad = vi.fn(() => old.promise);
+    const recentLoad = vi.fn(() => recent.promise);
+    const { result, rerender } = renderHook(
+      ({ load }) => useHomeRead(load, "month"),
+      { initialProps: { load: oldLoad } },
+    );
+
+    rerender({ load: recentLoad });
+    expect(result.current).toMatchObject({ data: null, loading: true, error: false });
+
+    await act(() => recent.resolve({ data: ["current loader"] }));
+    await act(() => old.resolve({ data: ["old loader"] }));
+    expect(result.current.data).toEqual(["current loader"]);
+  });
+
+  it("clears owner data and ignores completion from an older session generation", async () => {
+    const old = deferred();
+    const recent = deferred();
+    const load = vi.fn().mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    const { result } = renderHook(() => useHomeRead(load));
+
+    act(() => establishSession("owner-a", "a@example.test"));
+    expect(result.current).toMatchObject({ data: null, loading: true, error: false });
+
+    await act(() => old.resolve({ data: ["owner a"] }));
+    expect(result.current.data).toBeNull();
+
+    await act(() => recent.resolve({ data: ["current session"] }));
+    expect(result.current.data).toEqual(["current session"]);
+  });
+
+  it("does not request while logged out", () => {
+    clearSession();
+    const load = vi.fn();
+    const { result } = renderHook(() => useHomeRead(load));
+
+    expect(result.current).toMatchObject({ data: null, loading: false, error: false });
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it("drops a prior session result on logout without another request", async () => {
+    const load = vi.fn().mockResolvedValue({ data: ["private"] });
+    const { result } = renderHook(() => useHomeRead(load));
+    await waitFor(() => expect(result.current.data).toEqual(["private"]));
+
+    act(() => clearSession());
+
+    expect(result.current).toMatchObject({ data: null, loading: false, error: false });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores completion after unmount", async () => {
+    const request = deferred();
+    const load = vi.fn(() => request.promise);
+    const { unmount } = renderHook(() => useHomeRead(load));
+
+    unmount();
+    await act(() => request.resolve({ data: ["late"] }));
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/pages/OverviewPage.jsx
+++ b/frontend/src/app/pages/OverviewPage.jsx
@@ -1,120 +1,190 @@
-import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { ArrowRight, CalendarRange, ChartNoAxesCombined, ReceiptText } from "lucide-react";
-import { useBudgetLimits } from "../../features/budgetLimits/hooks/useBudgetLimits";
+import { useHomeRead } from "../hooks/useHomeRead";
+import { useCashFlow } from "../../features/analytics/hooks/useCashFlow";
+import CashFlowSummary from "../../features/analytics/components/CashFlowSummary";
+import { cashDateLabel, localThroughDate } from "../../features/analytics/utils/cashFlowPresentation";
+import { budgetLimitsApi } from "../../features/budgetLimits/api/budgetLimitsApi";
 import { computeMonthlyTotalsByCategory } from "../../features/budgetLimits/utils/totalsByCategory";
-import { useExpenses } from "../../features/expenses/hooks/useExpenses";
+import { expensesApi } from "../../features/expenses/api/expensesApi";
+import { formatExpenseDate } from "../../features/expenses/utils/calendarDate";
+import { paychecksApi } from "../../features/paychecks/api/paychecksApi";
+import { cadenceLabel, formatAmount, formatDate, formatMoney } from "../../features/paychecks/utils/formatPaychecks";
+import { commitmentsApi } from "../../features/commitments/api/commitmentsApi";
 import { getMonthYear } from "../../shared/utils/monthYear";
 import { usedPercentage } from "../../utils/budgets";
-import Card from "../../shared/ui/Card";
+import { displayText } from "../../utils/text";
 import StatusMessage from "../../shared/ui/StatusMessage";
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-});
+const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+
+async function readList(request) {
+  const response = await request;
+  if (!Array.isArray(response.data)) throw new Error("List unavailable");
+  return response;
+}
+const loadExpenses = () => readList(expensesApi.getAll());
+const loadLimits = (month) => readList(budgetLimitsApi.getByMonth(month));
+const loadCommitments = () => readList(commitmentsApi.getCommitments());
+const loadPaychecks = async () => {
+  const response = await paychecksApi.getPaychecks();
+  if (!Array.isArray(response.data?.paychecks)) throw new Error("Paychecks unavailable");
+  return response;
+};
+const ready = (read) => !read.loading && !read.error && read.data !== null;
+const compareIds = (left, right) => String(left.id).localeCompare(String(right.id), "en");
+
+function ReadStatus({ read, label }) {
+  if (read.error) return (
+    <div className="home-read-status">
+      <StatusMessage tone="danger">We couldn’t load {label}.</StatusMessage>
+      <button type="button" onClick={read.refresh}>Retry {label}</button>
+    </div>
+  );
+  return read.loading ? <StatusMessage>Loading {label}...</StatusMessage> : null;
+}
+
+function HomeModule({ id, title, href, linkText, children }) {
+  return (
+    <section className="card home-module" aria-labelledby={id}>
+      <h2 id={id} className="h2">{title}</h2>
+      <div className="home-module__content">{children}</div>
+      <Link to={href}>{linkText} <span aria-hidden="true">→</span></Link>
+    </section>
+  );
+}
 
 export default function OverviewPage() {
   const currentMonth = getMonthYear(new Date());
-  const { expenses, loading: expensesLoading } = useExpenses();
-  const { budgetLimits, loading: limitsLoading } = useBudgetLimits(currentMonth);
+  const cashFlow = useCashFlow(currentMonth);
+  const spending = useHomeRead(loadExpenses, currentMonth);
+  const limits = useHomeRead(loadLimits, currentMonth);
+  const paychecks = useHomeRead(loadPaychecks);
+  const commitments = useHomeRead(loadCommitments);
+  // Secondary reads are independent. If cash flow is unavailable, recent spending
+  // still uses an explicitly labelled local-calendar cutoff, never a guessed total.
+  const throughDate = cashFlow.data?.to ?? localThroughDate();
 
-  const totalsByCategory = useMemo(
-    () => computeMonthlyTotalsByCategory(expenses, currentMonth),
-    [expenses, currentMonth]
-  );
-
-  const recordedSpending = Object.values(totalsByCategory)
-    .reduce((sum, amount) => sum + Number(amount || 0), 0);
-  const spendingCategoryCount = Object.keys(totalsByCategory).length;
-  const totalLimits = (budgetLimits ?? []).length;
-  const attentionCount = (budgetLimits ?? []).filter((limit) => (
+  const totalsByCategory = computeMonthlyTotalsByCategory(spending.data ?? [], currentMonth);
+  const attention = (limits.data ?? []).filter((limit) => (
     usedPercentage(totalsByCategory[limit.category] || 0, limit.limitAmount) >= 90
-  )).length;
-  const loading = expensesLoading || limitsLoading;
-  const isEmpty = spendingCategoryCount === 0 && totalLimits === 0;
+  ));
+  const expectedPaychecks = (paychecks.data?.paychecks ?? [])
+    .filter((profile) => profile.lifecycle === "active" && profile.nextProjection)
+    .sort((left, right) => left.nextProjection.earliestExpectedDate.localeCompare(right.nextProjection.earliestExpectedDate) || compareIds(left, right))
+    .slice(0, 2);
+  const activeCommitments = (commitments.data ?? []).filter((commitment) => commitment.lifecycle === "active");
+  const recentSpending = (spending.data ?? [])
+    .filter((expense) => expense.date.startsWith(`${currentMonth}-`) && expense.date <= throughDate)
+    .sort((left, right) => right.date.localeCompare(left.date) || compareIds(left, right))
+    .slice(0, 3);
 
   return (
-    <div className="shell-page">
-      <section className="overview-grid" aria-label="Planning tools">
-          <div className="overview-hero">
-            <div className="overview-hero__content">
-              <p className="page-header__eyebrow">Personal finance workspace</p>
-              <h1>Welcome back</h1>
-              <p>Your finances now have a clearer home. Use the tools already available today while dedicated experiences continue to take shape.</p>
-              <Link className="button-link" to="/transactions">Open transactions <ArrowRight size={18} aria-hidden="true" /></Link>
-            </div>
-          </div>
-          <section className="overview-summary" aria-labelledby="overview-summary-heading">
-            <div className="overview-summary__header">
-              <div>
-                <p className="overview-kicker">Current month</p>
-                <h2 id="overview-summary-heading" className="h2">Recorded spending summary</h2>
-              </div>
-            </div>
-            {loading ? (
-              <StatusMessage>Loading current-month summary...</StatusMessage>
-            ) : (
-              <>
-                {isEmpty ? (
-                  <StatusMessage>No recorded spending or budget limits for this month yet.</StatusMessage>
-                ) : null}
-                <div className="overview-metrics">
-                  <Card className="overview-metric">
-                    <p className="overview-metric__label">Recorded spending this month</p>
-                    <p className="overview-metric__value">{currencyFormatter.format(recordedSpending)}</p>
-                    <p className="overview-metric__context">Includes recorded expenses through today.</p>
-                  </Card>
-                  <Card className="overview-metric">
-                    <p className="overview-metric__label">Categories with recorded spending</p>
-                    <p className="overview-metric__value">{spendingCategoryCount}</p>
-                    <p className="overview-metric__context">Uses the existing exact category grouping.</p>
-                  </Card>
-                  <Card className="overview-metric">
-                    <p className="overview-metric__label">Budget-limit attention</p>
-                    {totalLimits > 0 ? (
-                      <>
-                        <p className="overview-metric__value">{attentionCount}</p>
-                        <p className="overview-metric__context">
-                          {attentionCount === 1 ? "limit is" : "limits are"} at or above 90% used · {totalLimits} {totalLimits === 1 ? "limit" : "limits"} set
-                        </p>
-                      </>
-                    ) : (
-                      <>
-                        <p className="overview-metric__value">0</p>
-                        <p className="overview-metric__context">No budget limits are set for this month.</p>
-                        <Link to="/budgets">Set budget limits <span aria-hidden="true">→</span></Link>
-                      </>
-                    )}
-                  </Card>
-                </div>
-              </>
-            )}
-          </section>
-          <Card className="overview-module overview-module--activity">
-            <div className="overview-module__heading">
-              <ReceiptText size={24} aria-hidden="true" />
-              <span className="overview-module__status">Available now</span>
-            </div>
-            <div><h2 className="h2">Activity</h2><p>Record, edit, search, filter, and review expenses in the established workspace.</p></div>
-            <Link to="/transactions">Open activity <span aria-hidden="true">→</span></Link>
-          </Card>
-          <Card className="overview-module overview-module--plan">
-            <div className="overview-module__heading"><CalendarRange size={22} aria-hidden="true" /><span className="overview-module__status">Available now</span></div>
-            <div><h2 className="h2">Plan</h2><p>Shape your budget, recurring commitments, and expected paychecks.</p></div>
-            <Link to="/plan">Open plan <span aria-hidden="true">→</span></Link>
-            <div className="overview-module__links" aria-label="Planning tools">
-              <Link to="/budgets">Budgets</Link>
-              <Link to="/commitments">Commitments</Link>
-              <Link to="/paychecks">Paychecks</Link>
-            </div>
-          </Card>
-          <Card className="overview-module overview-module--insights">
-            <div className="overview-module__heading"><ChartNoAxesCombined size={22} aria-hidden="true" /><span className="overview-module__status">Available now</span></div>
-            <div><h2 className="h2">Insights</h2><p>Compare recorded spending with category limits by month.</p></div>
-            <Link to="/analytics">Open insights <span aria-hidden="true">→</span></Link>
-          </Card>
+    <div className="shell-page home-page">
+      <header className="page-header home-page__header">
+        <div><h1>Home</h1><p className="muted">This month, at a glance.</p></div>
+        <Link className="button-link" to="/transactions">Open activity <span aria-hidden="true">→</span></Link>
+      </header>
+
+      <section className="home-cash-flow" aria-label="This month’s recorded cash flow" aria-busy={cashFlow.loading}>
+        <div className="home-cash-flow__actions">
+          <Link to="/analytics">View insights <span aria-hidden="true">→</span></Link>
+          {ready(cashFlow) && <button type="button" className="button-ghost" onClick={cashFlow.refresh}>Refresh cash flow</button>}
+        </div>
+        {cashFlow.loading && <StatusMessage>Loading recorded cash flow...</StatusMessage>}
+        {cashFlow.error && <div className="home-read-status"><StatusMessage tone="danger">{cashFlow.error}</StatusMessage><button type="button" onClick={cashFlow.refresh}>Retry cash flow</button></div>}
+        {ready(cashFlow) && <CashFlowSummary data={cashFlow.data} />}
       </section>
+
+      <div className="home-modules">
+        <HomeModule id="home-paychecks-heading" title="Expected paychecks" href="/paychecks" linkText="All paychecks">
+          <ReadStatus read={paychecks} label="expected paychecks" />
+          {ready(paychecks) && (expectedPaychecks.length === 0 ? (
+            <StatusMessage>No expected paycheck windows are available.</StatusMessage>
+          ) : (
+            <>
+              <p className="home-qualification">Expected, not guaranteed.</p>
+              <ul className="home-records">
+                {expectedPaychecks.map((profile) => {
+                  const projection = profile.nextProjection;
+                  return (
+                    <li key={profile.id}>
+                      <div className="home-record__line"><strong>{profile.displayName}</strong><strong>{formatAmount(projection.amount)}</strong></div>
+                      <p>{cadenceLabel(profile.schedule?.cadence)}</p>
+                      <p>Expected {formatDate(projection.earliestExpectedDate)}{projection.latestExpectedDate !== projection.earliestExpectedDate && ` – ${formatDate(projection.latestExpectedDate)}`}</p>
+                    </li>
+                  );
+                })}
+              </ul>
+              <details className="home-disclosure">
+                <summary>About these expectations</summary>
+                <p>Evaluated {formatDate(paychecks.data.evaluatedOn)}. Expected windows can overlap; their order does not guarantee which deposit arrives first.</p>
+              </details>
+            </>
+          ))}
+        </HomeModule>
+
+        <HomeModule id="home-budgets-heading" title="Budget attention" href="/budgets" linkText="All budgets">
+          <ReadStatus read={spending} label="spending" />
+          <ReadStatus read={limits} label="budget limits" />
+          {ready(spending) && ready(limits) && (limits.data.length === 0 ? (
+            <StatusMessage>No budget limits are set for this month.</StatusMessage>
+          ) : attention.length === 0 ? (
+            <StatusMessage>No limits are at or above 90% used.</StatusMessage>
+          ) : (
+            <>
+              <p className="muted">{attention.length} {attention.length === 1 ? "limit is" : "limits are"} at or above 90% used · {limits.data.length} {limits.data.length === 1 ? "limit" : "limits"} set</p>
+              <ul className="home-records">
+                {attention.slice(0, 3).map((limit, index) => {
+                  const spent = totalsByCategory[limit.category] || 0;
+                  const percentage = usedPercentage(spent, limit.limitAmount);
+                  return (
+                    <li key={limit.id ?? index}>
+                      <div className="home-record__line"><strong>{displayText(limit.category)}</strong><span>{percentage.toFixed(1)}% used</span></div>
+                      <p>{currencyFormatter.format(spent)} spent of {currencyFormatter.format(limit.limitAmount)}</p>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          ))}
+        </HomeModule>
+
+        <HomeModule id="home-commitments-heading" title="Active commitments" href="/commitments" linkText="All commitments">
+          <ReadStatus read={commitments} label="active commitments" />
+          {ready(commitments) && (activeCommitments.length === 0 ? (
+            <StatusMessage>No active commitments.</StatusMessage>
+          ) : (
+            <>
+              <p className="muted">{activeCommitments.length} active {activeCommitments.length === 1 ? "commitment" : "commitments"}</p>
+              <ul className="home-records">
+                {activeCommitments.slice(0, 3).map((commitment) => (
+                  <li key={commitment.id}>
+                    <div className="home-record__line"><strong>{commitment.name}</strong><strong>{commitment.amountMode === "fixed" ? formatMoney(commitment.expectedAmount) : `${formatMoney(commitment.expectedMinimumAmount)}–${formatMoney(commitment.expectedMaximumAmount)}`}</strong></div>
+                    <p>{displayText(commitment.cadence)}</p>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ))}
+        </HomeModule>
+
+        <HomeModule id="home-spending-heading" title="Recent spending" href="/transactions" linkText="All spending">
+          <ReadStatus read={spending} label="spending" />
+          {ready(spending) && <>
+            <p className="muted">This month · Through {cashDateLabel(throughDate)}</p>
+            {recentSpending.length === 0 ? <StatusMessage>No spending recorded in this period.</StatusMessage> : (
+              <ul className="home-records">
+                {recentSpending.map((expense) => (
+                  <li key={expense.id}>
+                    <div className="home-record__line"><strong>{expense.description}</strong><strong>{currencyFormatter.format(expense.amount)}</strong></div>
+                    <p>{formatExpenseDate(expense.date)} · {displayText(expense.category)}</p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>}
+        </HomeModule>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/pages/OverviewPage.test.jsx
+++ b/frontend/src/app/pages/OverviewPage.test.jsx
@@ -1,95 +1,363 @@
-import { render, screen, within } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import OverviewPage from './OverviewPage'
-import { useExpenses } from '../../features/expenses/hooks/useExpenses'
-import { useBudgetLimits } from '../../features/budgetLimits/hooks/useBudgetLimits'
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OverviewPage from "./OverviewPage";
+import { cashFlowApi } from "../../features/analytics/api/cashFlowApi";
+import { cashFlowFixture } from "../../features/analytics/testFixtures";
+import { budgetLimitsApi } from "../../features/budgetLimits/api/budgetLimitsApi";
+import { commitmentsApi } from "../../features/commitments/api/commitmentsApi";
+import { expensesApi } from "../../features/expenses/api/expensesApi";
+import { paychecksApi } from "../../features/paychecks/api/paychecksApi";
+import { clearSession, establishSession } from "../../shared/auth/session";
 
-vi.mock('../../features/expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
-vi.mock('../../features/budgetLimits/hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
+vi.mock("../../features/analytics/api/cashFlowApi", () => ({ cashFlowApi: { get: vi.fn() } }));
+vi.mock("../../features/expenses/api/expensesApi", () => ({
+  expensesApi: { getAll: vi.fn(), create: vi.fn(), update: vi.fn(), remove: vi.fn() },
+}));
+vi.mock("../../features/budgetLimits/api/budgetLimitsApi", () => ({
+  budgetLimitsApi: { getByMonth: vi.fn(), upsert: vi.fn(), remove: vi.fn() },
+}));
+vi.mock("../../features/paychecks/api/paychecksApi", () => ({
+  paychecksApi: {
+    getCandidates: vi.fn(), getPaychecks: vi.fn(), getPaycheck: vi.fn(),
+    confirmCandidate: vi.fn(), dismissCandidate: vi.fn(), reconsiderCandidate: vi.fn(),
+    createPaycheck: vi.fn(), updatePaycheck: vi.fn(), updateLifecycle: vi.fn(),
+  },
+}));
+vi.mock("../../features/commitments/api/commitmentsApi", () => ({
+  commitmentsApi: {
+    getCandidates: vi.fn(), dismissCandidate: vi.fn(), reconsiderCandidate: vi.fn(),
+    confirmCandidate: vi.fn(), getCommitments: vi.fn(), getChanges: vi.fn(),
+    acceptAmountChange: vi.fn(), acceptTimingChange: vi.fn(), markEndedFromChange: vi.fn(),
+    keepChange: vi.fn(), reconsiderChange: vi.fn(), updateCommitment: vi.fn(), updateLifecycle: vi.fn(),
+  },
+}));
 
-function renderPage() {
-  return render(<MemoryRouter><OverviewPage /></MemoryRouter>)
+const response = (data) => ({ data });
+const never = () => new Promise(() => {});
+
+const expenses = [
+  { id: "expense-b", description: "Rent", category: "bills", amount: 1200, date: "2026-08-14" },
+  { id: "expense-a", description: "Utilities", category: "bills", amount: 15, date: "2026-08-14" },
+  { id: "expense-c", description: "Gas", category: "transport", amount: 40, date: "2026-08-13" },
+  { id: "expense-d", description: "Coffee", category: "Food", amount: 10, date: "2026-08-03" },
+  { id: "expense-e", description: "Groceries", category: "food", amount: 90, date: "2026-08-02" },
+  { id: "expense-f", description: "No-limit item", category: "zero", amount: 200, date: "2026-08-01" },
+  { id: "expense-g", description: "Health item", category: "health", amount: 10, date: "2026-08-01" },
+  { id: "expense-h", description: "Future purchase", category: "food", amount: 500, date: "2026-08-15" },
+  { id: "expense-i", description: "Last month", category: "food", amount: 999, date: "2026-07-31" },
+];
+
+const limits = [
+  { id: "limit-food", category: "food", limitAmount: 100 },
+  { id: "limit-Food", category: "Food", limitAmount: 20 },
+  { id: "limit-zero", category: "zero", limitAmount: 0 },
+  { id: "limit-bills", category: "bills", limitAmount: 1000 },
+  { id: "limit-transport", category: "transport", limitAmount: 20 },
+  { id: "limit-health", category: "health", limitAmount: 10 },
+];
+
+function projection(amount, earliestExpectedDate, latestExpectedDate = earliestExpectedDate) {
+  return {
+    evaluatedOn: "2026-09-05",
+    earliestExpectedDate,
+    latestExpectedDate,
+    amount: { mode: "fixed", fixedAmount: amount, minimumAmount: null, maximumAmount: null },
+  };
 }
 
-describe('Overview current-month summary', () => {
+const paychecks = [
+  { id: "b", displayName: "Payroll B", lifecycle: "active", schedule: { cadence: "monthly" }, nextProjection: projection("9999999999999999.99", "2026-08-20") },
+  { id: "a", displayName: "Payroll A", lifecycle: "active", schedule: { cadence: "monthly" }, nextProjection: projection("2500.00", "2026-08-20") },
+  { id: "c", displayName: "Payroll C", lifecycle: "active", schedule: { cadence: "monthly" }, nextProjection: projection("3000.00", "2026-08-21") },
+  { id: "paused", displayName: "Paused payroll", lifecycle: "paused", schedule: { cadence: "monthly" }, nextProjection: projection("100.00", "2026-08-01") },
+  { id: "missing", displayName: "No server projection", lifecycle: "active", schedule: { cadence: "monthly" }, nextProjection: null },
+];
+
+const commitments = [
+  { id: "commitment-1", name: "Rent plan", lifecycle: "active", cadence: "monthly", amountMode: "fixed", expectedAmount: "9999999999999999.99" },
+  { id: "commitment-2", name: "Electric plan", lifecycle: "active", cadence: "monthly", amountMode: "range", expectedMinimumAmount: "75.25", expectedMaximumAmount: "125.75" },
+  { id: "commitment-3", name: "Gym plan", lifecycle: "active", cadence: "weekly", amountMode: "fixed", expectedAmount: "20.00" },
+  { id: "commitment-4", name: "Fourth active plan", lifecycle: "active", cadence: "monthly", amountMode: "fixed", expectedAmount: "30.00" },
+  { id: "commitment-paused", name: "Paused plan", lifecycle: "paused", cadence: "monthly", amountMode: "fixed", expectedAmount: "40.00" },
+];
+
+function cashFlowData(overrides = {}) {
+  return cashFlowFixture("2026-08", {
+    cashInMinor: "999999999999999999",
+    paycheckCashInMinor: "900000000000000000",
+    otherCashInMinor: "99999999999999999",
+    spentMinor: "123456789012345678",
+    ...overrides,
+  });
+}
+
+function renderPage() {
+  return render(<MemoryRouter><OverviewPage /></MemoryRouter>);
+}
+
+function moduleNamed(name) {
+  return screen.getByRole("heading", { level: 2, name }).closest("section");
+}
+
+function expectReadCounts({ cash = 1, spending = 1, budgets = 1, paycheck = 1, commitment = 1 } = {}) {
+  expect(cashFlowApi.get).toHaveBeenCalledTimes(cash);
+  expect(expensesApi.getAll).toHaveBeenCalledTimes(spending);
+  expect(budgetLimitsApi.getByMonth).toHaveBeenCalledTimes(budgets);
+  expect(paychecksApi.getPaychecks).toHaveBeenCalledTimes(paycheck);
+  expect(commitmentsApi.getCommitments).toHaveBeenCalledTimes(commitment);
+}
+
+describe("Home current-month snapshot", () => {
   beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0))
-    useExpenses.mockReturnValue({
-      expenses: [
-        { category: 'food', amount: 90, date: '2026-08-02' },
-        { category: 'Food', amount: 10, date: '2026-08-03' },
-        { category: 'food', amount: 500, date: '2026-08-15' },
-      ],
-      loading: false,
-    })
-    useBudgetLimits.mockReturnValue({
-      budgetLimits: [
-        { category: 'food', limitAmount: 100 },
-        { category: 'Food', limitAmount: 20 },
-      ],
-      loading: false,
-    })
-  })
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 7, 14, 12, 0, 0));
+    establishSession("owner-a", "a@example.test");
+    vi.clearAllMocks();
+    cashFlowApi.get.mockResolvedValue(response(cashFlowData()));
+    expensesApi.getAll.mockResolvedValue(response(expenses));
+    budgetLimitsApi.getByMonth.mockResolvedValue(response(limits));
+    paychecksApi.getPaychecks.mockResolvedValue(response({ evaluatedOn: "2026-09-05", paychecks }));
+    commitmentsApi.getCommitments.mockResolvedValue(response(commitments));
+  });
 
   afterEach(() => {
-    vi.useRealTimers()
-    vi.clearAllMocks()
-  })
+    clearSession();
+    vi.useRealTimers();
+  });
 
-  it('derives only the approved signals with exact categories and future-day exclusion', () => {
-    renderPage()
+  it("composes the approved five reads without recomputing cash flow or invoking review and mutation APIs", async () => {
+    renderPage();
+    await screen.findByRole("heading", { name: "Recorded cash in vs Spent" });
 
-    expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-08')
-    expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.getByRole("heading", { level: 1, name: "Home" })).toBeInTheDocument();
+    const cashFlow = screen.getByRole("region", { name: "This month’s recorded cash flow" });
+    expect(cashFlow).toHaveTextContent("Recorded cash in$9,999,999,999,999,999.99");
+    expect(cashFlow).toHaveTextContent("Spent$1,234,567,890,123,456.78");
+    expect(cashFlow).toHaveTextContent("Through August 14, 2026");
 
-    const categoriesCard = screen.getByText('Categories with recorded spending').closest('.card')
-    expect(within(categoriesCard).getByText('2')).toBeInTheDocument()
+    const paycheckModule = moduleNamed("Expected paychecks");
+    const paycheckRows = within(paycheckModule).getAllByRole("listitem");
+    expect(paycheckRows).toHaveLength(2);
+    expect(paycheckRows[0]).toHaveTextContent("Payroll A$2,500.00");
+    expect(paycheckRows[1]).toHaveTextContent("Payroll B$9,999,999,999,999,999.99");
+    expect(paycheckModule).toHaveTextContent("Expected, not guaranteed.");
+    expect(paycheckModule).toHaveTextContent("Expected Aug 20, 2026");
+    expect(paycheckModule).toHaveTextContent("Evaluated Sep 5, 2026");
+    expect(paycheckModule).not.toHaveTextContent("Payroll C");
+    expect(paycheckModule).not.toHaveTextContent("Paused payroll");
+    expect(paycheckModule).not.toHaveTextContent("No server projection");
 
-    const attentionCard = screen.getByText('Budget-limit attention').closest('.card')
-    expect(within(attentionCard).getByText('1')).toBeInTheDocument()
-    expect(attentionCard).toHaveTextContent('limit is at or above 90% used · 2 limits set')
-    expect(screen.getByRole('heading', { name: 'Activity', level: 2 })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Plan', level: 2 })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Insights', level: 2 })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Open activity/ })).toHaveAttribute('href', '/transactions')
-    expect(screen.getByRole('link', { name: /Open plan/ })).toHaveAttribute('href', '/plan')
-    expect(screen.getByRole('link', { name: 'Budgets' })).toHaveAttribute('href', '/budgets')
-    expect(screen.getByRole('link', { name: 'Commitments' })).toHaveAttribute('href', '/commitments')
-    expect(screen.getByRole('link', { name: 'Paychecks' })).toHaveAttribute('href', '/paychecks')
-    expect(screen.getByRole('link', { name: /Open insights/ })).toHaveAttribute('href', '/analytics')
-    expect(screen.queryByRole('heading', { name: 'Investing', level: 2 })).not.toBeInTheDocument()
-  })
+    const budgetModule = moduleNamed("Budget attention");
+    expect(within(budgetModule).getAllByRole("listitem")).toHaveLength(3);
+    expect(budgetModule).toHaveTextContent("4 limits are at or above 90% used · 6 limits set");
+    expect(budgetModule).toHaveTextContent("Food90.0% used$90.00 spent of $100.00");
+    expect(budgetModule).not.toHaveTextContent("50.0% used");
+    expect(budgetModule).not.toHaveTextContent("Zero");
+    expect(budgetModule).not.toHaveTextContent("Health");
 
-  it('shows a loading status instead of transient metrics', () => {
-    useExpenses.mockReturnValue({ expenses: [], loading: true })
-    renderPage()
+    const commitmentModule = moduleNamed("Active commitments");
+    expect(commitmentModule).toHaveTextContent("4 active commitments");
+    expect(within(commitmentModule).getAllByRole("listitem")).toHaveLength(3);
+    expect(commitmentModule).toHaveTextContent("Rent plan$9,999,999,999,999,999.99");
+    expect(commitmentModule).toHaveTextContent("Electric plan$75.25–$125.75");
+    expect(commitmentModule).not.toHaveTextContent("Fourth active plan");
+    expect(commitmentModule).not.toHaveTextContent("Paused plan");
 
-    expect(screen.getByText('Loading current-month summary...')).toBeInTheDocument()
-    expect(screen.queryByText('Recorded spending this month')).not.toBeInTheDocument()
-  })
+    const spendingModule = moduleNamed("Recent spending");
+    const spendingRows = within(spendingModule).getAllByRole("listitem");
+    expect(spendingRows).toHaveLength(3);
+    expect(spendingRows.map((row) => within(row).getAllByRole("strong")[0].textContent))
+      .toEqual(["Utilities", "Rent", "Gas"]);
+    expect(spendingModule).toHaveTextContent("This month · Through August 14, 2026");
+    expect(spendingModule).not.toHaveTextContent("Future purchase");
+    expect(spendingModule).not.toHaveTextContent("Last month");
 
-  it('keeps expense metrics useful and explains when no limits exist', () => {
-    useExpenses.mockReturnValue({
-      expenses: [{ category: 'food', amount: 12.34, date: '2026-08-02' }],
-      loading: false,
-    })
-    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
-    renderPage()
+    expect(screen.getByRole("link", { name: /Open activity/ })).toHaveAttribute("href", "/transactions");
+    expect(screen.getByRole("link", { name: /View insights/ })).toHaveAttribute("href", "/analytics");
+    expect(screen.getByRole("link", { name: /All paychecks/ })).toHaveAttribute("href", "/paychecks");
+    expect(screen.getByRole("link", { name: /All budgets/ })).toHaveAttribute("href", "/budgets");
+    expect(screen.getByRole("link", { name: /All commitments/ })).toHaveAttribute("href", "/commitments");
+    expect(screen.getByRole("link", { name: /All spending/ })).toHaveAttribute("href", "/transactions");
 
-    expect(screen.getByText('$12.34')).toBeInTheDocument()
-    expect(screen.getByText('No budget limits are set for this month.')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Set budget limits/ })).toHaveAttribute('href', '/budgets')
-  })
+    expect(cashFlowApi.get).toHaveBeenCalledWith("2026-08", "2026-08-14", expect.any(AbortSignal));
+    expect(budgetLimitsApi.getByMonth).toHaveBeenCalledWith("2026-08");
+    expectReadCounts();
+    [expensesApi.create, expensesApi.update, expensesApi.remove,
+      budgetLimitsApi.upsert, budgetLimitsApi.remove,
+      paychecksApi.getCandidates, paychecksApi.getPaycheck, paychecksApi.confirmCandidate,
+      paychecksApi.dismissCandidate, paychecksApi.reconsiderCandidate, paychecksApi.createPaycheck,
+      paychecksApi.updatePaycheck, paychecksApi.updateLifecycle,
+      commitmentsApi.getCandidates, commitmentsApi.getChanges, commitmentsApi.dismissCandidate,
+      commitmentsApi.reconsiderCandidate, commitmentsApi.confirmCandidate,
+      commitmentsApi.acceptAmountChange, commitmentsApi.acceptTimingChange,
+      commitmentsApi.markEndedFromChange, commitmentsApi.keepChange, commitmentsApi.reconsiderChange,
+      commitmentsApi.updateCommitment, commitmentsApi.updateLifecycle]
+      .forEach((operation) => expect(operation).not.toHaveBeenCalled());
+  });
 
-  it('renders honest zero values and an empty status for an empty month', () => {
-    useExpenses.mockReturnValue({ expenses: [], loading: false })
-    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false })
-    renderPage()
+  it("orders by the supplied server window before ID and renders the projected range instead of the profile amount", async () => {
+    paychecksApi.getPaychecks.mockResolvedValue(response({
+      evaluatedOn: "2026-09-05",
+      paychecks: [
+        {
+          id: "a", displayName: "Later A", lifecycle: "active", schedule: { cadence: "monthly" },
+          amount: { mode: "fixed", fixedAmount: "1.00" },
+          nextProjection: projection("300.00", "2026-08-21"),
+        },
+        {
+          id: "z", displayName: "Earlier Z", lifecycle: "active", schedule: { cadence: "semimonthly" },
+          amount: { mode: "fixed", fixedAmount: "1.00" },
+          nextProjection: {
+            evaluatedOn: "2026-09-05",
+            earliestExpectedDate: "2026-08-18",
+            latestExpectedDate: "2026-08-19",
+            amount: { mode: "range", fixedAmount: null, minimumAmount: "100.25", maximumAmount: "200.75" },
+          },
+        },
+        {
+          id: "b", displayName: "Middle B", lifecycle: "active", schedule: { cadence: "weekly" },
+          amount: { mode: "fixed", fixedAmount: "1.00" },
+          nextProjection: projection("250.00", "2026-08-20"),
+        },
+      ],
+    }));
+    renderPage();
 
-    expect(screen.getByText('No recorded spending or budget limits for this month yet.')).toBeInTheDocument()
-    expect(screen.getByText('$0.00')).toBeInTheDocument()
-    expect(screen.getAllByText('0')).toHaveLength(2)
-  })
-})
+    const module = moduleNamed("Expected paychecks");
+    const rows = await within(module).findAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => within(row).getAllByRole("strong")[0].textContent))
+      .toEqual(["Earlier Z", "Middle B"]);
+    expect(rows[0]).toHaveTextContent("$100.25 – $200.75");
+    expect(rows[0]).toHaveTextContent("Twice a month");
+    expect(rows[0]).toHaveTextContent("Expected Aug 18, 2026 – Aug 19, 2026");
+    expect(module).not.toHaveTextContent("Later A");
+    expect(module).not.toHaveTextContent("$1.00");
+  });
+
+  it.each([
+    ["spending list", () => expensesApi.getAll.mockResolvedValue(response({})), "We couldn’t load spending.", "No spending recorded in this period.", 2],
+    ["budget-limit list", () => budgetLimitsApi.getByMonth.mockResolvedValue(response({})), "We couldn’t load budget limits.", "No budget limits are set for this month.", 1],
+    ["paycheck envelope", () => paychecksApi.getPaychecks.mockResolvedValue(response([])), "We couldn’t load expected paychecks.", "No expected paycheck windows are available.", 1],
+    ["commitment list", () => commitmentsApi.getCommitments.mockResolvedValue(response({})), "We couldn’t load active commitments.", "No active commitments.", 1],
+  ])("treats a malformed %s response as unavailable rather than successfully empty", async (_name, arrange, error, empty, count) => {
+    arrange();
+    renderPage();
+
+    expect(await screen.findAllByText(error)).toHaveLength(count);
+    expect(screen.queryByText(empty)).not.toBeInTheDocument();
+  });
+
+  it("keeps each module unavailable while its independent read is loading", () => {
+    cashFlowApi.get.mockReturnValue(never());
+    expensesApi.getAll.mockReturnValue(never());
+    budgetLimitsApi.getByMonth.mockReturnValue(never());
+    paychecksApi.getPaychecks.mockReturnValue(never());
+    commitmentsApi.getCommitments.mockReturnValue(never());
+    renderPage();
+
+    expect(screen.getByText("Loading recorded cash flow...")).toBeInTheDocument();
+    expect(screen.getByText("Loading expected paychecks...")).toBeInTheDocument();
+    expect(screen.getAllByText("Loading spending...")).toHaveLength(2);
+    expect(screen.getByText("Loading budget limits...")).toBeInTheDocument();
+    expect(screen.getByText("Loading active commitments...")).toBeInTheDocument();
+    expect(screen.queryByText("No expected paycheck windows are available.")).not.toBeInTheDocument();
+    expect(screen.queryByText("No active commitments.")).not.toBeInTheDocument();
+    expect(screen.queryByText("No spending recorded in this period.")).not.toBeInTheDocument();
+  });
+
+  it("keeps cash flow, paychecks, and commitments visible when spending fails, then retries only spending", async () => {
+    expensesApi.getAll.mockRejectedValueOnce(new Error("offline"));
+    renderPage();
+
+    expect(await screen.findAllByText("We couldn’t load spending.")).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" })).toBeInTheDocument();
+    expect(screen.getByText("Payroll A")).toBeInTheDocument();
+    expect(screen.getByText("Rent plan")).toBeInTheDocument();
+    expect(within(moduleNamed("Budget attention")).queryByRole("listitem")).not.toBeInTheDocument();
+    expect(within(moduleNamed("Recent spending")).queryByRole("listitem")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Retry spending" })[0]);
+    await within(moduleNamed("Recent spending")).findByText("Utilities");
+    expectReadCounts({ spending: 2 });
+  });
+
+  it("keeps recent spending visible when budget limits fail, then retries only limits", async () => {
+    budgetLimitsApi.getByMonth.mockRejectedValueOnce(new Error("offline"));
+    renderPage();
+
+    expect(await screen.findByText("We couldn’t load budget limits.")).toBeInTheDocument();
+    expect(within(moduleNamed("Recent spending")).getByText("Utilities")).toBeInTheDocument();
+    expect(within(moduleNamed("Budget attention")).queryByRole("listitem")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry budget limits" }));
+    await within(moduleNamed("Budget attention")).findByText("Food");
+    expectReadCounts({ budgets: 2 });
+  });
+
+  it("keeps other modules visible when expected paychecks fail, then retries only paychecks", async () => {
+    paychecksApi.getPaychecks.mockRejectedValueOnce(new Error("offline"));
+    renderPage();
+
+    expect(await screen.findByText("We couldn’t load expected paychecks.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" })).toBeInTheDocument();
+    expect(screen.getByText("Rent plan")).toBeInTheDocument();
+    expect(within(moduleNamed("Recent spending")).getByText("Utilities")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry expected paychecks" }));
+    await within(moduleNamed("Expected paychecks")).findByText("Payroll A");
+    expectReadCounts({ paycheck: 2 });
+  });
+
+  it("keeps other modules visible when commitments fail, then retries only commitments", async () => {
+    commitmentsApi.getCommitments.mockRejectedValueOnce(new Error("offline"));
+    renderPage();
+
+    expect(await screen.findByText("We couldn’t load active commitments.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recorded cash in vs Spent" })).toBeInTheDocument();
+    expect(screen.getByText("Payroll A")).toBeInTheDocument();
+    expect(within(moduleNamed("Recent spending")).getByText("Utilities")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry active commitments" }));
+    await within(moduleNamed("Active commitments")).findByText("Rent plan");
+    expectReadCounts({ commitment: 2 });
+  });
+
+  it("keeps every secondary module visible when cash flow fails, then retries only cash flow", async () => {
+    cashFlowApi.get.mockRejectedValueOnce(new Error("offline"));
+    renderPage();
+
+    expect(await screen.findByText("We couldn’t load recorded cash flow. Try again.")).toBeInTheDocument();
+    expect(screen.getByText("Payroll A")).toBeInTheDocument();
+    expect(within(moduleNamed("Budget attention")).getByText("Food")).toBeInTheDocument();
+    expect(screen.getByText("Rent plan")).toBeInTheDocument();
+    expect(within(moduleNamed("Recent spending")).getByText("Utilities")).toBeInTheDocument();
+    expect(moduleNamed("Recent spending")).toHaveTextContent("This month · Through August 14, 2026");
+    expect(moduleNamed("Recent spending")).not.toHaveTextContent("Future purchase");
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry cash flow" }));
+    await screen.findByRole("heading", { name: "Recorded cash in vs Spent" });
+    expectReadCounts({ cash: 2 });
+  });
+
+  it("shows successful empty states instead of treating them as failures", async () => {
+    cashFlowApi.get.mockResolvedValue(response(cashFlowData({
+      cashInMinor: "0", paycheckCashInMinor: "0", otherCashInMinor: "0", spentMinor: "0", netMinor: "0",
+    })));
+    expensesApi.getAll.mockResolvedValue(response([]));
+    budgetLimitsApi.getByMonth.mockResolvedValue(response([]));
+    paychecksApi.getPaychecks.mockResolvedValue(response({ evaluatedOn: "2026-09-05", paychecks: [] }));
+    commitmentsApi.getCommitments.mockResolvedValue(response([]));
+    renderPage();
+
+    expect(await screen.findByText("No expected paycheck windows are available.")).toBeInTheDocument();
+    expect(screen.getByText("No budget limits are set for this month.")).toBeInTheDocument();
+    expect(screen.getByText("No active commitments.")).toBeInTheDocument();
+    expect(screen.getByText("No spending recorded in this period.")).toBeInTheDocument();
+    expect(screen.getByText("No cash in recorded")).toBeInTheDocument();
+    expect(screen.getByText("No spending recorded")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expectReadCounts();
+  });
+});

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -78,38 +78,32 @@ summary { min-height: 44px; padding-block: .625rem; cursor: pointer; }
 .investing-capability__status { display: inline-block; margin-bottom: var(--space-3); color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
 .investing-capability h3 { margin-bottom: var(--space-2); font-size: var(--text-lg); }
 .investing-capability p { margin-bottom: 0; color: var(--color-text-muted); }
-.overview-hero { position: relative; grid-column: 1 / -1; min-height: 220px; overflow: hidden; padding: clamp(var(--space-5), 3vw, var(--space-6)); border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); box-shadow: var(--shadow-sm); }
-.overview-hero::after { position: absolute; top: 0; bottom: 0; left: 0; width: 4px; background: var(--color-primary); content: ""; }
-.overview-hero__content { position: relative; z-index: 1; max-width: 720px; }
-.overview-hero__content h1 { font-size: clamp(2.25rem, 5vw, 4rem); }
-.overview-hero__content > p:not(.page-header__eyebrow) { max-width: 640px; color: var(--color-text-muted); font-size: var(--text-lg); }
-.overview-kicker { margin-bottom: var(--space-1); color: var(--color-primary); font-size: var(--text-xs); font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
-.overview-grid { display: grid; overflow-wrap: anywhere; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); }
-.overview-grid > * { min-width: 0; }
-.overview-hero .button-link { max-width: 100%; }
-.overview-summary { grid-column: 1 / -1; }
-.overview-summary__header { margin-bottom: var(--space-3); }
-.overview-summary__header h2 { margin: 0; }
-.overview-metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); }
-.overview-metric { box-shadow: none; }
-.overview-metric__label { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
-.overview-metric__value { margin: var(--space-2) 0; font-size: clamp(1.8rem, 4vw, 2.6rem); font-weight: 900; font-variant-numeric: tabular-nums; }
-.overview-metric__context { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); }
-.overview-metric a { display: inline-block; margin-top: var(--space-3); color: var(--color-primary); font-weight: 800; text-decoration: none; }
-.overview-module { display: flex; min-height: 190px; flex-direction: column; justify-content: space-between; gap: var(--space-4); box-shadow: none; }
-.overview-module__heading { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); color: var(--color-primary); }
-.overview-module__status { color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
-.overview-module h2 { margin: 0 0 var(--space-2); font-size: var(--text-xl); }
-.overview-module p { margin: 0; color: var(--color-text-muted); }
-.overview-module a { color: var(--color-primary); font-weight: 800; text-decoration: none; }
-.overview-module__links { display: flex; flex-wrap: wrap; gap: var(--space-2); }
-.overview-module__links a { display: inline-flex; max-width: 100%; align-items: center; min-height: 44px; padding: var(--space-2) var(--space-3); border: 1px solid var(--color-control-border); border-radius: var(--radius-md); }
-.overview-module__links a:hover { background: var(--color-surface-raised); }
-.overview-module--activity { grid-column: span 2; min-height: 240px; border-color: color-mix(in srgb, var(--color-primary) 34%, var(--color-border)); background: var(--color-surface-raised); }
-.overview-module--activity::after { width: 42px; height: 3px; background: var(--color-primary); content: ""; }
-.overview-module--plan { grid-column: span 1; }
-.overview-module--plan .cluster { align-items: flex-start; flex-direction: column; }
-.overview-module--insights { grid-column: 1 / -1; min-height: 220px; background: var(--color-bg-accent); }
+/* Home composes existing reads without a feature-directory hero. */
+.home-page__header { flex-wrap: wrap; align-items: start; }
+.home-page__header > div { min-width: 0; }
+.home-page__header p { margin-bottom: 0; }
+.home-page { overflow-wrap: anywhere; }
+.home-cash-flow { min-width: 0; }
+.home-cash-flow__actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-3); }
+.home-cash-flow__actions a, .home-module > a { display: inline-flex; align-items: center; gap: var(--space-2); min-height: 44px; max-width: 100%; font-weight: 700; }
+.home-modules { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 23rem), 1fr)); align-items: start; gap: var(--space-4); }
+.home-module { display: flex; min-width: 0; flex-direction: column; gap: var(--space-4); margin-bottom: 0; box-shadow: none; }
+.home-module h2 { margin: 0; }
+.home-module__content { min-width: 0; }
+.home-module__content > :first-child { margin-top: 0; }
+.home-module__content > :last-child { margin-bottom: 0; }
+.home-records { margin: 0; padding: 0; list-style: none; }
+.home-records li { min-width: 0; padding-block: var(--space-3); border-bottom: 1px solid var(--color-divider); }
+.home-records li:first-child { padding-top: 0; }
+.home-records li:last-child { padding-bottom: 0; border-bottom: 0; }
+.home-record__line { display: flex; flex-wrap: wrap; justify-content: space-between; gap: var(--space-1) var(--space-3); font-variant-numeric: tabular-nums; }
+.home-record__line > * { min-width: 0; max-width: 100%; }
+.home-records p { margin: var(--space-1) 0 0; color: var(--color-text-muted); }
+.home-qualification { margin: 0 0 var(--space-3); color: var(--color-text-muted); }
+.home-disclosure { margin-top: var(--space-4); padding-top: var(--space-2); border-top: 1px solid var(--color-divider); }
+.home-disclosure summary { font-weight: 700; }
+.home-disclosure p { color: var(--color-text-muted); }
+.home-read-status { margin-bottom: var(--space-3); }
 .navigation-hub { display: grid; min-width: 0; overflow-wrap: anywhere; gap: var(--space-5); }
 .navigation-hub > .page-header { margin-bottom: 0; }
 .navigation-hub__cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr)); gap: var(--space-4); }
@@ -217,7 +211,7 @@ summary { min-height: 44px; padding-block: .625rem; cursor: pointer; }
 @media (max-width: 600px) { .cash-flow-facts { grid-template-columns: 1fr; } .cash-flow-trend__canvas { height: 270px; } }
 .mt-2 { margin-top: var(--space-4); }
 @media (min-width: 900px) { .mobile-parent-link { display: none; } }
-@media (max-width: 820px) { .overview-grid, .overview-metrics, .settings-grid, .investing-capabilities__grid, .analytics-grid { grid-template-columns: 1fr; } .overview-hero, .overview-summary, .overview-module--activity, .overview-module--plan, .overview-module--insights { grid-column: auto; } .overview-hero, .overview-module--activity { min-height: 220px; } }
+@media (max-width: 820px) { .settings-grid, .investing-capabilities__grid, .analytics-grid { grid-template-columns: 1fr; } }
 @media (max-width: 600px) { .analytics-panel__header { align-items: stretch; flex-direction: column; } .analytics-change-grid { grid-template-columns: 1fr; } }
 @media (max-width: 520px) { .card { padding: var(--space-4); } button:not(.icon-button):not(.password-toggle) { width: 100%; } }
 


### PR DESCRIPTION
## Summary

Related to #127, UX V3 slice 3 of 7. MEDIUM risk under the [approved plan](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563926559), [owner approval](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563943900), and [Home delivery checkpoint](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5573430125). Base main: `1338b22f96b15ca185d80c94e32d06e2deb3b107`.

Home now leads with this month's recorded cash in, spending, and net recorded cash flow, using the existing #126 comparison and disclosure unchanged. Four smaller modules show up to two active server-projected paycheck windows, up to three budget limits meeting the existing 90% attention rule, the active commitment count and up to three saved commitments, and the latest three current-month expenses through the cutoff. Each links to its existing workflow.

The new Home-local read hook consumes only the existing expense, monthly budget-limit, paycheck-list, and commitment-list APIs. Each read has independent loading/error/retry state and hides old data immediately on retry, month, loader, or session changes. Cash flow remains independent of secondary failures. Expense failures make budget attention and recent spending unavailable; failed reads never become empty or zero results. No candidate or commitment-change evaluations run on Home.

Cash totals retain exact integer-cent presentation and come only from the existing cash-flow response. Paycheck windows and amounts come from the existing projection, sorted by window start with an ID tie-break; evaluation dates remain separate from the local cash-flow cutoff. Commitments have no invented next-payment date. The existing guarded decimal formatter preserves commitment string cents and signals unsafe numeric amounts; existing financial utilities and other feature pages are unchanged. The Home budget rule retains exact category grouping, future-day exclusion, and its existing zero-limit behavior.

`PRODUCT_OVERVIEW.md` and the narrow Home architecture description reflect these boundaries. `RECENT_CHANGES.md` remains untouched until all V3 slices complete. The two reported untracked Desktop files remain untouched; work is isolated in `/tmp/ordo-127-v3`.

## Verification

- Focused Home read/page and existing cash-flow regression checks passed: 36 tests.
- Canonical `./scripts/verify.sh frontend` passed on rerun: 48 files / 446 tests, ESLint, and production build. The first run passed 445 tests and failed an unchanged Paychecks focus assertion at `PaychecksPage.test.jsx:215` (Confirm end versus the profiles heading). That file passed 10/10 in isolation, then the full canonical rerun passed without source/test changes. This intermittent failure is disclosed for independent review; no Paychecks code or assertions were altered.
- Isolated localhost browser checks passed using synthetic read-only fixtures: 320/375/768/1280px without document overflow; native keyboard disclosure controls and retained focus; light/dark/system themes and reduced motion; 200% root text, long names, and large values; each independent failure and working retry; loading hides prior cash flow while other modules stay available; successful empty states; Insights navigation/back/forward and main focus. Only the five approved read endpoints were observed. No JavaScript page errors. Screenshots remain private and were inspected locally.
- Manual screen-reader and native browser zoom checks were unavailable locally; root-text resizing and browser keyboard/accessibility structure checks are separate evidence.
- Backend code is unchanged and backend checks were not rerun locally. Disposable local PostgreSQL is unavailable; required Backend and PostgreSQL CI will supply independent evidence.
- Required CI passed on `9779cc0f4f88ea9d80519532df5f99cdc2b9ec77`: [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/34145812240/job/101817492142), [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/34145812243/job/101817492260), and [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/34145812243/job/101817492490).
- Vercel preview deployment succeeded. A credential-free read of the deployed Home route redirected to Vercel login protection, so deployed-page smoke verification was unavailable; no real-account authentication or bypass was used.

## Scope and review

Context expansion was limited to the existing feature list DTOs/order, presentation formatters, current Home budget/date selectors, and session read-lifecycle contracts. Backend DTO inspection established the precise paycheck envelope and commitment list fields; no backend edits were needed.

No new API/contracts, schema/migrations, dependencies, detector/projector rules, authentication behavior, or production operations. No Safe-to-Spend, bank balance, commitment forecast, or combined transaction feed. Rollback is a reviewed revert of this frontend/documentation slice without data operations.

Independent command-center review of the actual PR, discussion, and final CI remains required. Codex has not approved or merged this PR.
