### PR TITLE
Simplify Paychecks with active expectations and accessible Details (V3 slice 4)

### DIFF
--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -35,11 +35,13 @@ silently treating every detected pattern as a financial fact.
   expectations, and manage active, paused, or ended commitments. Change reviews
   surface supported amount or timing changes and payments not seen recently;
   accepting a change remains your decision.
-- **Paychecks:** Review possible recurring deposit patterns or create an expected
-  paycheck profile manually. Profiles support several pay schedules, fixed
-  amounts or accepted ranges, and active, paused, or ended status. Active profiles
-  can show the next expected payment window. These are expectations, not
-  guaranteed deposits or employer-verified earnings.
+- **Paychecks:** See active saved expectations first, with expected amounts and
+  the next available payment window, then review possible recurring deposits.
+  Add a paycheck manually or manage existing profiles; paused, ended, and
+  dismissed items sit in expandable groups. Card Details reveal linked records
+  and schedule information. Profiles support several pay schedules and fixed
+  amounts or accepted ranges. These are expectations, not guaranteed deposits
+  or employer-verified earnings.
 - **Insights / Analytics:** Compare recorded cash in with spending for a selected
   month and see the difference as net recorded cash flow. Explore a six-month
   trend and ranked spending categories, with budget usage, month-over-month

--- a/frontend/src/features/paychecks/components/PaycheckEvidence.jsx
+++ b/frontend/src/features/paychecks/components/PaycheckEvidence.jsx
@@ -1,24 +1,35 @@
 import { formatDate, formatMoney } from "../utils/formatPaychecks";
 
-export default function PaycheckEvidence({ evidence = [], confirmed = false }) {
+export default function PaycheckEvidence({ evidence = [], confirmed = false, disclosure = true }) {
   if (!evidence.length) return <p className="muted">No linked deposit evidence. This is your saved expectation.</p>;
+
+  const records = (
+    <ul className="paycheck-evidence__list">
+      {evidence.map((row) => (
+        <li key={row.accountInflowId} className="paycheck-evidence__row">
+          <div>
+            <strong>{row.description}</strong>
+            <span><time dateTime={row.postedDate}>{formatDate(row.postedDate)}</time> · {row.source === "imported" ? "Imported deposit" : "Manual deposit"}</span>
+            <span>Schedule date {formatDate(row.slotAnchor)} · {row.timingOffsetDays === 0 ? "On schedule date" : `${Math.abs(row.timingOffsetDays)} day(s) ${row.timingOffsetDays < 0 ? "before" : "after"}`}</span>
+            {confirmed && row.editedSinceConfirmation && <span className="paycheck-evidence__edited">Edited since confirmation. The saved expectation is unchanged.</span>}
+          </div>
+          <strong>{formatMoney(row.amount)}</strong>
+        </li>
+      ))}
+    </ul>
+  );
+
+  if (!disclosure) return (
+    <section className="paycheck-evidence paycheck-evidence--inline">
+      <h4>{confirmed ? "Records used to confirm" : "Deposits to review"} ({evidence.length})</h4>
+      {records}
+    </section>
+  );
 
   return (
     <details className="paycheck-evidence">
       <summary>{confirmed ? "Linked deposit evidence" : "Review every deposit"} ({evidence.length})</summary>
-      <ul className="paycheck-evidence__list">
-        {evidence.map((row) => (
-          <li key={row.accountInflowId} className="paycheck-evidence__row">
-            <div>
-              <strong>{row.description}</strong>
-              <span><time dateTime={row.postedDate}>{formatDate(row.postedDate)}</time> · {row.source === "imported" ? "Imported deposit" : "Manual deposit"}</span>
-              <span>Schedule date {formatDate(row.slotAnchor)} · {row.timingOffsetDays === 0 ? "On schedule date" : `${Math.abs(row.timingOffsetDays)} day(s) ${row.timingOffsetDays < 0 ? "before" : "after"}`}</span>
-              {confirmed && row.editedSinceConfirmation && <span className="paycheck-evidence__edited">Edited since confirmation. The saved expectation is unchanged.</span>}
-            </div>
-            <strong>{formatMoney(row.amount)}</strong>
-          </li>
-        ))}
-      </ul>
+      {records}
     </details>
   );
 }

--- a/frontend/src/features/paychecks/pages/PaychecksPage.jsx
+++ b/frontend/src/features/paychecks/pages/PaychecksPage.jsx
@@ -5,13 +5,12 @@ import StatusMessage from "../../../shared/ui/StatusMessage";
 import PaycheckEvidence from "../components/PaycheckEvidence";
 import PaycheckForm from "../components/PaycheckForm";
 import { usePaychecks } from "../hooks/usePaychecks";
-import { formatAmount, formatDate, formatMoney, formatSchedule, formatWindow } from "../utils/formatPaychecks";
+import { cadenceLabel, formatAmount, formatDate, formatMoney, formatSchedule, formatWindow } from "../utils/formatPaychecks";
 
-const LIFECYCLES = ["active", "paused", "ended"];
 const LIFECYCLE_LABELS = { active: "Active", paused: "Paused", ended: "Ended" };
 const STALE_CODES = new Set(["candidate_changed", "candidate_dismissed", "confirmation_conflict", "paycheck_not_found"]);
 
-function CandidateCard({ candidate, dismissed, busy, editor, onReview, onCancel, onConfirm, onDecision }) {
+function CandidateCard({ candidate, dismissed, evaluatedOn, busy, actionsDisabled, editor, onReview, onCancel, onConfirm, onDecision }) {
   const name = candidate.normalizedDescriptionIdentity;
   const reviewing = editor?.mode === "confirm" && editor.key === candidate.fingerprint;
   const observed = candidate.observedAmount;
@@ -19,31 +18,38 @@ function CandidateCard({ candidate, dismissed, busy, editor, onReview, onCancel,
     <Card as="article" className="paycheck-card">
       <header className="paycheck-card__header">
         <div>
-          <p className="paycheck-eyebrow">{dismissed ? "Dismissed candidate" : "Possible paycheck"}</p>
+          {dismissed && <p className="paycheck-status">Dismissed possible paycheck</p>}
           <h3>{name}</h3>
-          <p className="muted">{formatSchedule(candidate.schedule)}</p>
+          <p className="muted">{cadenceLabel(candidate.schedule.cadence)}</p>
         </div>
         <div className="paycheck-card__amount">
           <span>Observed deposits</span>
           <strong>{observed.mode === "fixed" ? formatMoney(observed.fixedAmount) : `${formatMoney(observed.minimumAmount)}–${formatMoney(observed.maximumAmount)}`}</strong>
         </div>
       </header>
-      <dl className="paycheck-facts">
-        <div><dt>Evidence</dt><dd>{candidate.occurrenceCount} deposits · {formatDate(candidate.coveredFrom)}–{formatDate(candidate.coveredTo)}</dd></div>
-        <div><dt>Observed timing</dt><dd>{formatWindow(candidate.windowBeforeDays, candidate.windowAfterDays)}</dd></div>
-        <div><dt>Observed amounts</dt><dd>{observed.mode === "fixed" ? "The same amount in each deposit" : `Variable · lower median ${formatMoney(observed.lowerMedianAmount)}. This history is not an accepted range.`}</dd></div>
-      </dl>
-      <PaycheckEvidence evidence={candidate.evidence} />
+      <p className="paycheck-candidate-count">Based on {candidate.occurrenceCount} deposits{observed.mode !== "fixed" && ". Observed history, not an accepted range."}</p>
+      <details className="paycheck-details">
+        <summary aria-label={`Details for ${name}`}>Details</summary>
+        <dl className="paycheck-facts">
+          <div><dt>Schedule</dt><dd>{formatSchedule(candidate.schedule)}</dd></div>
+          <div><dt>Records covered</dt><dd>{formatDate(candidate.coveredFrom)}–{formatDate(candidate.coveredTo)}</dd></div>
+          <div><dt>Observed timing</dt><dd>{formatWindow(candidate.windowBeforeDays, candidate.windowAfterDays)}</dd></div>
+          <div><dt>Observed amounts</dt><dd>{observed.mode === "fixed" ? "The same amount in each deposit" : `Variable · lower median ${formatMoney(observed.lowerMedianAmount)}. This history is not an accepted range.`}</dd></div>
+          {evaluatedOn && <div><dt>Evaluated</dt><dd>{formatDate(evaluatedOn)}</dd></div>}
+          <div><dt>Detection details</dt><dd>{candidate.algorithmVersion}</dd></div>
+        </dl>
+        <PaycheckEvidence evidence={candidate.evidence} disclosure={false} />
+      </details>
       {reviewing ? (
         <PaycheckForm key={candidate.fingerprint} mode="confirm" model={editor.model} busy={busy} onSubmit={onConfirm} onCancel={onCancel} />
       ) : (
         <div className="inline-actions paycheck-actions">
           {dismissed ? (
-            <button type="button" disabled={busy} onClick={() => onDecision(candidate, true)} aria-label={`Reconsider ${name}`}>Reconsider</button>
+            <button type="button" disabled={actionsDisabled} onClick={() => onDecision(candidate, true)} aria-label={`Reconsider ${name}`}>Reconsider</button>
           ) : (
             <>
-              <button type="button" disabled={busy} onClick={(event) => onReview(candidate, event.currentTarget)} aria-label={`Review and confirm ${name}`}>Review and confirm</button>
-              <button type="button" className="button-ghost" disabled={busy} onClick={() => onDecision(candidate, false)} aria-label={`Dismiss ${name}`}>Dismiss</button>
+              <button type="button" disabled={actionsDisabled} onClick={(event) => onReview(candidate, event.currentTarget)} aria-label={`Review and confirm ${name}`}>Review and confirm</button>
+              <button type="button" className="button-ghost" disabled={actionsDisabled} onClick={() => onDecision(candidate, false)} aria-label={`Dismiss ${name}`}>Dismiss</button>
             </>
           )}
         </div>
@@ -52,8 +58,8 @@ function CandidateCard({ candidate, dismissed, busy, editor, onReview, onCancel,
   );
 }
 
-function ProfileCard({ profile, busy, editor, onEdit, onCancel, onSave, onLifecycle }) {
-  const [ending, setEnding] = useState(false);
+function ProfileCard({ profile, evaluatedOn, busy, actionsDisabled, ending, onEndingChange, editor, onEdit, onCancel, onSave, onLifecycle }) {
+  const detailsRef = useRef(null);
   const endTrigger = useRef(null);
   const endConfirm = useRef(null);
   const editing = editor?.mode === "edit" && editor.key === profile.id;
@@ -65,56 +71,70 @@ function ProfileCard({ profile, busy, editor, onEdit, onCancel, onSave, onLifecy
 
   async function end() {
     const result = await onLifecycle(profile.id, "ended");
-    if (result?.ok) setEnding(false);
+    if (result?.ok) onEndingChange(null);
   }
 
   return (
     <Card as="article" className={`paycheck-card paycheck-card--${profile.lifecycle}`}>
       <header className="paycheck-card__header">
         <div>
-          <p className="paycheck-eyebrow">{LIFECYCLE_LABELS[profile.lifecycle]} · {profile.source === "manual" ? "Entered by you" : "Confirmed from deposits"}</p>
+          <p className="paycheck-status">{LIFECYCLE_LABELS[profile.lifecycle]}</p>
           <h3>{profile.displayName}</h3>
-          <p className="muted">{formatSchedule(profile.schedule)}</p>
+          <p className="muted">{cadenceLabel(profile.schedule.cadence)}</p>
         </div>
-        <div className="paycheck-card__amount"><span>Accepted expectation</span><strong>{formatAmount(profile.amount)}</strong></div>
+        <div className="paycheck-card__amount"><span>Expected amount</span><strong>{formatAmount(profile.amount)}</strong></div>
       </header>
       {projection ? (
         <div className="paycheck-projection">
-          <p className="paycheck-eyebrow">Next expected paycheck</p>
+          <p className="muted">Next expected window</p>
           <p className="paycheck-projection__date">{formatDate(projection.earliestExpectedDate)}{projection.earliestExpectedDate !== projection.latestExpectedDate && `–${formatDate(projection.latestExpectedDate)}`}</p>
-          <p>{formatAmount(projection.amount)} · schedule date {formatDate(projection.anchor)}</p>
-          <p className="muted">Expected based on your confirmed pattern; payment is not guaranteed. Evaluated {formatDate(projection.evaluatedOn)}.</p>
+          <p>Expected, not guaranteed.</p>
         </div>
       ) : (
-        <p className="paycheck-inactive">{profile.lifecycle === "active" ? "No expected projection is available." : `${LIFECYCLE_LABELS[profile.lifecycle]} profiles have no active payment projection.`}</p>
+        <p className="paycheck-inactive">{profile.lifecycle === "active" ? "No expected window is available. Expected, not guaranteed." : `${LIFECYCLE_LABELS[profile.lifecycle]} paychecks have no active expected window.`}</p>
       )}
-      <dl className="paycheck-facts">
-        <div><dt>Accepted timing window</dt><dd>{formatWindow(profile.windowBeforeDays, profile.windowAfterDays)}</dd></div>
-        <div><dt>Confirmation evidence</dt><dd>{profile.evidence.length} linked deposit(s)</dd></div>
-      </dl>
-      <PaycheckEvidence evidence={profile.evidence} confirmed />
+      <details ref={detailsRef} className="paycheck-details">
+        <summary aria-label={`Details for ${profile.displayName}`}>Details</summary>
+        <dl className="paycheck-facts">
+          <div><dt>Source</dt><dd>{profile.source === "manual" ? "Entered by you" : "Confirmed from deposits"}</dd></div>
+          {profile.origin?.algorithmVersion && <div><dt>Detection details</dt><dd>{profile.origin.algorithmVersion}</dd></div>}
+          <div><dt>Schedule</dt><dd>{formatSchedule(profile.schedule)}</dd></div>
+          <div><dt>Expected date window</dt><dd>{formatWindow(profile.windowBeforeDays, profile.windowAfterDays)}</dd></div>
+          <div><dt>Records used to confirm</dt><dd>{profile.evidence.length} linked deposit(s)</dd></div>
+          {evaluatedOn && <div><dt>Profiles evaluated</dt><dd>{formatDate(evaluatedOn)}</dd></div>}
+          {projection && <>
+            <div><dt>Projection amount</dt><dd>{formatAmount(projection.amount)}</dd></div>
+            <div><dt>Schedule date</dt><dd>{formatDate(projection.anchor)}</dd></div>
+            <div><dt>Projection evaluated</dt><dd>{formatDate(projection.evaluatedOn)}</dd></div>
+            <div><dt>Projection details</dt><dd>{projection.algorithmVersion}</dd></div>
+          </>}
+        </dl>
+        <PaycheckEvidence evidence={profile.evidence} confirmed disclosure={false} />
+        <p className="muted paycheck-schedule-note">To change this schedule, end this profile and create or confirm a replacement. Linked evidence stays with this profile.</p>
+        {!editing && !ending && <div className="inline-actions paycheck-actions">
+          {profile.lifecycle === "ended" && <button type="button" className="button-ghost" disabled={actionsDisabled} onClick={() => onLifecycle(profile.id, "paused")} aria-label={`Pause ${profile.displayName}`}>Pause</button>}
+          {profile.lifecycle !== "ended" && <button ref={endTrigger} type="button" className="button-ghost" disabled={actionsDisabled} onClick={() => onEndingChange({ id: profile.id, lifecycle: profile.lifecycle })} aria-label={`End ${profile.displayName}`}>End</button>}
+        </div>}
+      </details>
       {editing ? (
         <PaycheckForm key={profile.id} mode="edit" model={editor.model} busy={busy} onSubmit={(payload) => onSave(profile.id, payload)} onCancel={onCancel} />
+      ) : ending ? (
+        <div className="paycheck-end-confirmation" role="group" aria-label={`End ${profile.displayName}`}>
+          <p>End {profile.displayName}? Its projection will stop. The profile and linked evidence will remain, and you can reactivate it.</p>
+          <div className="inline-actions">
+            <button ref={endConfirm} type="button" disabled={busy} onClick={end}>Confirm end</button>
+            <button type="button" className="button-ghost" disabled={busy} onClick={() => { onEndingChange(null); if (detailsRef.current) detailsRef.current.open = true; requestAnimationFrame(() => endTrigger.current?.focus()); }}>Cancel ending</button>
+          </div>
+        </div>
       ) : (
-        <>
-          <p className="muted paycheck-schedule-note">To change this schedule, end this profile and create or confirm a replacement. Linked evidence stays with this profile.</p>
-          {ending ? (
-            <div className="paycheck-end-confirmation" role="group" aria-label={`End ${profile.displayName}`}>
-              <p>End {profile.displayName}? Its projection will stop. The profile and linked evidence will remain, and you can reactivate it.</p>
-              <div className="inline-actions">
-                <button ref={endConfirm} type="button" disabled={busy} onClick={end}>Confirm end</button>
-                <button type="button" className="button-ghost" disabled={busy} onClick={() => { setEnding(false); requestAnimationFrame(() => endTrigger.current?.focus()); }}>Cancel ending</button>
-              </div>
-            </div>
+        <div className="inline-actions paycheck-actions">
+          <button type="button" className="button-ghost" disabled={actionsDisabled} onClick={(event) => onEdit(profile, event.currentTarget)} aria-label={`Edit ${profile.displayName}`}>Edit</button>
+          {profile.lifecycle !== "active" ? (
+            <button type="button" disabled={actionsDisabled} onClick={() => onLifecycle(profile.id, "active")} aria-label={`Reactivate ${profile.displayName}`}>Reactivate</button>
           ) : (
-            <div className="inline-actions paycheck-actions">
-              <button type="button" className="button-ghost" disabled={busy} onClick={(event) => onEdit(profile, event.currentTarget)} aria-label={`Edit ${profile.displayName}`}>Edit expectation</button>
-              {profile.lifecycle !== "active" && <button type="button" disabled={busy} onClick={() => onLifecycle(profile.id, "active")} aria-label={`Reactivate ${profile.displayName}`}>Reactivate</button>}
-              {profile.lifecycle !== "paused" && <button type="button" className="button-ghost" disabled={busy} onClick={() => onLifecycle(profile.id, "paused")} aria-label={`Pause ${profile.displayName}`}>Pause</button>}
-              {profile.lifecycle !== "ended" && <button ref={endTrigger} type="button" className="button-ghost" disabled={busy} onClick={() => setEnding(true)} aria-label={`End ${profile.displayName}`}>End</button>}
-            </div>
+            <button type="button" className="button-ghost" disabled={actionsDisabled} onClick={() => onLifecycle(profile.id, "paused")} aria-label={`Pause ${profile.displayName}`}>Pause</button>
           )}
-        </>
+        </div>
       )}
     </Card>
   );
@@ -123,15 +143,24 @@ function ProfileCard({ profile, busy, editor, onEdit, onCancel, onSave, onLifecy
 export default function PaychecksPage() {
   const state = usePaychecks();
   const [editor, setEditor] = useState(null);
+  const [endingTarget, setEndingTarget] = useState(null);
+  const [historyOpen, setHistoryOpen] = useState({ paused: false, ended: false, dismissed: false });
   const editorTrigger = useRef(null);
   const editorLocation = useRef(null);
   const profilesHeading = useRef(null);
   const candidatesHeading = useRef(null);
-  const dismissedHeading = useRef(null);
+  const dismissedSummary = useRef(null);
   const feedback = useRef(null);
   const busy = Boolean(state.busyKey) || state.loading || state.refreshing;
+  const actionsDisabled = busy || Boolean(editor) || endingTarget !== null;
   const hasContent = state.paychecks.length + state.candidates.length + state.dismissedCandidates.length > 0;
   const showContent = hasContent || (!state.loading && !state.loadError);
+
+  useEffect(() => {
+    // Match the former card-local confirmation lifetime when a refresh removes
+    // the profile or moves it to another group; same-card refreshes keep it open.
+    if (endingTarget && !state.paychecks.some((profile) => profile.id === endingTarget.id && profile.lifecycle === endingTarget.lifecycle)) setEndingTarget(null);
+  }, [endingTarget, state.paychecks]);
 
   function focus(ref) {
     requestAnimationFrame(() => ref.current?.focus());
@@ -173,24 +202,40 @@ export default function PaychecksPage() {
   async function decide(candidate, reconsider) {
     const tuple = { algorithmVersion: candidate.algorithmVersion, cadence: candidate.schedule.cadence, fingerprint: candidate.fingerprint };
     const result = await (reconsider ? state.reconsiderCandidate(tuple) : state.dismissCandidate(tuple));
-    focus(result?.ok ? (reconsider ? candidatesHeading : dismissedHeading) : feedback);
+    if (result?.ok && !reconsider) setHistory("dismissed", true);
+    focus(result?.ok ? (reconsider ? candidatesHeading : dismissedSummary) : feedback);
   }
 
   async function lifecycle(id, value) {
     const result = await state.updateLifecycle(id, value);
-    focus(result?.ok ? profilesHeading : feedback);
+    if (result?.ok && value !== "active") setHistoryOpen((current) => ({ ...current, [value]: true }));
+    // These targets remain mounted. Delayed focus could steal focus from a
+    // subsequent End confirmation opened after the lifecycle read completes.
+    (result?.ok ? profilesHeading : feedback).current?.focus();
     return result;
   }
+
+  function setHistory(kind, open) {
+    setHistoryOpen((current) => current[kind] === open ? current : { ...current, [kind]: open });
+  }
+
+  function profileCard(profile) {
+    return <ProfileCard key={profile.id} profile={profile} evaluatedOn={state.paychecksEvaluatedOn}
+      busy={busy} actionsDisabled={actionsDisabled} ending={endingTarget?.id === profile.id && endingTarget.lifecycle === profile.lifecycle} onEndingChange={setEndingTarget}
+      editor={editor} onEdit={(model, trigger) => openEditor("edit", model, trigger)} onCancel={cancelEditor}
+      onSave={(id, payload) => submit(() => state.updatePaycheck(id, payload))} onLifecycle={lifecycle} />;
+  }
+
+  const activeProfiles = state.paychecks.filter((profile) => profile.lifecycle === "active");
 
   return (
     <div className="container paychecks-page">
       <header className="page-header">
         <div>
-          <p className="page-header__eyebrow">Plan around your pay</p>
           <h1>Paychecks</h1>
-          <p className="muted">Review recurring deposits and save the paycheck expectations you choose.</p>
+          <p className="muted">Manage expected pay and review possible paychecks.</p>
         </div>
-        <button type="button" className="paycheck-create" disabled={busy || Boolean(state.loadError) || state.uncertainCreate} onClick={(event) => openEditor("manual", null, event.currentTarget)}>
+        <button type="button" className="paycheck-create" disabled={actionsDisabled || Boolean(state.loadError) || state.uncertainCreate} onClick={(event) => openEditor("manual", null, event.currentTarget)}>
           <Plus size={18} aria-hidden="true" /> Add paycheck manually
         </button>
       </header>
@@ -218,34 +263,46 @@ export default function PaychecksPage() {
         <>
           <section className="paycheck-section" aria-labelledby="paycheck-profiles-heading" aria-busy={Boolean(state.busyKey)}>
             <header className="paycheck-section__header">
-              <div><h2 id="paycheck-profiles-heading" ref={profilesHeading} tabIndex={-1}>Your paychecks</h2><p className="muted">Saved expectations, kept separate from unconfirmed deposit patterns.</p></div>
-              {state.paychecksEvaluatedOn && <p className="paycheck-evaluated">Evaluated {formatDate(state.paychecksEvaluatedOn)}</p>}
+              <h2 id="paycheck-profiles-heading" ref={profilesHeading} tabIndex={-1}>Your paychecks</h2>
             </header>
-            {state.paychecks.length === 0 ? (
-              <div className="paycheck-empty"><WalletCards size={28} aria-hidden="true" /><h3>No paycheck profiles yet</h3><p>Review a candidate below or add an expectation manually. A deposit alone is not a confirmed paycheck.</p></div>
-            ) : LIFECYCLES.map((lifecycleValue) => {
-              const profiles = state.paychecks.filter((profile) => profile.lifecycle === lifecycleValue);
-              return profiles.length > 0 && (
-                <div key={lifecycleValue} className="paycheck-group" role="group" aria-label={`${LIFECYCLE_LABELS[lifecycleValue]} paychecks`}>
-                  <p className="paycheck-group__label">{LIFECYCLE_LABELS[lifecycleValue]} <span>{profiles.length}</span></p>
-                  {profiles.map((profile) => <ProfileCard key={profile.id} profile={profile} busy={busy} editor={editor} onEdit={(model, trigger) => openEditor("edit", model, trigger)} onCancel={cancelEditor} onSave={(id, payload) => submit(() => state.updatePaycheck(id, payload))} onLifecycle={lifecycle} />)}
-                </div>
-              );
-            })}
+            {activeProfiles.length === 0 ? (
+              <div className="paycheck-empty"><WalletCards size={28} aria-hidden="true" /><h3>{state.paychecks.length === 0 ? "No paycheck profiles yet" : "No active paychecks"}</h3><p>Review a possible paycheck below or add an expectation manually. A deposit alone is not a confirmed paycheck.</p></div>
+            ) : (
+              <div className="paycheck-group" role="group" aria-label="Active paychecks">
+                {activeProfiles.map(profileCard)}
+              </div>
+            )}
           </section>
 
           <section className="paycheck-section" aria-labelledby="paycheck-candidates-heading">
             <header className="paycheck-section__header">
-              <div><h2 id="paycheck-candidates-heading" ref={candidatesHeading} tabIndex={-1}>Candidates to review</h2><p className="muted">These deposits may form a paycheck pattern. Review the evidence before accepting an expectation.</p></div>
-              {state.candidatesEvaluatedOn && <p className="paycheck-evaluated">Evaluated {formatDate(state.candidatesEvaluatedOn)}</p>}
+              <div><h2 id="paycheck-candidates-heading" ref={candidatesHeading} tabIndex={-1}>Possible paychecks</h2><p className="muted">Review the deposits before confirming an expectation.</p></div>
+              {state.candidates.length > 0 && <p className="muted">{state.candidates.length} to review</p>}
             </header>
-            {state.candidates.length === 0 ? <p className="paycheck-empty">No paycheck candidates need review. You can still add a manual expectation.</p> : state.candidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} busy={busy} editor={editor} onReview={(model, trigger) => openEditor("confirm", model, trigger)} onCancel={cancelEditor} onConfirm={(payload) => submit(() => state.confirmCandidate(payload))} onDecision={decide} />)}
+            {state.candidates.length === 0 ? <p className="paycheck-empty">No possible paychecks need review. You can still add a manual expectation.</p> : state.candidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} evaluatedOn={state.candidatesEvaluatedOn} busy={busy} actionsDisabled={actionsDisabled} editor={editor} onReview={(model, trigger) => openEditor("confirm", model, trigger)} onCancel={cancelEditor} onConfirm={(payload) => submit(() => state.confirmCandidate(payload))} onDecision={decide} />)}
           </section>
 
-          <section className="paycheck-section" aria-labelledby="paycheck-dismissed-heading">
-            <header><h2 id="paycheck-dismissed-heading" ref={dismissedHeading} tabIndex={-1}>Dismissed candidates</h2><p className="muted">Dismissal applies to the exact evidence reviewed. Reconsider a candidate to review it again.</p></header>
-            {state.dismissedCandidates.length === 0 ? <p className="muted">No dismissed candidates.</p> : state.dismissedCandidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} dismissed busy={busy} onDecision={decide} />)}
-          </section>
+          {["paused", "ended"].map((kind) => {
+            const profiles = state.paychecks.filter((profile) => profile.lifecycle === kind);
+            const locked = profiles.some((profile) => (endingTarget?.id === profile.id && endingTarget.lifecycle === profile.lifecycle) || (editor?.mode === "edit" && editor.key === profile.id) || state.busyKey === `lifecycle:${profile.id}`);
+            return profiles.length > 0 && (
+              <details key={kind} className="paycheck-history" open={historyOpen[kind] || locked} onToggle={(event) => { if (!locked) setHistory(kind, event.currentTarget.open); }}>
+                <summary aria-disabled={locked || undefined} onClick={(event) => { if (locked) event.preventDefault(); }}><h2>{LIFECYCLE_LABELS[kind]} paychecks <span>({profiles.length})</span></h2></summary>
+                <div className="paycheck-history__content paycheck-group" role="group" aria-label={`${LIFECYCLE_LABELS[kind]} paychecks`}>
+                  {locked && <p className="muted paycheck-history-note">Finish or cancel the open action before closing this group.</p>}
+                  {profiles.map(profileCard)}
+                </div>
+              </details>
+            );
+          })}
+
+          <details className="paycheck-history" open={historyOpen.dismissed || state.busyKey?.startsWith("reconsider:")} onToggle={(event) => { if (!state.busyKey?.startsWith("reconsider:")) setHistory("dismissed", event.currentTarget.open); }}>
+            <summary ref={dismissedSummary} aria-disabled={state.busyKey?.startsWith("reconsider:") || undefined} onClick={(event) => { if (state.busyKey?.startsWith("reconsider:")) event.preventDefault(); }}><h2 id="paycheck-dismissed-heading">Dismissed possible paychecks <span>({state.dismissedCandidates.length})</span></h2></summary>
+            <div className="paycheck-history__content">
+              <p className="muted">Dismissal applies to the exact evidence reviewed. Reconsider a possible paycheck to review it again.</p>
+              {state.dismissedCandidates.length === 0 ? <p className="muted">No dismissed possible paychecks.</p> : state.dismissedCandidates.map((candidate) => <CandidateCard key={candidate.fingerprint} candidate={candidate} evaluatedOn={state.candidatesEvaluatedOn} dismissed busy={busy} actionsDisabled={actionsDisabled} onDecision={decide} />)}
+            </div>
+          </details>
         </>
       )}
     </div>

--- a/frontend/src/features/paychecks/pages/PaychecksPage.test.jsx
+++ b/frontend/src/features/paychecks/pages/PaychecksPage.test.jsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PaychecksPage from "./PaychecksPage";
 import { paychecksApi } from "../api/paychecksApi";
 import { makeCandidate, makeCandidateResponse, makePaycheck, makePaychecksResponse } from "../test/paycheckFixtures";
@@ -13,6 +13,9 @@ vi.mock("../api/paychecksApi", () => ({ paychecksApi: {
 const response = (data) => ({ data });
 const deferred = () => { let resolve, reject; const promise = new Promise((yes, no) => { resolve = yes; reject = no; }); return { promise, resolve, reject }; };
 const card = (name) => screen.getByRole("heading", { name, exact: true }).closest("article");
+const disclosure = (name) => screen.getByLabelText(name).closest("details");
+const historyHeading = (name) => screen.getByRole("heading", { level: 2, name: new RegExp(`^${name} \\(\\d+\\)$`) });
+const history = (name) => historyHeading(name).closest("details");
 
 function loadState({ candidates = [makeCandidate()], dismissedCandidates = [], paychecks = [makePaycheck()] } = {}) {
   paychecksApi.getCandidates.mockResolvedValue(response(makeCandidateResponse({ candidates, dismissedCandidates })));
@@ -42,8 +45,13 @@ beforeEach(() => {
   paychecksApi.updateLifecycle.mockResolvedValue(response(makePaycheck()));
 });
 
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+});
+
 describe("Paychecks page", () => {
   it("separates lifecycle/candidate groups, exact evidence and evaluation dates; projects only active profiles", async () => {
+    const user = userEvent.setup();
     const active = makePaycheck();
     active.evidence[0].editedSinceConfirmation = true;
     const paused = makePaycheck({ id: "22222222-2222-2222-2222-222222222222", displayName: "Paused pay", lifecycle: "paused" });
@@ -52,19 +60,135 @@ describe("Paychecks page", () => {
     loadState({ paychecks: [active, paused, ended], dismissedCandidates: [dismissed] });
     paychecksApi.getCandidates.mockResolvedValue(response(makeCandidateResponse({ evaluatedOn: "2026-07-13", dismissedCandidates: [dismissed] })));
     await renderPage();
-    expect(screen.getByText("Evaluated Jul 12, 2026")).toBeInTheDocument();
-    expect(screen.getByText("Evaluated Jul 13, 2026")).toBeInTheDocument();
-    for (const lifecycle of ["Active", "Paused", "Ended"]) expect(screen.getByRole("group", { name: `${lifecycle} paychecks` })).toBeInTheDocument();
-    expect(screen.getAllByText(/Expected based on your confirmed pattern; payment is not guaranteed/)).toHaveLength(1);
-    expect(screen.getByText("Paused profiles have no active payment projection.")).toBeInTheDocument();
-    expect(screen.getByText("Ended profiles have no active payment projection.")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Active paychecks" })).toBeInTheDocument();
+    expect(history("Paused paychecks")).not.toHaveAttribute("open");
+    expect(history("Ended paychecks")).not.toHaveAttribute("open");
+    await user.click(historyHeading("Paused paychecks").closest("summary"));
+    await user.click(historyHeading("Ended paychecks").closest("summary"));
+    expect(history("Dismissed possible paychecks")).not.toHaveAttribute("open");
+    await user.click(historyHeading("Dismissed possible paychecks").closest("summary"));
+    expect(screen.getByRole("group", { name: "Paused paychecks" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Ended paychecks" })).toBeInTheDocument();
+    expect(screen.getAllByText("Expected, not guaranteed.")).toHaveLength(1);
+    expect(screen.getByText("Paused paychecks have no active expected window.")).toBeInTheDocument();
+    expect(screen.getByText("Ended paychecks have no active expected window.")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "old payroll" })).toBeInTheDocument();
     const profile = within(card("Acme Payroll"));
-    await userEvent.setup().click(profile.getByText("Linked deposit evidence (3)"));
+    expect(profile.getByText("Active")).toBeVisible();
+    expect(profile.getByText("Expected amount")).toBeVisible();
+    expect(profile.getAllByText("$2,500.00").length).toBeGreaterThan(0);
+    expect(profile.getByText("Monthly")).toBeVisible();
+    expect(profile.getByText("Aug 9, 2026–Aug 11, 2026")).toBeVisible();
+    expect(profile.getByRole("button", { name: "Edit Acme Payroll" })).toBeVisible();
+    expect(profile.getByRole("button", { name: "Pause Acme Payroll" })).toBeVisible();
+    expect(profile.getByText("Confirmed from deposits")).not.toBeVisible();
+    expect(disclosure("Details for Acme Payroll")).not.toHaveAttribute("open");
+    expect(profile.getByLabelText("Details for Acme Payroll")).toHaveProperty("tabIndex", 0);
+    await user.click(profile.getByLabelText("Details for Acme Payroll"));
+    expect(profile.getByText("Schedule").closest("div")).toHaveTextContent("Monthly, day 10");
+    expect(profile.getByText("Profiles evaluated").closest("div")).toHaveTextContent("Jul 12, 2026");
+    expect(profile.getByText("Detection details").closest("div")).toHaveTextContent("paycheck-candidate-v1");
+    expect(profile.getByText("Projection details").closest("div")).toHaveTextContent("paycheck-projector-v1");
+    expect(profile.getByText("Records used to confirm (3)")).toBeVisible();
     expect(profile.getByText(/Edited since confirmation\. The saved expectation is unchanged/)).toBeVisible();
     expect(profile.getAllByRole("listitem")).toHaveLength(3);
     expect(profile.getByText(/May 10, 2026/, { selector: "time" })).toHaveAttribute("datetime", "2026-05-10");
+    const candidate = within(card("acme payroll"));
+    expect(candidate.getByText("Observed deposits")).toBeVisible();
+    expect(candidate.getByText("Monthly")).toBeVisible();
+    expect(candidate.getByText("Based on 3 deposits")).toBeVisible();
+    expect(candidate.getByRole("button", { name: "Review and confirm acme payroll" })).toBeVisible();
+    expect(candidate.getByRole("button", { name: "Dismiss acme payroll" })).toBeVisible();
+    expect(candidate.getByText("Detection details")).not.toBeVisible();
+    expect(disclosure("Details for acme payroll")).not.toHaveAttribute("open");
+    expect(candidate.getByLabelText("Details for acme payroll")).toHaveProperty("tabIndex", 0);
+    await user.click(candidate.getByLabelText("Details for acme payroll"));
+    expect(candidate.getByText("Evaluated").closest("div")).toHaveTextContent("Jul 13, 2026");
+    expect(candidate.getByText("Deposits to review (3)")).toBeVisible();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("orders active profiles and possible paychecks before closed history disclosures", async () => {
+    const activeWithoutProjection = makePaycheck({ nextProjection: null });
+    const paused = makePaycheck({ id: "22222222-2222-2222-2222-222222222222", displayName: "Paused pay", lifecycle: "paused", nextProjection: null });
+    const ended = makePaycheck({ id: "33333333-3333-3333-3333-333333333333", displayName: "Ended pay", lifecycle: "ended", nextProjection: null });
+    const dismissed = makeCandidate({ fingerprint: "d".repeat(64), normalizedDescriptionIdentity: "old payroll" });
+    loadState({ paychecks: [activeWithoutProjection, paused, ended], dismissedCandidates: [dismissed] });
+
+    await renderPage();
+
+    const headings = [
+      screen.getByRole("heading", { level: 2, name: "Your paychecks" }),
+      screen.getByRole("heading", { level: 2, name: "Possible paychecks" }),
+      historyHeading("Paused paychecks"),
+      historyHeading("Ended paychecks"),
+      historyHeading("Dismissed possible paychecks"),
+    ];
+    for (let index = 0; index < headings.length - 1; index += 1) {
+      expect(headings[index].compareDocumentPosition(headings[index + 1]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+    for (const name of ["Paused paychecks", "Ended paychecks", "Dismissed possible paychecks"]) {
+      expect(history(name)).not.toHaveAttribute("open");
+      expect(historyHeading(name)).toHaveAccessibleName(`${name} (1)`);
+      expect(historyHeading(name).closest("summary")).toHaveProperty("tabIndex", 0);
+    }
+    const profile = within(card("Acme Payroll"));
+    expect(profile.getByText("No expected window is available. Expected, not guaranteed.")).toBeVisible();
+  });
+
+  it("keeps review drafts outside read-only details across disclosure, theme, and rerender changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<PaychecksPage />);
+    await screen.findByRole("heading", { name: "Your paychecks" });
+    await user.click(screen.getByRole("button", { name: "Review and confirm acme payroll" }));
+    const form = screen.getByRole("form", { name: "Confirm paycheck" });
+    const name = within(form).getByLabelText("Display name");
+    await user.clear(name);
+    await user.type(name, "Draft payroll");
+    expect(form.closest("details")).toBeNull();
+
+    const candidateDetails = disclosure("Details for acme payroll");
+    await user.click(screen.getByLabelText("Details for acme payroll"));
+    expect(candidateDetails).toHaveAttribute("open");
+    await user.click(screen.getByLabelText("Details for acme payroll"));
+    expect(candidateDetails).not.toHaveAttribute("open");
+    document.documentElement.dataset.theme = "dark";
+    rerender(<PaychecksPage />);
+
+    expect(screen.getByRole("form", { name: "Confirm paycheck" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Display name")).toHaveValue("Draft payroll");
+    expect(disclosure("Details for acme payroll")).not.toHaveAttribute("open");
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("keeps an inactive edit visible and its history open until the draft is finished", async () => {
+    const user = userEvent.setup();
+    const paused = makePaycheck({ displayName: "Paused pay", lifecycle: "paused", nextProjection: null });
+    loadState({ paychecks: [paused] });
+    const { rerender } = render(<PaychecksPage />);
+    await screen.findByRole("heading", { name: "Your paychecks" });
+
+    const pausedHistory = history("Paused paychecks");
+    const pausedSummary = historyHeading("Paused paychecks").closest("summary");
+    await user.click(pausedSummary);
+    await user.click(screen.getByRole("button", { name: "Edit Paused pay" }));
+    const form = screen.getByRole("form", { name: "Save changes" });
+    const profileDetails = disclosure("Details for Paused pay");
+    expect(pausedHistory).toHaveAttribute("open");
+    expect(pausedSummary).toHaveAttribute("aria-disabled", "true");
+    expect(pausedHistory).toContainElement(form);
+    expect(profileDetails).not.toContainElement(form);
+
+    await user.clear(within(form).getByLabelText("Display name"));
+    await user.type(within(form).getByLabelText("Display name"), "Paused draft");
+    await user.click(pausedSummary);
+    expect(pausedHistory).toHaveAttribute("open");
+    document.documentElement.dataset.theme = "light";
+    rerender(<PaychecksPage />);
+    expect(screen.getByRole("form", { name: "Save changes" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Display name")).toHaveValue("Paused draft");
+    expect(history("Paused paychecks")).toHaveAttribute("open");
+    document.documentElement.removeAttribute("data-theme");
   });
 
   it("shows initial loading and durable load error, then retries to intentional empty states", async () => {
@@ -77,15 +201,15 @@ describe("Paychecks page", () => {
     loadState({ candidates: [], dismissedCandidates: [], paychecks: [] });
     await userEvent.setup().click(screen.getByRole("button", { name: "Refresh paychecks" }));
     expect(await screen.findByText("No paycheck profiles yet")).toBeInTheDocument();
-    expect(screen.getByText(/No paycheck candidates need review/)).toBeInTheDocument();
-    expect(screen.getByText("No dismissed candidates.")).toBeInTheDocument();
+    expect(screen.getByText(/No possible paychecks need review/)).toBeInTheDocument();
+    expect(screen.getByText("No dismissed possible paychecks.")).toBeInTheDocument();
   });
 
   it.each([true, false])("handles the candidates/profiles-only empty combination (candidates=%s)", async (candidatesOnly) => {
     loadState({ candidates: candidatesOnly ? [makeCandidate()] : [], paychecks: candidatesOnly ? [] : [makePaycheck()] });
     await renderPage();
     expect(Boolean(screen.queryByText("No paycheck profiles yet"))).toBe(candidatesOnly);
-    expect(Boolean(screen.queryByText(/No paycheck candidates need review/))).toBe(!candidatesOnly);
+    expect(Boolean(screen.queryByText(/No possible paychecks need review/))).toBe(!candidatesOnly);
   });
 
   it("requires explicit fixed confirmation and sends the exact candidate schedule and accepted decimal", async () => {
@@ -132,12 +256,14 @@ describe("Paychecks page", () => {
     loadState({ candidates: [], dismissedCandidates: [other] });
     await user.click(screen.getByRole("button", { name: "Dismiss other payroll" }));
     await screen.findByRole("button", { name: "Reconsider other payroll" });
+    expect(history("Dismissed possible paychecks")).toHaveAttribute("open");
+    await waitFor(() => expect(historyHeading("Dismissed possible paychecks").closest("summary")).toHaveFocus());
     const tuple = { algorithmVersion: other.algorithmVersion, cadence: "monthly", fingerprint: other.fingerprint };
     expect(paychecksApi.dismissCandidate).toHaveBeenCalledExactlyOnceWith(tuple);
     loadState({ candidates: [other] });
     await user.click(screen.getByRole("button", { name: "Reconsider other payroll" }));
     expect(paychecksApi.reconsiderCandidate).toHaveBeenCalledExactlyOnceWith(tuple);
-    await waitFor(() => expect(screen.getByRole("heading", { name: "Candidates to review" })).toHaveFocus());
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Possible paychecks" })).toHaveFocus());
   });
 
   it("keeps a known manual creation successful when refresh fails, without offering repeat submission", async () => {
@@ -163,10 +289,14 @@ describe("Paychecks page", () => {
     await renderPage();
     const form = await fillManual(user);
     await user.click(within(form).getByRole("button", { name: "Create paycheck" }));
+    expect(screen.getByText("Saving your decision…").closest("details")).toBeNull();
+    expect(form.closest("details")).toBeNull();
     expect(screen.getByRole("button", { name: "Dismiss acme payroll" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Edit Acme Payroll" })).toBeDisabled();
     await act(async () => pending.reject(new Error("network lost")));
-    expect(await screen.findByRole("alert")).toHaveTextContent("could not confirm whether the paycheck was created");
+    const uncertain = await screen.findByRole("alert");
+    expect(uncertain).toHaveTextContent("could not confirm whether the paycheck was created");
+    expect(uncertain.closest("details")).toBeNull();
     expect(within(form).getByRole("button", { name: "Create paycheck" })).toBeDisabled();
     expect(within(form).getByRole("button", { name: "Cancel" })).toBeEnabled();
     expect(paychecksApi.createPaycheck).toHaveBeenCalledTimes(1);
@@ -189,6 +319,110 @@ describe("Paychecks page", () => {
     expect(paychecksApi.confirmCandidate).toHaveBeenCalledTimes(1);
   });
 
+  it("pauses an ended profile from Details and opens the paused destination history", async () => {
+    const user = userEvent.setup();
+    const ended = makePaycheck({ displayName: "Ended pay", lifecycle: "ended", nextProjection: null });
+    loadState({ paychecks: [ended] });
+    await renderPage();
+
+    expect(historyHeading("Ended paychecks")).toHaveAccessibleName("Ended paychecks (1)");
+    expect(history("Ended paychecks")).not.toHaveAttribute("open");
+    await user.click(historyHeading("Ended paychecks").closest("summary"));
+    await user.click(screen.getByLabelText("Details for Ended pay"));
+    const endedCard = within(card("Ended pay"));
+    expect(endedCard.getByText("Detection details").closest("div")).toHaveTextContent("paycheck-candidate-v1");
+
+    loadState({ paychecks: [{ ...ended, lifecycle: "paused" }] });
+    await user.click(endedCard.getByRole("button", { name: "Pause Ended pay" }));
+
+    expect(paychecksApi.updateLifecycle).toHaveBeenCalledExactlyOnceWith(ended.id, "paused");
+    expect(await screen.findByRole("group", { name: "Paused paychecks" })).toHaveTextContent("Ended pay");
+    expect(history("Paused paychecks")).toHaveAttribute("open");
+  });
+
+  it.each([
+    ["no longer includes the profile", [], null],
+    ["shows the profile already ended", [makePaycheck({ lifecycle: "ended", nextProjection: null })], "Ended paychecks (1)"],
+    ["shows the profile now paused", [makePaycheck({ lifecycle: "paused", nextProjection: null })], "Paused paychecks (1)"],
+  ])("clears an orphaned end confirmation when the refresh %s", async (_state, refreshedPaychecks, destinationHeading) => {
+    const user = userEvent.setup();
+    const active = makePaycheck();
+    loadState({ paychecks: [active] });
+    await renderPage();
+    await user.click(screen.getByLabelText("Details for Acme Payroll"));
+    await user.click(screen.getByRole("button", { name: "End Acme Payroll" }));
+    expect(screen.getByRole("button", { name: "Confirm end" })).toHaveFocus();
+
+    paychecksApi.updateLifecycle.mockRejectedValueOnce({ response: { status: 404, data: { code: "paycheck_not_found" } } });
+    loadState({ paychecks: refreshedPaychecks });
+    await user.click(screen.getByRole("button", { name: "Confirm end" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("That paycheck is no longer available. Review the current profiles.");
+    expect(alert.closest("details")).toBeNull();
+    await waitFor(() => expect(screen.queryByRole("group", { name: "End Acme Payroll" })).not.toBeInTheDocument());
+    expect(paychecksApi.updateLifecycle).toHaveBeenCalledExactlyOnceWith(active.id, "ended");
+    expect(screen.getByRole("button", { name: "Review and confirm acme payroll" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add paycheck manually" })).toBeEnabled();
+    if (destinationHeading) expect(screen.getByRole("heading", { level: 2, name: destinationHeading })).toBeInTheDocument();
+    else {
+      expect(screen.queryByRole("heading", { level: 2, name: "Ended paychecks (1)" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { level: 2, name: "Paused paychecks (1)" })).not.toBeInTheDocument();
+    }
+  });
+
+  it("retains end confirmation when a stale refresh keeps the same profile card", async () => {
+    const user = userEvent.setup();
+    const active = makePaycheck();
+    loadState({ paychecks: [active] });
+    await renderPage();
+    await user.click(screen.getByLabelText("Details for Acme Payroll"));
+    await user.click(screen.getByRole("button", { name: "End Acme Payroll" }));
+
+    paychecksApi.updateLifecycle.mockRejectedValueOnce({ response: { status: 404, data: { code: "paycheck_not_found" } } });
+    loadState({ paychecks: [active] });
+    await user.click(screen.getByRole("button", { name: "Confirm end" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("That paycheck is no longer available. Review the current profiles.");
+    expect(screen.getByRole("group", { name: "End Acme Payroll" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel ending" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Review and confirm acme payroll" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add paycheck manually" })).toBeDisabled();
+  });
+
+  it("retains end confirmation and task locks when its stale-state refresh fails", async () => {
+    const user = userEvent.setup();
+    const active = makePaycheck();
+    loadState({ paychecks: [active] });
+    await renderPage();
+    await user.click(screen.getByLabelText("Details for Acme Payroll"));
+    await user.click(screen.getByRole("button", { name: "End Acme Payroll" }));
+
+    paychecksApi.updateLifecycle.mockRejectedValueOnce({ response: { status: 404, data: { code: "paycheck_not_found" } } });
+    paychecksApi.getCandidates.mockRejectedValueOnce(new Error("refresh failed"));
+    paychecksApi.getPaychecks.mockRejectedValueOnce(new Error("refresh failed"));
+    await user.click(screen.getByRole("button", { name: "Confirm end" }));
+
+    const errors = await screen.findAllByRole("alert");
+    expect(errors.map((alert) => alert.textContent).join(" ")).toContain("That paycheck is no longer available. Review the current profiles.");
+    expect(errors.map((alert) => alert.textContent).join(" ")).toContain("Paychecks could not be loaded");
+    errors.forEach((alert) => expect(alert.closest("details")).toBeNull());
+    expect(screen.getByRole("group", { name: "End Acme Payroll" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel ending" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Refresh paychecks" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Review and confirm acme payroll" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add paycheck manually" })).toBeDisabled();
+
+    loadState({ paychecks: [active] });
+    await user.click(screen.getByRole("button", { name: "Refresh paychecks" }));
+    expect(screen.getByRole("group", { name: "End Acme Payroll" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Review and confirm acme payroll" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Cancel ending" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "End Acme Payroll" })).toHaveFocus());
+    expect(screen.getByRole("button", { name: "Review and confirm acme payroll" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add paycheck manually" })).toBeEnabled();
+  });
+
   it("preserves edit restrictions and restores focus for cancel, then moves profiles through lifecycle groups", async () => {
     const user = userEvent.setup();
     await renderPage();
@@ -209,10 +443,22 @@ describe("Paychecks page", () => {
     await screen.findByRole("button", { name: "Pause Renamed payroll" });
     loadState({ paychecks: [{ ...profile, lifecycle: "paused", nextProjection: null }] });
     await user.click(screen.getByRole("button", { name: "Pause Renamed payroll" }));
-    expect(await screen.findByRole("group", { name: "Paused paychecks" })).toHaveTextContent("Renamed payroll");
+    const pausedGroup = await screen.findByRole("group", { name: "Paused paychecks" });
+    expect(pausedGroup).toHaveTextContent("Renamed payroll");
+    const pausedHistory = history("Paused paychecks");
+    const pausedSummary = historyHeading("Paused paychecks").closest("summary");
+    expect(pausedHistory).toHaveAttribute("open");
     expect(paychecksApi.updateLifecycle).toHaveBeenLastCalledWith(profile.id, "paused");
+    await user.click(screen.getByLabelText("Details for Renamed payroll"));
+    const profileDetails = disclosure("Details for Renamed payroll");
     await user.click(screen.getByRole("button", { name: "End Renamed payroll" }));
-    expect(screen.getByRole("button", { name: "Confirm end" })).toHaveFocus();
+    const confirmEnd = screen.getByRole("button", { name: "Confirm end" });
+    expect(confirmEnd).toHaveFocus();
+    expect(profileDetails).not.toContainElement(confirmEnd);
+    expect(pausedHistory).toContainElement(confirmEnd);
+    expect(pausedSummary).toHaveAttribute("aria-disabled", "true");
+    await user.click(pausedSummary);
+    expect(pausedHistory).toHaveAttribute("open");
     await user.click(screen.getByRole("button", { name: "Cancel ending" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "End Renamed payroll" })).toHaveFocus());
     await user.click(screen.getByRole("button", { name: "End Renamed payroll" }));
@@ -224,5 +470,33 @@ describe("Paychecks page", () => {
     await user.click(screen.getByRole("button", { name: "Reactivate Renamed payroll" }));
     expect(await screen.findByRole("group", { name: "Active paychecks" })).toHaveTextContent("Renamed payroll");
     expect(paychecksApi.updateLifecycle).toHaveBeenLastCalledWith(profile.id, "active");
+  });
+
+  it("does not let delayed lifecycle focus steal focus from an immediate end confirmation", async () => {
+    const user = userEvent.setup();
+    const frames = [];
+    const animationFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+
+    try {
+      const profile = makePaycheck();
+      await renderPage();
+      loadState({ paychecks: [{ ...profile, lifecycle: "paused", nextProjection: null }] });
+      await user.click(screen.getByRole("button", { name: "Pause Acme Payroll" }));
+      await screen.findByRole("group", { name: "Paused paychecks" });
+      await user.click(screen.getByLabelText("Details for Acme Payroll"));
+      await user.click(screen.getByRole("button", { name: "End Acme Payroll" }));
+      const confirmation = screen.getByRole("button", { name: "Confirm end" });
+      expect(confirmation).toHaveFocus();
+
+      act(() => {
+        frames.splice(0).forEach((callback) => callback(performance.now()));
+      });
+      expect(confirmation).toHaveFocus();
+    } finally {
+      animationFrame.mockRestore();
+    }
   });
 });

--- a/frontend/src/styles/paychecks.css
+++ b/frontend/src/styles/paychecks.css
@@ -1,6 +1,6 @@
 .paychecks-page { display: grid; gap: var(--space-6); padding-bottom: var(--space-5); }
 .paychecks-page > .page-header { margin-bottom: 0; }
-.paycheck-create { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); white-space: nowrap; }
+.paycheck-create { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); white-space: normal; }
 .paycheck-feedback:empty { display: none; }
 .paycheck-feedback { display: grid; justify-items: start; gap: var(--space-2); }
 .paycheck-feedback p { margin: 0; }
@@ -9,7 +9,7 @@
 .paycheck-section__header { display: flex; align-items: start; justify-content: space-between; gap: var(--space-4); }
 .paycheck-section h2 { margin-bottom: var(--space-2); }
 .paycheck-section header p { margin-bottom: 0; }
-.paycheck-evaluated { flex-shrink: 0; padding-top: var(--space-1); color: var(--color-text-muted); font-size: var(--text-sm); }
+.paycheck-evaluated { min-width: 0; padding-top: var(--space-1); color: var(--color-text-muted); font-size: var(--text-sm); overflow-wrap: anywhere; }
 .paycheck-group__label { display: flex; gap: var(--space-2); align-items: center; margin: var(--space-2) 0 0; font-weight: 800; }
 .paycheck-group__label span { display: inline-grid; place-items: center; min-width: 26px; min-height: 26px; border-radius: var(--radius-pill); background: var(--color-surface-raised); font-size: var(--text-sm); }
 .paycheck-card { display: grid; min-width: 0; gap: var(--space-4); box-shadow: var(--shadow-sm); }
@@ -19,28 +19,45 @@
 .paycheck-card h3, .paycheck-card p, .paycheck-card dd { overflow-wrap: anywhere; }
 .paycheck-card h3 { margin-bottom: var(--space-2); font-size: var(--text-xl); }
 .paycheck-eyebrow { margin: 0 0 var(--space-2); color: var(--color-text-muted); font-size: var(--text-xs); letter-spacing: .06em; text-transform: uppercase; font-weight: 800; }
-.paycheck-card__amount { display: grid; gap: var(--space-1); flex-shrink: 0; text-align: right; font-variant-numeric: tabular-nums; }
+.paycheck-status { margin: 0 0 var(--space-1); color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
+.paycheck-candidate-count { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
+.paycheck-card__amount { display: grid; min-width: 0; max-width: 50%; gap: var(--space-1); flex: 0 1 auto; text-align: right; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
 .paycheck-card__amount span { color: var(--color-text-muted); font-size: var(--text-xs); }
-.paycheck-card__amount strong { font-size: var(--text-xl); }
+.paycheck-card__amount strong { min-width: 0; font-size: var(--text-xl); overflow-wrap: anywhere; }
 .paycheck-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); margin: 0; }
 .paycheck-facts > div { min-width: 0; }
 .paycheck-facts dt { margin-bottom: var(--space-1); color: var(--color-text-muted); font-size: var(--text-sm); }
 .paycheck-facts dd { margin: 0; }
-.paycheck-projection { padding: var(--space-4); background: color-mix(in srgb, var(--color-primary) 5%, var(--color-surface)); border: 1px solid color-mix(in srgb, var(--color-primary) 20%, var(--color-border)); border-radius: var(--radius-sm); }
+.paycheck-projection { min-width: 0; padding: var(--space-2) 0 var(--space-2) var(--space-3); border-left: 2px solid color-mix(in srgb, var(--color-primary) 45%, var(--color-border)); }
 .paycheck-projection p { margin-bottom: var(--space-2); }
 .paycheck-projection p:last-child { margin: 0; font-size: var(--text-sm); }
 .paycheck-projection__date { font-size: var(--text-xl); font-weight: 800; font-variant-numeric: tabular-nums; }
 .paycheck-inactive { padding: var(--space-3); margin: 0; border: 1px solid var(--color-divider); color: var(--color-text-muted); border-radius: var(--radius-sm); }
+.paycheck-details { min-width: 0; border-top: 1px solid var(--color-divider); }
+.paycheck-details > summary { width: fit-content; max-width: 100%; padding-inline: var(--space-1); border-radius: var(--radius-sm); color: var(--color-primary); font-weight: 700; overflow-wrap: anywhere; }
+.paycheck-details > summary::marker { color: var(--color-primary); }
+.paycheck-details[open] > summary { margin-bottom: var(--space-3); }
+.paycheck-details > .paycheck-facts { margin-bottom: var(--space-3); }
 .paycheck-evidence { min-width: 0; border-block: 1px solid var(--color-divider); padding-block: var(--space-3); }
 .paycheck-evidence summary { width: fit-content; max-width: 100%; min-height: 44px; cursor: pointer; font-weight: 700; }
+.paycheck-evidence--inline { border-block: 0; padding-block: 0; }
 .paycheck-evidence__list { display: grid; gap: var(--space-3); margin: var(--space-3) 0 0; padding: 0; list-style: none; }
-.paycheck-evidence__row { display: flex; justify-content: space-between; gap: var(--space-3); padding: var(--space-3); border-radius: var(--radius-sm); background: var(--color-surface-subtle); overflow-wrap: anywhere; }
+.paycheck-evidence__row { display: flex; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) 0; border-top: 1px solid var(--color-divider); overflow-wrap: anywhere; }
 .paycheck-evidence__row > div { display: grid; min-width: 0; gap: var(--space-1); }
 .paycheck-evidence__row span { color: var(--color-text-muted); font-size: var(--text-sm); }
-.paycheck-evidence__row > strong { flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.paycheck-evidence__row > strong { min-width: 0; flex: 0 1 auto; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
 .paycheck-evidence__row .paycheck-evidence__edited { color: var(--color-text); font-weight: 700; }
-.paycheck-actions { flex-wrap: wrap; }
+.paycheck-actions { min-width: 0; flex-wrap: wrap; }
 .paycheck-schedule-note { margin: 0; font-size: var(--text-sm); }
+.paycheck-history { min-width: 0; border-top: 1px solid var(--color-divider); }
+.paycheck-history > summary { width: 100%; padding: var(--space-3) var(--space-2); border-radius: var(--radius-sm); overflow-wrap: anywhere; }
+.paycheck-history > summary::marker { color: var(--color-primary); }
+.paycheck-history > summary:hover { background: var(--color-surface-subtle); }
+.paycheck-history > summary h2 { display: inline; margin: 0; font-size: var(--text-lg); }
+.paycheck-history > summary span { margin-left: var(--space-2); color: var(--color-text-muted); font-size: var(--text-sm); font-weight: 700; }
+.paycheck-history > summary[aria-disabled="true"] { cursor: default; color: var(--color-text-muted); }
+.paycheck-history__content { display: grid; min-width: 0; gap: var(--space-4); padding-top: var(--space-3); }
+.paycheck-history-note { margin: 0; padding: var(--space-3); border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: var(--text-sm); overflow-wrap: anywhere; }
 .paycheck-empty { display: grid; justify-items: start; gap: var(--space-2); margin: 0; padding: var(--space-5); background: var(--color-surface); border: 1px dashed var(--color-border); border-radius: var(--radius-md); color: var(--color-text-muted); }
 .paycheck-empty h3, .paycheck-empty p { margin: 0; }
 .paycheck-empty h3 { color: var(--color-text); }
@@ -57,9 +74,10 @@
 .paychecks-page h2:focus, .paycheck-feedback:focus { outline: 3px solid var(--color-focus); outline-offset: 3px; }
 @media (max-width: 720px) {
   .paycheck-card__header, .paycheck-section__header, .paycheck-evidence__row { flex-direction: column; }
-  .paycheck-card__amount { text-align: left; flex-shrink: 1; }
+  .paycheck-card__amount { width: 100%; max-width: 100%; text-align: left; }
   .paycheck-card__amount strong { overflow-wrap: anywhere; }
   .paycheck-facts, .paycheck-form__grid { grid-template-columns: minmax(0, 1fr); }
   .paycheck-manual { padding: var(--space-4); }
   .paycheck-evaluated { margin: 0; padding: 0; }
+  .paycheck-history > summary { padding-inline: 0; }
 }


### PR DESCRIPTION
## Summary

Paychecks now leads with active saved expectations and their existing server-provided payment windows, followed by possible paychecks to review. Card Details disclose records and schedule mechanics; paused, ended, and dismissed items start in quieter expandable groups.

## Issue

References #127 — UX V3 slice 4 of 7, based on `main` at `7badd4d63612468aa651957dcc5c7e6f11df44ba`.

[Approved plan](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563926559), [owner approval](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563943900), and [Paychecks delivery checkpoint](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5573790166). #127 stays open for the remaining slices.

## Risk

- [ ] LOW
- [x] MEDIUM — approved presentation and interaction slice
- [ ] HIGH

## Changes

- Saved cards retain name, status, expected amount/range, cadence, active-only server window, visible “Expected, not guaranteed,” Edit, and Pause/Reactivate. Possible paychecks retain observed amounts, evidence count, explicit review/confirm/dismiss, and the qualification that variable history is not an accepted range.
- Named native Details reveal source, immutable schedule/window, linked records, separate evaluation dates, and correctly distinguished detection/projection versions. End remains explicit within Details, with its confirmation outside the disclosure. The existing ended-to-paused action is preserved.
- Forms and confirmations stay visible when card Details closes. Inactive history cannot collapse over an open task or pending lifecycle action. Competing task openers stay disabled until the current draft/confirmation finishes. Successful moves reveal their destination.
- Preserve focus on cancel and completed actions. Fix the previously reported delayed Pause focus callback that could steal focus from a subsequent End confirmation. Clear lifted confirmation state when a refresh removes its card or changes its lifecycle; retain it across same-card or failed refreshes.
- Update the high-level Paychecks product description. `RECENT_CHANGES.md` remains untouched until V3 completion.

## Non-goals

No other V3 slice, paycheck change detection, financial aggregation, backend, API, schema, migration, dependency, authentication, or production-configuration changes. Hooks, API adapters, `PaycheckForm`, financial formatters, candidate tuples, money guards, and schedule/lifecycle semantics are unchanged. No production operation or merge performed.

## Verification

### Passed locally

- `./scripts/verify.sh frontend`: locked install, full tests, lint, and production build passed during development. After review corrections, `npm run verify` also passed: 48 test files / 456 tests, ESLint, and Vite build. The existing bundle-size advisory remains; no dependency or bundle-policy changes are included.
- All 107 focused Paychecks tests passed. Tests retain exact mutation, immutable schedule, guarded decimal, manual creation, stale-conflict, uncertain-write, loading/error/retry, and focus assertions, with new disclosure/history/draft regressions.
- Complete diff review and `git diff --check`.

### Not run locally — capability unavailable

- Disposable local PostgreSQL is unavailable. No hosted database substitute was used; PostgreSQL verification is required from CI.
- Native screen-reader and native browser-zoom checks are unavailable in this automated session; keyboard/DOM accessibility and 200% root-text enlargement are supplemental evidence.

Backend/container local lanes were not rerun for this frontend-only slice; the required Backend CI job runs backend tests and the production-container checks.

### Required/proven by CI

All required checks succeeded on final head `7e083f3ea6f4e47172c21e945a28722d8535268a`:

- [Frontend test, lint, and build](https://github.com/OL1V3S/ordo/actions/runs/34148738029/job/101826287758)
- [Backend build and tests](https://github.com/OL1V3S/ordo/actions/runs/34148737980/job/101826287586)
- [PostgreSQL financial integration](https://github.com/OL1V3S/ordo/actions/runs/34148737980/job/101826287790)

### Smoke checks (supplemental)

Synthetic localhost Chromium checks verify keyboard Details/history operation, candidate draft preservation across closing Details/theme/resize, Cancel focus, dismiss/reconsider destination and focus, Pause-to-End confirmation focus, locked pending history, and explicit End completion. All browser mutations target private in-memory fixtures, with no real account or database. Screenshots remain private in `/tmp`. The responsive sweep passed at 320/375/768/1280px with Light/Dark/System (including system dark preference), reduced motion, long names and large exact ranges. A 320px / 200% root-text check exposed nowrap on the manual-create button forcing horizontal overflow; allowing its label to wrap corrected it, and the repeated check had no horizontal overflow. Initial loading, failed load, keyboard retry, empty state, Paychecks/Plan route and browser Back/Forward focus also passed. Manual draft open/375→320 resize/Cancel preserved the draft and restored opener focus without overflow. Final Chromium runtime errors were empty and no Vite overlay was present.

### Preview evidence (non-blocking)

[Vercel preview deployment](https://vercel.com/ol1v3s-projects/budget-planner/CgK4DERLFuPwtYSNDGfn3eZ3SYd7) and Vercel Preview Comments succeeded. An unauthenticated request to the preview `/paychecks` route redirected to `https://vercel.com/login`; deployed-page verification is unavailable behind deployment protection. No protection bypass or production smoke was attempted.

### Remaining verification gaps

Deployed-page verification is unavailable behind Vercel login protection; native screen-reader/native-zoom checks remain unavailable as disclosed above.

## API impact

None.

## Database / migration impact

None.

## Dependency impact

None.

## Deployment considerations

Ordinary frontend deployment after independent review and authorized merge, subject to existing release prerequisites. Rollback is a reviewed revert of this frontend slice and its product-description update; no data/schema rollback is needed.

## Review notes

Review the actual diff, discussion, and final CI independently, especially disclosure reachability, stale confirmation cleanup, and unchanged mutation/financial contracts. Local development review does not replace command-center approval, and Codex has not self-approved or merged this PR.

Context stayed within the Paychecks page/evidence/styles/tests and existing form, hook, API, fixtures, formatter, shared disclosure/session contracts; those dependencies were inspected to preserve data, draft, and request behavior. Canonical authority/verification/product documents and CI definitions supplied scope and evidence requirements. No material expansion beyond that boundary.

Work is isolated in `/tmp/ordo-127-v3` under the [checkout authorization](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5563724912). The two reported untracked files in the Desktop checkout remain untouched. After independent merge confirmation and completion, clean up the remote feature branch under `AGENTS.md`.
