### PR TITLE
Complete UX V3 budgets and final presentation pass (slice 7/7)

### DIFF
--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -28,9 +28,10 @@ silently treating every detected pattern as a financial fact.
   and categories, and expand date/category filters when needed. Open Add expense
   or Import statement to start a task; edit and delete remain available on each
   record. Active drafts and import review stay visible while you work.
-- **Budgets:** Set monthly spending limits for default or custom categories,
-  adjust or remove them, and compare recorded spending with each limit and its
-  percentage used.
+- **Budgets:** Review category spending against the selected month’s limits,
+  with visible progress and near-limit or over-limit status. Open add or edit
+  when needed; drafts keep their original month. Zero limits remain explicit
+  no-spend budgets, and unavailable spending is shown separately from zero.
 - **Commitments:** See active saved expectations, amounts, and timing patterns
   first, then review supported changes and possible recurring expenses. Edit,
   pause, reactivate, or end saved commitments; confirm or dismiss suggestions.
@@ -43,7 +44,7 @@ silently treating every detected pattern as a financial fact.
   Add a paycheck manually or manage existing profiles; paused, ended, and
   dismissed items sit in expandable groups. Card Details reveal linked records
   and schedule information. Profiles support several pay schedules and fixed
-  amounts or accepted ranges. These are expectations, not guaranteed deposits
+  amounts or expected ranges. These are expectations, not guaranteed deposits
   or employer-verified earnings.
 - **Insights / Analytics:** Compare recorded cash in with spending for a selected
   month and see the difference as net recorded cash flow. Explore a six-month
@@ -58,15 +59,19 @@ silently treating every detected pattern as a financial fact.
   Credits are optional and must be explicitly selected; they become inflow
   records without automatically being classified as income or paychecks.
   Scanned PDFs are not supported.
-- **Settings and account access:** View your signed-in email and choose a System,
-  Light, or Dark theme saved on your device. Account access includes registration,
+- **Settings and account access:** Choose a System, Light, or Dark theme first,
+  then view your signed-in email in a compact account section. Account access
+  includes registration,
   sign-in and sign-out, email confirmation and resend, and password recovery by
   email. Settings currently provides email display and appearance controls,
   rather than a full account-management area.
 
 Navigation uses Home, Activity, and Insights consistently across screen sizes.
-On smaller screens, Plan groups Budgets, Commitments, and Paychecks, while More
-contains secondary destinations. The underlying financial workflows are the same.
+On smaller screens, Plan is a simple hub for Budgets, Commitments, and Paychecks.
+More places Settings ahead of the explicitly unavailable Investing placeholder;
+these destinations also sit below the main desktop navigation. Details and
+history expand on demand, while active tasks, errors, and review warnings stay
+visible. The underlying financial workflows are the same.
 
 ## What the figures mean
 

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -19,8 +19,8 @@ the permanent, complete archive.
 - Skip trivial typo-only or formatting-only changes and mechanical maintenance
   with no meaningful product or engineering effect.
 - Do not backfill older history. The completed **Ordo UX V3 work governed by
-  [#127](https://github.com/OL1V3S/ordo/issues/127)** will create the first real
-  entry after that work merges.
+  [#127](https://github.com/OL1V3S/ordo/issues/127)** is the starting point for
+  this history.
 
 ## History
 
@@ -32,7 +32,8 @@ the permanent, complete archive.
 [PR #134](https://github.com/OL1V3S/ordo/pull/134),
 [PR #135](https://github.com/OL1V3S/ordo/pull/135),
 [PR #136](https://github.com/OL1V3S/ordo/pull/136),
-[PR #137](https://github.com/OL1V3S/ordo/pull/137)
+[PR #137](https://github.com/OL1V3S/ordo/pull/137),
+[PR #138](https://github.com/OL1V3S/ordo/pull/138)
 
 - Simplified Home, Activity/import, Budgets, Commitments, Paychecks, and Insights
   around recorded figures, saved expectations, and explicit review tasks.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -24,4 +24,19 @@ the permanent, complete archive.
 
 ## History
 
-No entries yet. This section remains empty until the UX V3 starting point above.
+### 2026-09-07 — Ordo UX V3
+
+[Issue #127](https://github.com/OL1V3S/ordo/issues/127) ·
+[PR #132](https://github.com/OL1V3S/ordo/pull/132),
+[PR #133](https://github.com/OL1V3S/ordo/pull/133),
+[PR #134](https://github.com/OL1V3S/ordo/pull/134),
+[PR #135](https://github.com/OL1V3S/ordo/pull/135),
+[PR #136](https://github.com/OL1V3S/ordo/pull/136),
+[PR #137](https://github.com/OL1V3S/ordo/pull/137)
+
+- Simplified Home, Activity/import, Budgets, Commitments, Paychecks, and Insights
+  around recorded figures, saved expectations, and explicit review tasks.
+- Added a consistent responsive shell, task-focused account-access pages,
+  expandable details/history, and quieter Plan, More, and Settings pages.
+- Improved focus, accessible control names, draft preservation, and distinct
+  loading/error states while preserving existing financial and account behavior.

--- a/frontend/src/app/App.test.jsx
+++ b/frontend/src/app/App.test.jsx
@@ -167,7 +167,9 @@ describe('application routes and shell', () => {
       expect(within(link).getByText(label, { selector: 'span:not(.sr-only)' })).toBeInTheDocument()
     }
     const desktop = screen.getByRole('navigation', { name: 'Primary navigation' })
-    expect([...desktop.querySelectorAll('a')].map((link) => link.getAttribute('href'))).toEqual(['/overview', '/transactions', '/budgets', '/analytics', '/commitments', '/paychecks', '/investing'])
+    expect([...desktop.querySelectorAll('a')].map((link) => link.getAttribute('href'))).toEqual(['/overview', '/transactions', '/budgets', '/analytics', '/commitments', '/paychecks'])
+    const secondary = screen.getByRole('navigation', { name: 'Secondary navigation' })
+    expect([...secondary.querySelectorAll('a')].map((link) => link.getAttribute('href'))).toEqual(['/settings', '/investing'])
     expect(screen.getAllByRole('link', { name: /Settings/ })).toHaveLength(2)
   })
 

--- a/frontend/src/app/AppShell.jsx
+++ b/frontend/src/app/AppShell.jsx
@@ -29,7 +29,10 @@ export default function AppShell({ email, onLogout }) {
   const accountMenuRef = useRef(null);
   const accountButtonRef = useRef(null);
   const mainRef = useRef(null);
-  const primaryDestinations = APP_DESTINATIONS.filter((destination) => destination.to !== "/settings");
+  const primaryDestinations = APP_DESTINATIONS.filter((destination) =>
+    !["/settings", "/investing"].includes(destination.to));
+  const secondaryDestinations = ["/settings", "/investing"]
+    .map((to) => APP_DESTINATIONS.find((destination) => destination.to === to));
   const settingsDestination = APP_DESTINATIONS.find((destination) => destination.to === "/settings");
   const { pathname } = useLocation();
   const path = pathname.replace(/\/+$/, "") || "/";
@@ -78,9 +81,11 @@ export default function AppShell({ email, onLogout }) {
           ))}
         </nav>
         <div className="app-sidebar__utilities">
-          <div className="app-sidebar__settings">
-            <NavigationLink destination={settingsDestination} />
-          </div>
+          <nav className="app-sidebar__secondary" aria-label="Secondary navigation">
+            {secondaryDestinations.map((destination) => (
+              <NavigationLink key={destination.to} destination={destination} />
+            ))}
+          </nav>
           <span className="app-sidebar__identity">{email || "Signed in"}</span>
           <button type="button" className="button-ghost app-sidebar__logout" onClick={onLogout}>
             <LogOut size={18} aria-hidden="true" />

--- a/frontend/src/app/navigation.js
+++ b/frontend/src/app/navigation.js
@@ -17,14 +17,14 @@ export const APP_DESTINATIONS = [
   { to: "/analytics", label: "Insights", icon: ChartNoAxesCombined },
   { to: "/commitments", label: "Commitments", icon: Repeat2, description: "Review recurring expenses and manage saved commitments." },
   { to: "/paychecks", label: "Paychecks", icon: WalletCards, description: "Review deposits and manage saved paycheck expectations." },
-  { to: "/investing", label: "Investing", icon: Landmark, description: "Unavailable today. View the planned investing workspace." },
-  { to: "/settings", label: "Settings", icon: Settings, description: "Review your account and theme preference." },
+  { to: "/investing", label: "Investing", icon: Landmark, description: "Planned for a future release." },
+  { to: "/settings", label: "Settings", icon: Settings, description: "Choose your theme and review your signed-in email." },
 ];
 
 export const PLAN_DESTINATIONS = APP_DESTINATIONS.filter(({ to }) =>
   ["/budgets", "/commitments", "/paychecks"].includes(to));
-export const MORE_DESTINATIONS = APP_DESTINATIONS.filter(({ to }) =>
-  ["/investing", "/settings"].includes(to));
+export const MORE_DESTINATIONS = ["/settings", "/investing"]
+  .map((to) => APP_DESTINATIONS.find((destination) => destination.to === to));
 
 export const MOBILE_DESTINATIONS = [
   { to: "/overview", label: "Home", icon: LayoutDashboard, paths: ["/overview"] },

--- a/frontend/src/app/pages/InvestingPage.jsx
+++ b/frontend/src/app/pages/InvestingPage.jsx
@@ -1,9 +1,10 @@
 import { Landmark } from "lucide-react";
 import Card from "../../shared/ui/Card";
+import "../../styles/secondary-pages.css";
 
 export default function InvestingPage() {
   return (
-    <div className="shell-page">
+    <div className="shell-page investing-page">
       <header className="page-header">
         <div>
           <p className="page-header__eyebrow">Investing</p>

--- a/frontend/src/app/pages/MorePage.jsx
+++ b/frontend/src/app/pages/MorePage.jsx
@@ -1,29 +1,39 @@
 import { Link } from "react-router-dom";
 import { MORE_DESTINATIONS } from "../navigation";
+import "../../styles/secondary-pages.css";
 
 export default function MorePage() {
   return (
-    <div className="shell-page navigation-hub">
+    <div className="shell-page secondary-page">
       <header className="page-header">
         <div>
-          <p className="page-header__eyebrow">More</p>
           <h1>More</h1>
-          <p className="muted">Find additional workspace tools and preferences.</p>
+          <p className="muted">Settings and other secondary tools.</p>
         </div>
       </header>
 
-      <div className="navigation-hub__list">
+      <nav aria-label="More destinations">
+        <ul className="secondary-links secondary-links--more">
         {MORE_DESTINATIONS.map((destination) => {
           const { to, label, icon: Icon, description } = destination;
+          const unavailable = to === "/investing";
           return (
-            <Link className="card navigation-hub__link" to={to} key={to}>
-              <Icon className="navigation-hub__icon" size={24} aria-hidden="true" />
-              <h2 className="h2">{label}</h2>
-              <span className="navigation-hub__description">{description}</span>
-            </Link>
+            <li className={unavailable ? "secondary-links__subordinate" : ""} key={to}>
+              <Link className="secondary-link" to={to}>
+                <Icon className="secondary-link__icon" size={20} aria-hidden="true" />
+                <span className="secondary-link__body">
+                  <span className="secondary-link__title-row">
+                    <span className="secondary-link__label">{label}</span>
+                    {unavailable && <span className="secondary-link__status">Unavailable</span>}
+                  </span>
+                  <span className="secondary-link__description">{description}</span>
+                </span>
+              </Link>
+            </li>
           );
         })}
-      </div>
+        </ul>
+      </nav>
     </div>
   );
 }

--- a/frontend/src/app/pages/MorePage.test.jsx
+++ b/frontend/src/app/pages/MorePage.test.jsx
@@ -6,15 +6,17 @@ import MorePage from './MorePage'
 describe('More navigation hub', () => {
   afterEach(() => vi.unstubAllGlobals())
 
-  it('links to the unavailable investing surface and settings', () => {
+  it('puts Settings first and keeps the Investing placeholder subordinate and explicit', () => {
     const fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)
     render(<MemoryRouter><MorePage /></MemoryRouter>)
 
     expect(screen.getByRole('heading', { name: 'More', level: 1 })).toBeInTheDocument()
+    const links = screen.getAllByRole('link')
+    expect(links.map((link) => link.getAttribute('href'))).toEqual(['/settings', '/investing'])
     const investingLink = screen.getByRole('link', { name: /Investing/ })
     expect(investingLink).toHaveAttribute('href', '/investing')
-    expect(investingLink).toHaveTextContent(/unavailable today/i)
+    expect(investingLink).toHaveTextContent(/unavailable/i)
     expect(screen.getByRole('link', { name: /Settings/ })).toHaveAttribute('href', '/settings')
     expect(screen.getAllByRole('link')).toHaveLength(2)
     expect(screen.queryByRole('button')).not.toBeInTheDocument()

--- a/frontend/src/app/pages/PlanPage.jsx
+++ b/frontend/src/app/pages/PlanPage.jsx
@@ -1,29 +1,32 @@
 import { Link } from "react-router-dom";
 import { PLAN_DESTINATIONS } from "../navigation";
+import "../../styles/secondary-pages.css";
 
 export default function PlanPage() {
   return (
-    <div className="shell-page navigation-hub">
+    <div className="shell-page secondary-page">
       <header className="page-header">
         <div>
-          <p className="page-header__eyebrow">Plan</p>
           <h1>Plan</h1>
-          <p className="muted">Build a practical plan for spending, recurring commitments, and income.</p>
+          <p className="muted">Choose an area to plan.</p>
         </div>
       </header>
 
-      <div className="navigation-hub__cards">
+      <nav aria-label="Planning tools">
+        <ul className="secondary-links secondary-links--plan">
         {PLAN_DESTINATIONS.map((destination) => {
-          const { to, label, icon: Icon, description } = destination;
+          const { to, label, icon: Icon } = destination;
           return (
-            <Link className="card navigation-hub__link" to={to} key={to}>
-              <Icon className="navigation-hub__icon" size={24} aria-hidden="true" />
-              <h2 className="h2">{label}</h2>
-              <span className="navigation-hub__description">{description}</span>
-            </Link>
+            <li key={to}>
+              <Link className="secondary-link" to={to}>
+                <Icon className="secondary-link__icon" size={20} aria-hidden="true" />
+                <span className="secondary-link__label">{label}</span>
+              </Link>
+            </li>
           );
         })}
-      </div>
+        </ul>
+      </nav>
     </div>
   );
 }

--- a/frontend/src/app/pages/PlanPage.test.jsx
+++ b/frontend/src/app/pages/PlanPage.test.jsx
@@ -12,15 +12,12 @@ describe('Plan navigation hub', () => {
     render(<MemoryRouter><PlanPage /></MemoryRouter>)
 
     expect(screen.getByRole('heading', { name: 'Plan', level: 1 })).toBeInTheDocument()
-    expect(screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent)).toEqual([
-      'Budgets',
-      'Commitments',
-      'Paychecks',
-    ])
+    expect(screen.getByRole('navigation', { name: 'Planning tools' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Budgets/ })).toHaveAttribute('href', '/budgets')
     expect(screen.getByRole('link', { name: /Commitments/ })).toHaveAttribute('href', '/commitments')
     expect(screen.getByRole('link', { name: /Paychecks/ })).toHaveAttribute('href', '/paychecks')
     expect(screen.getAllByRole('link')).toHaveLength(3)
+    expect(screen.queryByText(/monthly category limits/i)).not.toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/pages/SettingsPage.jsx
+++ b/frontend/src/app/pages/SettingsPage.jsx
@@ -1,32 +1,31 @@
 import Card from "../../shared/ui/Card";
 import ThemeControl from "../../shared/theme/ThemeControl";
+import "../../styles/secondary-pages.css";
 
 export default function SettingsPage({ email }) {
   return (
-    <div className="shell-page">
+    <div className="shell-page secondary-page settings-page">
       <header className="page-header">
         <div>
-          <p className="page-header__eyebrow">Settings</p>
           <h1>Settings</h1>
-          <p className="muted">Review the signed-in account and presentation preferences supported on this device.</p>
+          <p className="muted">Choose how Ordo looks on this device.</p>
         </div>
       </header>
 
-      <div className="settings-grid">
-        <Card as="section" className="settings-card">
-          <h2 className="h2">Account</h2>
-          <p className="field__label">Signed-in email</p>
-          <p className="settings-value">{email}</p>
-          <p className="muted">This identifies the account currently signed in to the workspace.</p>
-        </Card>
-
-        <Card as="section" className="settings-card">
+      <div className="settings-page__content">
+        <Card as="section" className="settings-page__appearance">
           <h2 className="h2">Appearance</h2>
           <ThemeControl label="Theme preference" className="theme-control--settings" />
-          <p className="muted settings-card__note">
-            System follows this device’s appearance. Light or Dark is stored locally on this device.
-          </p>
+          <p className="muted settings-page__helper">System follows your device. Light or Dark is saved on this device.</p>
         </Card>
+
+        <section className="settings-page__account" aria-labelledby="settings-account-heading">
+          <h2 className="h2" id="settings-account-heading">Account</h2>
+          <dl className="settings-page__account-row">
+            <dt>Signed-in email</dt>
+            <dd>{email}</dd>
+          </dl>
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/app/pages/SettingsPage.test.jsx
+++ b/frontend/src/app/pages/SettingsPage.test.jsx
@@ -17,6 +17,11 @@ describe('Settings supported account and appearance behavior', () => {
     expect(screen.getByText('person@example.com')).toBeInTheDocument()
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent)).toEqual([
+      'Appearance',
+      'Account',
+    ])
+    expect(screen.getByText('Signed-in email').tagName).toBe('DT')
   })
 
   it('uses the existing theme preference and persistence behavior', async () => {
@@ -25,7 +30,7 @@ describe('Settings supported account and appearance behavior', () => {
     const control = screen.getByRole('combobox', { name: 'Theme preference' })
 
     expect(control).toHaveValue('system')
-    expect(screen.getByText(/stored locally on this device/)).toBeInTheDocument()
+    expect(screen.getByText(/saved on this device/)).toBeInTheDocument()
 
     await user.selectOptions(control, 'dark')
     expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')

--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -197,7 +197,7 @@ export default function AnalyticsPage() {
                     <div>
                       <p className="analytics-kicker">Top five</p>
                     </div>
-                    <Link to="/transactions">Review transactions</Link>
+                    <Link to="/transactions">Review activity</Link>
                   </div>
                   {insights.largestExpenses.length === 0 ? (
                     <StatusMessage>No expenses to rank for this month.</StatusMessage>

--- a/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.test.jsx
@@ -93,7 +93,7 @@ describe("monthly spending insights page", () => {
 
     expect(openDetail("Month-over-month change")).toHaveTextContent("+$25.00");
     expect(openDetail("Largest expenses")).toHaveTextContent("Groceries");
-    expect(screen.getByRole("link", { name: "Review transactions" })).toHaveAttribute("href", "/transactions");
+    expect(screen.getByRole("link", { name: "Review activity" })).toHaveAttribute("href", "/transactions");
   });
 
   it("keeps spending detail closed by default, keyboard reachable, and open across page state updates", () => {

--- a/frontend/src/features/auth/components/AuthFlows.test.jsx
+++ b/frontend/src/features/auth/components/AuthFlows.test.jsx
@@ -35,7 +35,7 @@ describe('existing authentication flows', () => {
     authApi.login.mockResolvedValue({ data: { token: 'jwt-value', email: 'person@example.com' } })
     renderAt(<AuthPage onLogin={onLogin} />)
 
-    expect(screen.getByRole('heading', { name: 'Log in', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Log in', level: 1 })).toHaveFocus()
     expect(screen.getByText('ordo')).not.toHaveRole('heading')
     expect(screen.getByText('Email', { selector: 'label' })).toBeVisible()
     expect(screen.getByText('Password', { selector: 'label' })).toBeVisible()
@@ -100,7 +100,7 @@ describe('existing authentication flows', () => {
     renderAt(<AuthPage onLogin={vi.fn()} />)
 
     await user.click(screen.getByRole('button', { name: 'Need an account? Register' }))
-    expect(screen.getByRole('heading', { name: 'Create account', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Create account', level: 1 })).toHaveFocus()
     expect(screen.getByText('Confirm password', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('Confirm password')).toBe(screen.getByPlaceholderText('Confirm Password'))
     await user.type(screen.getByPlaceholderText('Email'), 'person@example.com')
@@ -123,7 +123,7 @@ describe('existing authentication flows', () => {
       userId: 'user-123',
       token: 'a+b_c',
     }))
-    expect(await screen.findByRole('heading', { name: 'Email confirmed', level: 1 })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Email confirmed', level: 1 })).toHaveFocus()
     expect(screen.getByRole('status')).toHaveTextContent('You can now log in.')
   })
 
@@ -139,7 +139,7 @@ describe('existing authentication flows', () => {
     authApi.resetPassword.mockResolvedValue({ data: { message: 'ok' } })
     renderAt(<ResetPasswordPage />, '/reset-password?email=person%40example.com&token=reset%2Btoken')
 
-    expect(screen.getByRole('heading', { name: 'Reset password', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Reset password', level: 1 })).toHaveFocus()
     expect(screen.getByText('New password', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('New password')).toBe(screen.getByPlaceholderText('New password'))
     await user.type(screen.getByPlaceholderText('New password'), 'NewSecret1!')
@@ -159,7 +159,7 @@ describe('existing authentication flows', () => {
     })
     renderAt(<ForgotPasswordPage />, '/forgot-password')
 
-    expect(screen.getByRole('heading', { name: 'Forgot password', level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Forgot password', level: 1 })).toHaveFocus()
     expect(screen.getByText('Email', { selector: 'label' })).toBeVisible()
     expect(screen.getByLabelText('Email')).toBe(screen.getByPlaceholderText('Email'))
     await user.type(screen.getByPlaceholderText('Email'), 'unknown@example.com')
@@ -258,7 +258,7 @@ describe('existing authentication flows', () => {
       email: 'person@example.com',
       password: 'Secret1!',
     }))
-    expect(await screen.findByRole('heading', { name: 'Check your email', level: 1 })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Check your email', level: 1 })).toHaveFocus()
     expect(screen.getByRole('status')).toHaveTextContent('A confirmation link was sent to person@example.com.')
     expect(screen.getByText('person@example.com', { selector: 'strong' })).toBeVisible()
     expect(onLogin).not.toHaveBeenCalled()

--- a/frontend/src/features/auth/components/AuthShell.jsx
+++ b/frontend/src/features/auth/components/AuthShell.jsx
@@ -1,14 +1,19 @@
-import { useId } from "react";
+import { useEffect, useId, useRef } from "react";
 
 export default function AuthShell({ title, description, children }) {
   const titleId = useId();
+  const titleRef = useRef(null);
+
+  useEffect(() => {
+    titleRef.current?.focus({ preventScroll: true });
+  }, [title]);
 
   return (
     <div className="auth-page">
       <main className="auth-card" aria-labelledby={titleId}>
         <p className="auth-shell__brand">ordo</p>
         <header className="auth-shell__header">
-          <h1 id={titleId}>{title}</h1>
+          <h1 id={titleId} ref={titleRef} tabIndex={-1}>{title}</h1>
           {description && <p className="auth-help">{description}</p>}
         </header>
         <div className="auth-shell__content">{children}</div>

--- a/frontend/src/features/budgetLimits/components/BudgetLimitsPanel.jsx
+++ b/frontend/src/features/budgetLimits/components/BudgetLimitsPanel.jsx
@@ -1,233 +1,227 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { usedPercentage } from "../../../utils/budgets";
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import { displayText, normalizeText } from "../../../utils/text";
-import Card from "../../../shared/ui/Card";
 import FormField from "../../../shared/ui/FormField";
 import StatusMessage from "../../../shared/ui/StatusMessage";
 
+const roundMoney = (value) => Number(parseFloat(value || 0).toFixed(2));
+const isValidMoney = (value) => /^\d*\.?\d{0,2}$/.test(value);
+function focusAfterRender(target) {
+  window.requestAnimationFrame(() => target()?.focus());
+}
+
 export default function BudgetLimitsPanel({
-  limitMonthYear,
-  setLimitMonthYear,
-  budgetLimits,
-  limitsLoading,
-  totalsByCategory,
-  upsertLimit,
-  deleteLimit,
+  limitMonthYear, setLimitMonthYear, budgetLimits, limitsLoading,
+  limitsError = null, refreshLimits = async () => {},
+  spendingLoading = false, spendingError = null, refreshSpending = async () => {},
+  totalsByCategory, upsertLimit, deleteLimit,
 }) {
+  // Preserve the existing exact category keys and last-record grouping.
   const budgetLimitsByCategory = useMemo(() => {
-    const obj = {};
-    for (const l of budgetLimits ?? []) obj[l.category] = l;
-    return obj;
+    const result = {};
+    for (const limit of budgetLimits ?? []) result[limit.category] = limit;
+    return result;
   }, [budgetLimits]);
+  const [task, setTask] = useState(null);
+  const [pending, setPending] = useState(false);
+  const [feedback, setFeedback] = useState(null);
+  const [validation, setValidation] = useState(null);
+  const [outcomeNeedsRefresh, setOutcomeNeedsRefresh] = useState(false);
+  const writeInFlight = useRef(false);
+  const taskOpener = useRef(null);
+  const taskField = useRef(null);
+  const amountField = useRef(null);
+  const addButton = useRef(null);
+  const feedbackRegion = useRef(null);
+  const sectionHeading = useRef(null);
+  const limitsUnavailable = !limitMonthYear || limitsLoading || Boolean(limitsError);
+  const mutationDisabled = pending || limitsUnavailable || outcomeNeedsRefresh;
+  const spendingAvailable = !spendingLoading && !spendingError;
+  const [year, month] = limitMonthYear.split("-").map(Number);
+  const nextResetDate = limitMonthYear ? new Date(year, month, 1).toLocaleDateString() : "";
 
-  const [limitCategory, setLimitCategory] = useState("");
-  const [limitCustomCategory, setLimitCustomCategory] = useState("");
-  const [limitAmount, setLimitAmount] = useState("");
-
-  const [editingBudgetCategory, setEditingBudgetCategory] = useState(null);
-  const [editingBudgetData, setEditingBudgetData] = useState({});
-
-  const roundMoney = (val) => Number(parseFloat(val || 0).toFixed(2));
-  const isValidMoney = (val) => /^\d*\.?\d{0,2}$/.test(val);
-
-  async function handleSetBudgetLimit() {
-    if (!limitCategory || !limitAmount || !limitMonthYear) {
-      alert("Fill all budget limit fields");
+  function openAdd() {
+    if (task || mutationDisabled) return;
+    taskOpener.current = addButton.current;
+    setValidation(null);
+    setTask({ type: "add", month: limitMonthYear, category: "", customCategory: "", amount: "" });
+    focusAfterRender(() => taskField.current);
+  }
+  function openEdit(category, opener) {
+    if (task || mutationDisabled) return;
+    taskOpener.current = opener;
+    setValidation(null);
+    setTask({
+      type: "edit", month: limitMonthYear, category,
+      amount: Number(budgetLimitsByCategory[category]?.limitAmount ?? 0).toFixed(2),
+    });
+    focusAfterRender(() => taskField.current);
+  }
+  function cancelTask() {
+    if (writeInFlight.current) return;
+    setTask(null);
+    focusAfterRender(() => taskOpener.current?.isConnected && !taskOpener.current.disabled
+      ? taskOpener.current : sectionHeading.current);
+  }
+  async function mutate(action, successMessage) {
+    if (writeInFlight.current || mutationDisabled) return;
+    writeInFlight.current = true;
+    setPending(true);
+    setFeedback(null);
+    try {
+      const result = await action();
+      setTask(null);
+      setOutcomeNeedsRefresh(Boolean(result?.refreshFailed));
+      setFeedback({
+        tone: result?.refreshFailed ? "warning" : "success",
+        message: result?.refreshFailed
+          ? `${successMessage} Budget limits could not be refreshed. Refresh limits before making another change.`
+          : successMessage,
+      });
+    } catch {
+      setOutcomeNeedsRefresh(true);
+      setFeedback({ tone: "danger", message: "We couldn’t confirm the change. Refresh limits and check the saved budgets before trying again." });
+    } finally {
+      writeInFlight.current = false;
+      setPending(false);
+      focusAfterRender(() => feedbackRegion.current);
+    }
+  }
+  function saveTask() {
+    if (!task || mutationDisabled) return;
+    if (task.type === "add" && (!task.category || !task.amount || !task.month)) {
+      const field = !task.category ? "category" : "amount";
+      setValidation(field);
+      (field === "category" ? taskField.current : amountField.current)?.focus();
       return;
     }
-
-    const finalCategory =
-      limitCategory === "other"
-        ? normalizeText(limitCustomCategory || "uncategorized")
-        : normalizeText(limitCategory);
-
+    const category = task.type === "edit" ? task.category
+      : task.category === "other" ? normalizeText(task.customCategory || "uncategorized")
+        : normalizeText(task.category);
     const payload = {
-      category: finalCategory,
-      limitAmount: roundMoney(limitAmount),
-      monthYear: new Date(limitMonthYear + "-01T00:00:00").toISOString(),
+      category, limitAmount: roundMoney(task.amount),
+      monthYear: new Date(task.month + "-01T00:00:00").toISOString(),
     };
-
-    await upsertLimit(payload);
-
-    setLimitCategory("");
-    setLimitCustomCategory("");
-    setLimitAmount("");
+    return mutate(() => upsertLimit(payload), "Budget limit saved.");
   }
-
-  function startEditBudget(category) {
-    const limit = budgetLimitsByCategory[category];
-
-    setEditingBudgetCategory(category);
-    setEditingBudgetData({
-      limitAmount: Number(limit?.limitAmount ?? 0).toFixed(2),
-    });
-  }
-
-  function cancelEditBudget() {
-    setEditingBudgetCategory(null);
-    setEditingBudgetData({});
-  }
-
-  async function saveBudgetEdit(category) {
-    const payload = {
-      category,
-      limitAmount: roundMoney(editingBudgetData.limitAmount),
-      monthYear: new Date(limitMonthYear + "-01T00:00:00").toISOString(),
-    };
-
-    await upsertLimit(payload);
-    cancelEditBudget();
-  }
-
-  async function handleDeleteBudgetLimit(limitId, category) {
+  function removeLimit(limit, category) {
+    if (task || mutationDisabled) return;
     if (!window.confirm(`Delete budget limit for category "${displayText(category)}"?`)) return;
-    await deleteLimit(limitId);
+    return mutate(() => deleteLimit(limit.id), "Budget limit deleted.");
+  }
+  async function retryLimits() {
+    try {
+      await refreshLimits({ rethrow: true });
+      setOutcomeNeedsRefresh(false);
+      setFeedback(outcomeNeedsRefresh
+        ? { tone: "info", message: "Budget limits refreshed. Check the saved limits before retrying your change." }
+        : null);
+    } catch {
+      // Keep unknown write outcomes gated until the selected month can be read.
+    }
   }
 
   return (
-    <Card as="section" className="section">
-      <h2 className="h2">Budget Limits for {limitMonthYear}</h2>
-
-      {limitsLoading ? (
-        <StatusMessage>Loading budget limits...</StatusMessage>
-      ) : Object.keys(budgetLimitsByCategory).length === 0 ? (
-        <p className="empty-state">No budget limits set for this month.</p>
-      ) : (
-        <div className="table-wrapper" role="region" aria-label="Budget limits table" tabIndex="0">
-          <table className="data-table" border="1" cellPadding="6">
-            <caption className="sr-only">Budget limits for {limitMonthYear}</caption>
-            <thead>
-              <tr>
-                <th>Category</th>
-                <th>Limit Amount ($)</th>
-                <th>Used ($)</th>
-                <th>Next Reset</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-
-            <tbody>
-              {Object.entries(budgetLimitsByCategory).map(([cat, limit]) => {
-                const used = Number((totalsByCategory[cat] || 0).toFixed(2));
-                const limitAmt = Number((limit.limitAmount || 0).toFixed(2));
-                const pct = limitAmt ? usedPercentage(used, limitAmt) : 0;
-
-                const nextResetDate = (() => {
-                  const [yr, mon] = limitMonthYear.split("-").map(Number);
-                  return new Date(yr, mon, 1);
-                })();
-
-                return (
-                  <tr key={cat} className={used >= limitAmt * 0.9 ? "budget-row--warning" : undefined}>
-                    <td>{displayText(cat)}</td>
-
-                    <td>
-                      {editingBudgetCategory === cat ? (
-                        <input
-                          aria-label={`Limit amount for ${displayText(cat)}`}
-                          type="text"
-                          value={editingBudgetData.limitAmount}
-                          onChange={(e) => {
-                            const value = e.target.value;
-
-                            if (isValidMoney(value)) {
-                              setEditingBudgetData((p) => ({
-                                ...p,
-                                limitAmount: value,
-                              }));
-                            }
-                          }}
-                        />
-                      ) : (
-                        limitAmt.toFixed(2)
-                      )}
-                    </td>
-
-                    <td>
-                      {used.toFixed(2)}
-                      {limitAmt ? (
-                        <span className={pct >= 90 ? "budget-usage--warning" : undefined}>
-                          ({Math.round(pct)}%)
-                        </span>
-                      ) : null}
-                    </td>
-
-                    <td>{nextResetDate.toLocaleDateString()}</td>
-
-                    <td>
-                      {editingBudgetCategory === cat ? (
-                        <div className="inline-actions">
-                          <button onClick={() => saveBudgetEdit(cat)}>Save</button>
-                          <button className="button-ghost" onClick={cancelEditBudget}>
-                            Cancel
-                          </button>
-                        </div>
-                      ) : (
-                        <div className="inline-actions">
-                          <button onClick={() => startEditBudget(cat)}>Edit</button>
-                          <button
-                            className="button-danger"
-                            onClick={() => handleDeleteBudgetLimit(limit.id, cat)}
-                          >
-                            Delete
-                          </button>
-                        </div>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      <div className="section">
-        <h2 className="h2">Set Budget Limit</h2>
-
-        <div className="form-grid">
-          <FormField label="Category">{(id) => <select id={id} value={limitCategory} onChange={(e) => setLimitCategory(e.target.value)}>
-            <option value="">Category</option>
-            {DEFAULT_CATEGORIES.map((c) => (
-              <option key={c} value={c.toLowerCase()}>
-                {displayText(c)}
-              </option>
-            ))}
-            <option value="other">Other</option>
-          </select>}</FormField>
-
-          {limitCategory === "other" && (
-            <FormField label="Custom category">{(id) => <input id={id}
-              type="text"
-              placeholder="Custom Category"
-              value={limitCustomCategory}
-              onChange={(e) => setLimitCustomCategory(e.target.value)}
-            />}</FormField>
-          )}
-
-          <FormField label="Limit amount">{(id) => <input id={id}
-            type="text"
-            placeholder="Limit Amount"
-            value={limitAmount}
-            onChange={(e) => {
-              const value = e.target.value;
-
-              if (isValidMoney(value)) {
-                setLimitAmount(value);
-              }
-            }}
-          />}</FormField>
-
-          <FormField label="Budget month">{(id) => <input id={id}
-            type="month"
-            value={limitMonthYear}
-            onChange={(e) => setLimitMonthYear(e.target.value)}
-          />}</FormField>
-
-          <button onClick={handleSetBudgetLimit}>Save Limit</button>
-        </div>
+    <section className="budget-workspace" aria-labelledby="category-budgets-heading">
+      <div className="budget-toolbar">
+        <FormField label="Budget month">{(id) => <input id={id} type="month" value={limitMonthYear}
+          disabled={Boolean(task) || pending || outcomeNeedsRefresh}
+          onChange={(event) => { setLimitMonthYear(event.target.value); setFeedback(null); }} />}</FormField>
+        <button type="button" ref={addButton} aria-expanded={task?.type === "add"} aria-controls="budget-task"
+          disabled={Boolean(task) || mutationDisabled} onClick={openAdd}>Add category budget</button>
       </div>
-    </Card>
+      {task && <p className="muted budget-task-note">Finish or cancel this {task.month} budget before changing months.</p>}
+      <div ref={feedbackRegion} tabIndex={-1} className="budget-feedback">
+        {feedback && <StatusMessage tone={feedback.tone}>{feedback.message}</StatusMessage>}
+      </div>
+      <div id="budget-task" hidden={!task}>
+        {task && <form className="card budget-form" noValidate onSubmit={(event) => { event.preventDefault(); saveTask(); }}>
+          <h2>{task.type === "edit" ? `Edit ${displayText(task.category)} budget` : "Add category budget"}</h2>
+          <p className="muted">For {task.month}</p>
+          {validation && <div id="budget-validation"><StatusMessage tone="danger">Choose a category and enter a limit amount.</StatusMessage></div>}
+          <fieldset disabled={pending}>
+            <legend className="sr-only">Budget details</legend>
+            <div className="budget-form__fields">
+              {task.type === "add" && <FormField label="Category">{(id) => <select id={id} ref={taskField}
+                aria-invalid={validation === "category" && !task.category} aria-describedby={validation ? "budget-validation" : undefined}
+                value={task.category} onChange={(event) => setTask((current) => ({ ...current, category: event.target.value }))}>
+                <option value="">Category</option>
+                {DEFAULT_CATEGORIES.map((category) => <option key={category} value={category.toLowerCase()}>{displayText(category)}</option>)}
+                <option value="other">Other</option>
+              </select>}</FormField>}
+              {task.type === "add" && task.category === "other" && <FormField label="Custom category">{(id) => <input id={id}
+                placeholder="Custom Category" value={task.customCategory}
+                onChange={(event) => setTask((current) => ({ ...current, customCategory: event.target.value }))} />}</FormField>}
+              <FormField label={task.type === "edit" ? `Limit amount for ${displayText(task.category)}` : "Limit amount"}>{(id) => <input id={id}
+                ref={(element) => { amountField.current = element; if (task.type === "edit") taskField.current = element; }}
+                aria-invalid={validation === "amount" && !task.amount} aria-describedby={validation ? "budget-validation" : undefined}
+                type="text" inputMode="decimal" placeholder="Limit Amount" value={task.amount}
+                onChange={(event) => {
+                  if (isValidMoney(event.target.value)) setTask((current) => ({ ...current, amount: event.target.value }));
+                }} />}</FormField>
+            </div>
+          </fieldset>
+          <div className="inline-actions">
+            <button type="submit" disabled={mutationDisabled}>{pending ? "Saving…" : "Save limit"}</button>
+            <button type="button" className="button-ghost" disabled={pending} onClick={cancelTask}>Cancel</button>
+          </div>
+        </form>}
+      </div>
+      <div className="budget-section-header">
+        <h2 id="category-budgets-heading" ref={sectionHeading} tabIndex={-1}>Category budgets</h2>
+        <button type="button" className="button-ghost" disabled={limitsLoading || pending || !limitMonthYear} onClick={retryLimits}>Refresh limits</button>
+      </div>
+      {!limitMonthYear ? <StatusMessage>Choose a month to view its category budgets.</StatusMessage>
+        : limitsLoading ? <StatusMessage>Loading budget limits...</StatusMessage>
+          : limitsError ? <StatusMessage tone="danger">We couldn’t load budget limits for {limitMonthYear}. Refresh limits to try again.</StatusMessage>
+            : null}
+      {limitMonthYear && spendingLoading && <StatusMessage>Loading recorded spending...</StatusMessage>}
+      {limitMonthYear && spendingError && <div className="budget-spending-error">
+        <StatusMessage tone="danger">We couldn’t load recorded spending. Used amounts and progress are unavailable.</StatusMessage>
+        <button type="button" className="button-ghost" disabled={spendingLoading || pending}
+          onClick={() => refreshSpending().catch(() => {})}>Retry spending</button>
+      </div>}
+      {!limitsUnavailable && (Object.keys(budgetLimitsByCategory).length === 0
+        ? <p className="empty-state">No budget limits set for this month.</p>
+        : <div className="budget-cards">
+          {Object.entries(budgetLimitsByCategory).map(([category, limit]) => {
+            const name = displayText(category);
+            const used = Number((totalsByCategory[category] || 0).toFixed(2));
+            const limitAmount = Number((limit.limitAmount || 0).toFixed(2));
+            const percentage = limitAmount ? usedPercentage(used, limitAmount) : 0;
+            const warning = spendingAvailable && used >= limitAmount * 0.9;
+            const status = !spendingAvailable ? "Spending unavailable"
+              : !limitAmount ? "Zero limit"
+                : used > limitAmount ? "Over limit" : used === limitAmount ? "Limit reached"
+                  : warning ? "Near limit" : "Within limit";
+            return <article key={category} className={`card budget-card${warning ? " budget-card--warning" : ""}`} aria-label={`${name} budget`}>
+              <div className="budget-card__header"><h3>{name}</h3><span className="budget-card__status">{status}</span></div>
+              <p className="budget-card__amounts">
+                <strong>{spendingAvailable ? `$${used.toFixed(2)}` : "Unavailable"}</strong>
+                <span> used of ${limitAmount.toFixed(2)}</span>
+              </p>
+              {spendingAvailable && limitAmount > 0 && <div className="budget-card__progress">
+                <progress max="100" value={Math.min(100, Math.max(0, percentage))} aria-label={`${name} budget used`}
+                  aria-valuetext={`$${used.toFixed(2)} used of $${limitAmount.toFixed(2)}, ${Math.round(percentage)}%`} />
+                <span>{Math.round(percentage)}% used</span>
+              </div>}
+              {spendingAvailable && limitAmount === 0 && <p className="muted budget-card__note">No percentage for a zero limit.</p>}
+              <div className="inline-actions">
+                <button type="button" aria-label={`Edit ${name} budget`} aria-controls="budget-task"
+                  aria-expanded={task?.type === "edit" && task.category === category}
+                  disabled={Boolean(task) || mutationDisabled} onClick={(event) => openEdit(category, event.currentTarget)}>Edit</button>
+                <button type="button" className="button-danger" aria-label={`Delete ${name} budget`}
+                  disabled={Boolean(task) || mutationDisabled} onClick={() => removeLimit(limit, category)}>Delete</button>
+              </div>
+            </article>;
+          })}
+        </div>)}
+      {limitMonthYear && <details className="budget-explanation">
+        <summary>About monthly limits</summary>
+        <p>Next reset: {nextResetDate}. Each limit applies to its selected calendar month.</p>
+        <p>A zero limit is an intentional no-spend budget. It is different from having no budget for a category.</p>
+      </details>}
+    </section>
   );
 }

--- a/frontend/src/features/budgetLimits/components/BudgetLimitsPanel.test.jsx
+++ b/frontend/src/features/budgetLimits/components/BudgetLimitsPanel.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BudgetLimitsPanel from './BudgetLimitsPanel'
@@ -21,9 +21,10 @@ describe('existing budget-limit workflows', () => {
     const upsertLimit = vi.fn().mockResolvedValue(undefined)
     render(<BudgetLimitsPanel {...baseProps} upsertLimit={upsertLimit} />)
 
+    await user.click(screen.getByRole('button', { name: 'Add category budget' }))
     await user.selectOptions(screen.getByRole('combobox'), 'food')
     await user.type(screen.getByPlaceholderText('Limit Amount'), '123.45')
-    await user.click(screen.getByRole('button', { name: 'Save Limit' }))
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
 
     expect(upsertLimit).toHaveBeenCalledWith({
       category: 'food',
@@ -37,10 +38,11 @@ describe('existing budget-limit workflows', () => {
     const upsertLimit = vi.fn().mockResolvedValue(undefined)
     render(<BudgetLimitsPanel {...baseProps} upsertLimit={upsertLimit} />)
 
+    await user.click(screen.getByRole('button', { name: 'Add category budget' }))
     await user.selectOptions(screen.getByRole('combobox'), 'other')
     await user.type(screen.getByPlaceholderText('Custom Category'), '  Home Repair  ')
     await user.type(screen.getByPlaceholderText('Limit Amount'), '80')
-    await user.click(screen.getByRole('button', { name: 'Save Limit' }))
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
 
     expect(upsertLimit).toHaveBeenCalledWith(expect.objectContaining({
       category: 'home repair',
@@ -58,19 +60,169 @@ describe('existing budget-limit workflows', () => {
       totalsByCategory={{ 'Home Repair': 10 }}
     />)
 
-    const row = screen.getByText('Home Repair').closest('tr')
-    expect(screen.getByRole('region', { name: 'Budget limits table' })).toHaveAttribute('tabindex', '0')
-    expect(screen.getByText('Budget limits for 2026-08', { selector: 'caption' })).toBeInTheDocument()
-    await user.click(within(row).getByRole('button', { name: 'Edit' }))
-    expect(within(row).getByLabelText('Limit amount for Home Repair')).toBeInTheDocument()
-    await user.clear(within(row).getByRole('textbox'))
-    await user.type(within(row).getByRole('textbox'), '75.25')
-    await user.click(within(row).getByRole('button', { name: 'Save' }))
+    const row = screen.getByRole('article', { name: 'Home Repair budget' })
+    expect(within(row).getByRole('progressbar')).toHaveAttribute('aria-valuetext', '$10.00 used of $50.00, 20%')
+    await user.click(within(row).getByRole('button', { name: 'Edit Home Repair budget' }))
+    expect(screen.getByLabelText('Limit amount for Home Repair')).toBeInTheDocument()
+    await user.clear(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), '75.25')
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
 
     expect(upsertLimit).toHaveBeenCalledWith({
       category: 'Home Repair',
       limitAmount: 75.25,
       monthYear: new Date('2026-08-01T00:00:00').toISOString(),
     })
+  })
+})
+
+describe('budget hierarchy and truthful states', () => {
+  it('explains incomplete add fields inline and focuses the first missing value without changing zero semantics', async () => {
+    const user = userEvent.setup()
+    const upsertLimit = vi.fn().mockResolvedValue({ refreshFailed: false })
+    render(<BudgetLimitsPanel {...baseProps} upsertLimit={upsertLimit} />)
+    await user.click(screen.getByRole('button', { name: 'Add category budget' }))
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('Choose a category and enter a limit amount.')
+    expect(screen.getByLabelText('Category')).toHaveFocus()
+    expect(screen.getByLabelText('Category')).toHaveAttribute('aria-invalid', 'true')
+    await user.selectOptions(screen.getByLabelText('Category'), 'food')
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
+    expect(screen.getByLabelText('Limit amount')).toHaveFocus()
+    expect(upsertLimit).not.toHaveBeenCalled()
+    await user.type(screen.getByLabelText('Limit amount'), '0{Enter}')
+    expect(upsertLimit).toHaveBeenCalledWith(expect.objectContaining({ category: 'food', limitAmount: 0 }))
+  })
+  const limits = [
+    { id: 1, category: 'food', limitAmount: 100 },
+    { id: 2, category: 'bills', limitAmount: 100 },
+    { id: 3, category: 'zero', limitAmount: 0 },
+  ]
+  it('leads with month and progress while keeping the add form and reset details closed', () => {
+    render(<BudgetLimitsPanel {...baseProps} budgetLimits={limits} totalsByCategory={{ food: 95, bills: 125 }} />)
+    expect(screen.getByLabelText('Budget month')).toHaveValue('2026-08')
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    const food = screen.getByRole('article', { name: 'Food budget' })
+    expect(within(food).getByText('Near limit')).toBeVisible()
+    expect(within(food).getByRole('progressbar')).toHaveValue(95)
+    const bills = screen.getByRole('article', { name: 'Bills budget' })
+    expect(within(bills).getByText('Over limit')).toBeVisible()
+    expect(within(bills).getByText('125% used')).toBeVisible()
+    expect(within(bills).getByRole('progressbar')).toHaveValue(100)
+    expect(within(bills).getByRole('progressbar')).toHaveAttribute('aria-valuetext', '$125.00 used of $100.00, 125%')
+    const zero = screen.getByRole('article', { name: 'Zero budget' })
+    expect(within(zero).getByText('Zero limit')).toBeVisible()
+    expect(within(zero).queryByRole('progressbar')).not.toBeInTheDocument()
+    expect(zero).toHaveClass('budget-card--warning')
+    expect(screen.getByText('About monthly limits').closest('details')).not.toHaveAttribute('open')
+  })
+  it.each([{ spendingLoading: true }, { spendingError: new Error('offline') }])('never renders zero spending or progress when the read is unavailable: %j', (state) => {
+    render(<BudgetLimitsPanel {...baseProps} {...state} budgetLimits={limits} />)
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    for (const card of screen.getAllByRole('article')) {
+      expect(within(card).getByText('Unavailable')).toBeVisible()
+      expect(within(card).getByText('Spending unavailable')).toBeVisible()
+      expect(card).not.toHaveClass('budget-card--warning')
+    }
+    expect(screen.queryByText('Within limit')).not.toBeInTheDocument()
+    expect(screen.queryByText('0% used')).not.toBeInTheDocument()
+  })
+  it('exposes separate limits and spending retries and never treats failures as empty budgets', async () => {
+    const user = userEvent.setup()
+    const refreshLimits = vi.fn().mockRejectedValue(new Error('offline'))
+    const refreshSpending = vi.fn().mockRejectedValue(new Error('offline'))
+    render(<BudgetLimitsPanel {...baseProps} limitsError={new Error('offline')} spendingError={new Error('offline')}
+      refreshLimits={refreshLimits} refreshSpending={refreshSpending} />)
+    expect(screen.getAllByRole('alert')).toHaveLength(2)
+    expect(screen.queryByText('No budget limits set for this month.')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Refresh limits' }))
+    await user.click(screen.getByRole('button', { name: 'Retry spending' }))
+    expect(refreshLimits).toHaveBeenCalledWith({ rethrow: true })
+    expect(refreshSpending).toHaveBeenCalledOnce()
+  })
+  it('shows loading and missing-month prompts without false empty results', () => {
+    const { rerender } = render(<BudgetLimitsPanel {...baseProps} limitsLoading />)
+    expect(screen.getByRole('status')).toHaveTextContent('Loading budget limits')
+    expect(screen.queryByText('No budget limits set for this month.')).not.toBeInTheDocument()
+    rerender(<BudgetLimitsPanel {...baseProps} limitMonthYear="" />)
+    expect(screen.getByRole('status')).toHaveTextContent('Choose a month')
+    expect(screen.getByRole('button', { name: 'Add category budget' })).toBeDisabled()
+  })
+  it('keeps a draft visible through refresh failure, locks its month, and restores opener focus on cancel', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<BudgetLimitsPanel {...baseProps} budgetLimits={limits} />)
+    const opener = screen.getByRole('button', { name: 'Edit Food budget' })
+    await user.click(opener)
+    const input = screen.getByLabelText('Limit amount for Food')
+    await user.clear(input)
+    await user.type(input, '123.45')
+    expect(screen.getByLabelText('Budget month')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Add category budget' })).toBeDisabled()
+    await user.click(screen.getByText('About monthly limits'))
+    await user.click(screen.getByText('About monthly limits'))
+    rerender(<BudgetLimitsPanel {...baseProps} limitsLoading />)
+    expect(input).toHaveValue('123.45')
+    expect(input).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Save limit' })).toBeDisabled()
+    rerender(<BudgetLimitsPanel {...baseProps} limitsError={new Error('offline')} />)
+    expect(input).toHaveValue('123.45')
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)) })
+    expect(screen.getByRole('heading', { name: 'Category budgets' })).toHaveFocus()
+    expect(screen.getByLabelText('Budget month')).toBeEnabled()
+  })
+  it('keeps money-input behavior and permits an explicit zero limit', async () => {
+    const user = userEvent.setup()
+    const upsertLimit = vi.fn().mockResolvedValue(undefined)
+    render(<BudgetLimitsPanel {...baseProps} upsertLimit={upsertLimit} />)
+    await user.click(screen.getByRole('button', { name: 'Add category budget' }))
+    await user.selectOptions(screen.getByRole('combobox'), 'food')
+    const amount = screen.getByLabelText('Limit amount')
+    fireEvent.change(amount, { target: { value: '12.345' } })
+    expect(amount).toHaveValue('')
+    await user.type(amount, '0')
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
+    expect(upsertLimit).toHaveBeenCalledWith({ category: 'food', limitAmount: 0, monthYear: new Date('2026-08-01T00:00:00').toISOString() })
+  })
+  it('locks pending writes and retains an uncertain draft until a successful explicit refresh', async () => {
+    const user = userEvent.setup()
+    let rejectSave
+    const upsertLimit = vi.fn(() => new Promise((resolve, reject) => { rejectSave = reject }))
+    const refreshLimits = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(undefined)
+    render(<BudgetLimitsPanel {...baseProps} budgetLimits={limits} upsertLimit={upsertLimit} refreshLimits={refreshLimits} />)
+    await user.click(screen.getByRole('button', { name: 'Edit Food budget' }))
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
+    expect(screen.getByLabelText('Limit amount for Food')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    expect(screen.getByLabelText('Budget month')).toBeDisabled()
+    await act(async () => rejectSave(new Error('uncertain')))
+    expect(screen.getByRole('alert')).toHaveTextContent('We couldn’t confirm the change')
+    expect(screen.getByLabelText('Limit amount for Food')).toHaveValue('100.00')
+    expect(screen.getByRole('button', { name: 'Save limit' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Refresh limits' }))
+    expect(screen.getByRole('button', { name: 'Save limit' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Refresh limits' }))
+    expect(screen.getByRole('button', { name: 'Save limit' })).toBeEnabled()
+    expect(upsertLimit).toHaveBeenCalledOnce()
+  })
+  it('reports a known completed write separately from its failed refresh and clears that draft', async () => {
+    const user = userEvent.setup()
+    render(<BudgetLimitsPanel {...baseProps} budgetLimits={limits} upsertLimit={vi.fn().mockResolvedValue({ refreshFailed: true })} />)
+    await user.click(screen.getByRole('button', { name: 'Edit Food budget' }))
+    await user.click(screen.getByRole('button', { name: 'Save limit' }))
+    expect(screen.queryByLabelText('Limit amount for Food')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Budget limit saved. Budget limits could not be refreshed.')
+    expect(screen.getByRole('button', { name: 'Edit Food budget' })).toBeDisabled()
+  })
+  it('retains explicit delete confirmation and the exact limit id', async () => {
+    const user = userEvent.setup()
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValueOnce(false).mockReturnValueOnce(true)
+    const deleteLimit = vi.fn().mockResolvedValue(undefined)
+    render(<BudgetLimitsPanel {...baseProps} budgetLimits={limits} deleteLimit={deleteLimit} />)
+    await user.click(screen.getByRole('button', { name: 'Delete Food budget' }))
+    expect(deleteLimit).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'Delete Food budget' }))
+    expect(confirm).toHaveBeenCalledWith('Delete budget limit for category "Food"?')
+    expect(deleteLimit).toHaveBeenCalledWith(1)
   })
 })

--- a/frontend/src/features/budgetLimits/hooks/useBudgetLimits.js
+++ b/frontend/src/features/budgetLimits/hooks/useBudgetLimits.js
@@ -3,13 +3,22 @@ import { budgetLimitsApi } from "../api/budgetLimitsApi";
 
 export function useBudgetLimits(monthYear) {
   const [budgetLimits, setBudgetLimits] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [queryMonth, setQueryMonth] = useState(monthYear);
   const requestId = useRef(0);
 
   const refresh = useCallback(async function refresh({ rethrow = false } = {}) {
-    if (!monthYear) return;
+    if (!monthYear) {
+      requestId.current += 1;
+      setQueryMonth("");
+      setBudgetLimits([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
     const currentRequestId = ++requestId.current;
+    setQueryMonth(monthYear);
     setLoading(true);
     setError(null);
     setBudgetLimits([]);
@@ -31,15 +40,30 @@ export function useBudgetLimits(monthYear) {
     return () => { requestId.current += 1; };
   }, [refresh]);
 
+  async function refreshAfterWrite() {
+    try {
+      await refresh({ rethrow: true });
+      return { refreshFailed: false };
+    } catch {
+      return { refreshFailed: true };
+    }
+  }
+
   async function upsertLimit(payload) {
     await budgetLimitsApi.upsert(payload);
-    await refresh({ rethrow: true });
+    return refreshAfterWrite();
   }
 
   async function deleteLimit(id) {
     await budgetLimitsApi.remove(id);
-    await refresh({ rethrow: true });
+    return refreshAfterWrite();
   }
 
-  return { budgetLimits, loading, error, refresh, upsertLimit, deleteLimit };
+  const currentMonth = queryMonth === monthYear;
+  return {
+    budgetLimits: currentMonth && monthYear ? budgetLimits : [],
+    loading: Boolean(monthYear) && (loading || !currentMonth),
+    error: currentMonth && monthYear ? error : null,
+    refresh, upsertLimit, deleteLimit,
+  };
 }

--- a/frontend/src/features/budgetLimits/hooks/useBudgetLimits.test.js
+++ b/frontend/src/features/budgetLimits/hooks/useBudgetLimits.test.js
@@ -72,3 +72,71 @@ describe('budget-limit refresh behavior', () => {
     expect(budgetLimitsApi.getByMonth).toHaveBeenLastCalledWith('2026-08')
   })
 })
+
+describe('budget read and write outcomes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    budgetLimitsApi.getByMonth.mockResolvedValue({ data: [] })
+  })
+  it.each([
+    ['upsertLimit', 'upsert', [{ category: 'food', limitAmount: 0, monthYear: '2026-08-01T05:00:00.000Z' }]],
+    ['deleteLimit', 'remove', [7]],
+  ])('retains successful %s when its subsequent read fails', async (method, apiMethod, args) => {
+    const { result } = renderHook(() => useBudgetLimits('2026-08'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    budgetLimitsApi[apiMethod].mockResolvedValueOnce({})
+    const error = new Error('read failed')
+    budgetLimitsApi.getByMonth.mockRejectedValueOnce(error)
+    let outcome
+    await act(async () => { outcome = await result.current[method](...args) })
+    expect(outcome).toEqual({ refreshFailed: true })
+    expect(result.current.error).toBe(error)
+    expect(budgetLimitsApi[apiMethod]).toHaveBeenCalledExactlyOnceWith(...args)
+  })
+  it('preserves write rejection and does not turn it into a completed save', async () => {
+    const { result } = renderHook(() => useBudgetLimits('2026-08'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const error = new Error('write failed')
+    budgetLimitsApi.upsert.mockRejectedValueOnce(error)
+    await act(async () => { await expect(result.current.upsertLimit({})).rejects.toBe(error) })
+    expect(budgetLimitsApi.getByMonth).toHaveBeenCalledTimes(1)
+  })
+  it('never exposes old limits under the newly selected month, including the render before effects', async () => {
+    const observations = []
+    budgetLimitsApi.getByMonth.mockImplementation((month) => month === '2026-08'
+      ? Promise.resolve({ data: [{ id: 1, category: 'old month' }] }) : new Promise(() => {}))
+    const { result, rerender } = renderHook(({ month }) => {
+      const value = useBudgetLimits(month)
+      observations.push({ month, limits: value.budgetLimits, loading: value.loading })
+      return value
+    }, { initialProps: { month: '2026-08' } })
+    await waitFor(() => expect(result.current.budgetLimits).toHaveLength(1))
+    rerender({ month: '2026-09' })
+    expect(observations.filter((value) => value.month === '2026-09').every((value) => value.loading && value.limits.length === 0)).toBe(true)
+  })
+  it('clears the view for an empty month selection without requesting an empty month', async () => {
+    const { result, rerender } = renderHook(({ month }) => useBudgetLimits(month), { initialProps: { month: '2026-08' } })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    rerender({ month: '' })
+    expect(result.current.budgetLimits).toEqual([])
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(budgetLimitsApi.getByMonth).not.toHaveBeenCalledWith('')
+  })
+  it('does not revive old limits while reselecting the same month after clearing it', async () => {
+    const observations = []
+    budgetLimitsApi.getByMonth.mockResolvedValueOnce({ data: [{ id: 1, category: 'old result' }] })
+    const { result, rerender } = renderHook(({ month }) => {
+      const value = useBudgetLimits(month)
+      observations.push({ month, limits: value.budgetLimits, loading: value.loading })
+      return value
+    }, { initialProps: { month: '2026-08' } })
+    await waitFor(() => expect(result.current.budgetLimits).toHaveLength(1))
+    rerender({ month: '' })
+    observations.length = 0
+    budgetLimitsApi.getByMonth.mockImplementationOnce(() => new Promise(() => {}))
+    rerender({ month: '2026-08' })
+    expect(observations.length).toBeGreaterThan(0)
+    expect(observations.every((value) => value.loading && value.limits.length === 0)).toBe(true)
+  })
+})

--- a/frontend/src/features/budgetLimits/pages/BudgetsPage.jsx
+++ b/frontend/src/features/budgetLimits/pages/BudgetsPage.jsx
@@ -4,13 +4,16 @@ import { useBudgetLimits } from "../hooks/useBudgetLimits";
 import { computeMonthlyTotalsByCategory } from "../utils/totalsByCategory";
 import { getMonthYear } from "../../../shared/utils/monthYear";
 import BudgetLimitsPanel from "../components/BudgetLimitsPanel";
+import "../../../styles/budgets.css";
 
 export default function BudgetsPage() {
-  const { expenses } = useExpenses();
+  const { expenses, loading: spendingLoading, error: spendingError, refresh: refreshSpending } = useExpenses();
   const [limitMonthYear, setLimitMonthYear] = useState(getMonthYear(new Date()));
   const {
     budgetLimits,
     loading: limitsLoading,
+    error: limitsError,
+    refresh: refreshLimits,
     upsertLimit,
     deleteLimit,
   } = useBudgetLimits(limitMonthYear);
@@ -21,12 +24,11 @@ export default function BudgetsPage() {
   );
 
   return (
-    <div className="container">
+    <div className="container budgets-page">
       <header className="page-header">
         <div>
-          <p className="page-header__eyebrow">Plan your spending</p>
           <h1>Budgets</h1>
-          <p className="muted">Set monthly category limits and track how much you have used.</p>
+          <p className="muted">See how your spending compares with each category limit.</p>
         </div>
       </header>
 
@@ -35,6 +37,11 @@ export default function BudgetsPage() {
         setLimitMonthYear={setLimitMonthYear}
         budgetLimits={budgetLimits}
         limitsLoading={limitsLoading}
+        limitsError={limitsError}
+        refreshLimits={refreshLimits}
+        spendingLoading={spendingLoading}
+        spendingError={spendingError}
+        refreshSpending={refreshSpending}
         totalsByCategory={totalsByCategory}
         upsertLimit={upsertLimit}
         deleteLimit={deleteLimit}

--- a/frontend/src/features/budgetLimits/pages/BudgetsPage.test.jsx
+++ b/frontend/src/features/budgetLimits/pages/BudgetsPage.test.jsx
@@ -7,8 +7,12 @@ import { useBudgetLimits } from '../hooks/useBudgetLimits'
 vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
 vi.mock('../hooks/useBudgetLimits', () => ({ useBudgetLimits: vi.fn() }))
 vi.mock('../components/BudgetLimitsPanel', () => ({
-  default: ({ limitMonthYear, setLimitMonthYear, totalsByCategory, upsertLimit, deleteLimit }) => (
+  default: ({ limitMonthYear, setLimitMonthYear, totalsByCategory, upsertLimit, deleteLimit, limitsLoading, limitsError, spendingLoading, spendingError, refreshLimits, refreshSpending }) => (
     <div data-testid="budget-panel">
+      <span data-testid="limits-state">{limitsLoading ? 'loading' : limitsError ? 'error' : 'ready'}</span>
+      <span data-testid="spending-state">{spendingLoading ? 'loading' : spendingError ? 'error' : 'ready'}</span>
+      <button onClick={refreshLimits}>Refresh limits</button>
+      <button onClick={refreshSpending}>Refresh spending</button>
       <span data-testid="budget-month">{limitMonthYear}</span>
       <span data-testid="budget-totals">{JSON.stringify(totalsByCategory)}</span>
       <button onClick={() => setLimitMonthYear('2026-07')}>Choose July</button>
@@ -67,4 +71,21 @@ describe('Budgets page ownership', () => {
     expect(screen.getByTestId('budget-totals')).toHaveTextContent('{"bills":50}')
     expect(useBudgetLimits).toHaveBeenLastCalledWith('2026-07')
   })
+  it('forwards independent read states and retry functions to the budget presentation', () => {
+    const refreshLimits = vi.fn()
+    const refreshSpending = vi.fn()
+    useBudgetLimits.mockReturnValue({ budgetLimits: [], loading: false, error: new Error('limits'), refresh: refreshLimits })
+    useExpenses.mockReturnValue({ expenses: [], loading: true, error: null, refresh: refreshSpending })
+    const { rerender } = render(<BudgetsPage />)
+    expect(screen.getByTestId('limits-state')).toHaveTextContent('error')
+    expect(screen.getByTestId('spending-state')).toHaveTextContent('loading')
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh limits' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh spending' }))
+    expect(refreshLimits).toHaveBeenCalledOnce()
+    expect(refreshSpending).toHaveBeenCalledOnce()
+    useExpenses.mockReturnValue({ expenses: [], loading: false, error: new Error('spending'), refresh: refreshSpending })
+    rerender(<BudgetsPage />)
+    expect(screen.getByTestId('spending-state')).toHaveTextContent('error')
+  })
+
 })

--- a/frontend/src/features/commitments/components/CommitmentChangeReview.jsx
+++ b/frontend/src/features/commitments/components/CommitmentChangeReview.jsx
@@ -3,6 +3,7 @@ import Card from "../../../shared/ui/Card";
 import CommitmentEvidence from "./CommitmentEvidence";
 import { formatDate, formatMoney } from "../utils/formatCommitments";
 import groupCommitmentChanges from "../utils/groupCommitmentChanges";
+import { displayText } from "../../../utils/text";
 
 function title(value) {
   const text = value?.replaceAll("_", " ").replace(/([a-z])([A-Z])/g, "$1 $2") ?? "";
@@ -80,7 +81,7 @@ function Comparison({ change, dimension, assessment }) {
   return (
     <dl className="commitment-change__comparison">
       <div><dt>Current expectation</dt><dd>{current}</dd></div>
-      <div><dt>Observed proposal</dt><dd>{proposed}</dd></div>
+      <div><dt>Observed change</dt><dd>{proposed}</dd></div>
     </dl>
   );
 }
@@ -147,7 +148,7 @@ function ChangeActions({ change, dimension, assessment, state, kept, activeTask,
     return (
       <div className="commitment-change__confirmation" role="group" aria-labelledby={confirmationId}>
         <p id={confirmationId}>
-          Mark {name} ended? This changes its lifecycle, and you can change it again from the confirmed commitment.
+          Mark {name} ended? This changes its status, and you can change it again from the confirmed commitment.
         </p>
         <div className="inline-actions">
           <button
@@ -244,9 +245,9 @@ function ChangeCard({ change, state, kept, activeTask, onTaskChange, onReviewedO
     <Card as="article" className={`commitment-card commitment-change-card${kept ? " commitment-change-card--kept" : ""}`}>
       <div className="commitment-card__header">
         <div>
-          <p className="commitment-card__eyebrow">{kept ? "Kept change" : "Needs your decision"}</p>
+          <p className="commitment-card__eyebrow">{kept ? "Reviewed change" : "Needs your decision"}</p>
           <h3>{change.commitment.name}</h3>
-          <p className="muted">{change.commitment.category} · {title(change.commitment.cadence)}</p>
+          <p className="muted">{displayText(change.commitment.category)} · {title(change.commitment.cadence)}</p>
         </div>
       </div>
 

--- a/frontend/src/features/commitments/components/CommitmentChangeReview.test.jsx
+++ b/frontend/src/features/commitments/components/CommitmentChangeReview.test.jsx
@@ -113,7 +113,7 @@ describe("commitment change review", () => {
     const pendingGym = within(pendingSection).getByRole("heading", { name: "Gym plan", level: 3 }).closest("article");
 
     const currentExpectation = within(pendingGym).getByText("Current expectation").closest("div");
-    const observedProposal = within(pendingGym).getByText("Observed proposal").closest("div");
+    const observedProposal = within(pendingGym).getByText("Observed change").closest("div");
     expect(within(currentExpectation).getByText("$20.00")).toBeVisible();
     expect(within(observedProposal).getByText("$25.00")).toBeVisible();
     expect(within(pendingGym).getByText("2 recent expenses support this amount change.")).toBeVisible();
@@ -133,6 +133,8 @@ describe("commitment change review", () => {
     expect(reviewedHistory()).not.toHaveAttribute("open");
     await user.click(reviewedHeading().closest("summary"));
     const keptGym = within(reviewedHistory()).getByRole("heading", { name: "Gym plan", level: 3 }).closest("article");
+    expect(within(keptGym).getByText("Reviewed change")).toBeVisible();
+    expect(within(keptGym).getByText("Health · Monthly")).toBeVisible();
     const timingDetails = within(keptGym).getByLabelText("Details for timing change for Gym plan").closest("details");
     expect(timingDetails).not.toHaveAttribute("open");
     await user.click(within(keptGym).getByLabelText("Details for timing change for Gym plan"));

--- a/frontend/src/features/commitments/components/CommitmentEvidence.jsx
+++ b/frontend/src/features/commitments/components/CommitmentEvidence.jsx
@@ -1,4 +1,5 @@
 import { formatDate, formatMoney } from "../utils/formatCommitments";
+import { displayText } from "../../../utils/text";
 
 function sourceLabel(source) {
   return source === "sunflower_pdf" ? "Sunflower statement" : "Manual entry";
@@ -13,7 +14,7 @@ export default function CommitmentEvidence({ evidence, heading = "Supporting exp
           <li key={expense.expenseId} className="commitment-evidence__item">
             <div>
               <strong>{expense.description}</strong>
-              <span>{formatDate(expense.date)} · {expense.category}</span>
+              <span>{formatDate(expense.date)} · {displayText(expense.category)}</span>
               <span>{sourceLabel(expense.source)}</span>
             </div>
             <strong>{formatMoney(expense.amount)}</strong>

--- a/frontend/src/features/commitments/pages/CommitmentsPage.jsx
+++ b/frontend/src/features/commitments/pages/CommitmentsPage.jsx
@@ -7,6 +7,7 @@ import CommitmentForm from "../components/CommitmentForm";
 import { useCommitments } from "../hooks/useCommitments";
 import { formatDate, formatMoney } from "../utils/formatCommitments";
 import groupCommitmentChanges from "../utils/groupCommitmentChanges";
+import { displayText } from "../../../utils/text";
 
 const EVIDENCE_RULES = {
   consecutive_calendar_months: "Consecutive calendar months",
@@ -45,7 +46,7 @@ function CandidateCard({ candidate, dismissed, state, task, disabled, onOpen, on
         <div>
           {dismissed && <p className="commitment-status">Dismissed possible commitment</p>}
           <h3>{candidate.description}</h3>
-          <p className="muted">{candidate.category} · {title(candidate.cadence)}</p>
+          <p className="muted">{displayText(candidate.category)} · {title(candidate.cadence)}</p>
         </div>
         <div className="commitment-card__value"><span>Observed amount{candidate.observedAmountMode === "fixed" ? "" : " range"}</span><strong className="commitment-card__amount">{amountSummary(candidate)}</strong></div>
       </div>
@@ -91,7 +92,7 @@ function ConfirmedCommitmentCard({ commitment, state, task, disabled, onOpen, on
         <div>
           <p className="commitment-status">{title(commitment.lifecycle)}</p>
           <h3>{commitment.name}</h3>
-          <p className="muted">{commitment.category} · {title(commitment.cadence)}</p>
+          <p className="muted">{displayText(commitment.category)} · {title(commitment.cadence)}</p>
         </div>
         <div className="commitment-card__value"><span>Expected amount</span><strong className="commitment-card__amount">{amountSummary(commitment)}</strong></div>
       </div>

--- a/frontend/src/features/commitments/pages/CommitmentsPage.test.jsx
+++ b/frontend/src/features/commitments/pages/CommitmentsPage.test.jsx
@@ -93,7 +93,7 @@ describe("Commitments workspace", () => {
     expect(saved.getByText("Active")).toBeVisible();
     expect(saved.getByText("Expected amount")).toBeVisible();
     expect(saved.getAllByText("$1,200.00")[0]).toBeVisible();
-    expect(saved.getByText("housing · Monthly")).toBeVisible();
+    expect(saved.getByText("Housing · Monthly")).toBeVisible();
     expect(saved.getByText("Day 1, with a 1-day before / 1-day after window")).toBeVisible();
     expect(saved.getByRole("button", { name: "Edit Rent" })).toBeVisible();
     expect(saved.getByRole("button", { name: "Pause Rent" })).toBeVisible();
@@ -103,6 +103,7 @@ describe("Commitments workspace", () => {
     expect(saved.getByText("3 linked expense(s)")).toBeVisible();
     expect(saved.getByText("Records used to confirm", { selector: "h4" })).toBeVisible();
     expect(saved.getByText("Sunflower statement")).toBeVisible();
+    expect(saved.getByText("May 15, 2026 · Housing")).toBeVisible();
     expect(saved.queryByText(/revision/i)).not.toBeInTheDocument();
 
     const possible = within(card("Gym membership"));
@@ -115,6 +116,7 @@ describe("Commitments workspace", () => {
     expect(possible.getByText("3 expenses · Consecutive calendar months")).toBeVisible();
     expect(possible.getByText("Identical each time")).toBeVisible();
     expect(possible.getByText("commitment-v1")).toBeVisible();
+    expect(possible.getByText("Health · Monthly")).toBeVisible();
     expect(possible.getByText("Sunflower statement")).toBeVisible();
 
     for (const name of ["Paused commitments", "Ended commitments", "Reviewed changes", "Dismissed possible commitments"]) {
@@ -132,7 +134,7 @@ describe("Commitments workspace", () => {
     expect(screen.getByRole("heading", { name: "Ended rent" })).toBeVisible();
     expect(screen.getByRole("heading", { name: "Streaming service" })).toBeVisible();
     expect(within(history("Reviewed changes")).getByText("Current expectation")).toBeVisible();
-    expect(within(history("Reviewed changes")).getByText("Observed proposal")).toBeVisible();
+    expect(within(history("Reviewed changes")).getByText("Observed change")).toBeVisible();
   });
 
   it("keeps the complete month-end timing pattern visible for saved commitments and disclosed for candidates", async () => {

--- a/frontend/src/features/expenses/components/ExpenseForm.jsx
+++ b/frontend/src/features/expenses/components/ExpenseForm.jsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from "react";
 import { DEFAULT_CATEGORIES } from "../../../shared/constants/categories";
 import { displayText } from "../../../utils/text";
 import Card from "../../../shared/ui/Card";
@@ -20,14 +21,50 @@ export default function ExpenseForm({
   inputRef,
   pending = false,
 }) {
+  const formRef = useRef(null);
+  const [invalidField, setInvalidField] = useState("");
+
+  function firstMissingField() {
+    return [
+      ["description", newName],
+      ["amount", newAmount],
+      ["date", newDate],
+      ["category", newCategory],
+    ].find(([, value]) => !value)?.[0] ?? "";
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const missingField = firstMissingField();
+    if (missingField) {
+      setInvalidField(missingField);
+      window.requestAnimationFrame(() => formRef.current?.elements.namedItem(missingField)?.focus());
+      return;
+    }
+    setInvalidField("");
+    onAdd();
+  }
+
+  function handleCancel() {
+    setInvalidField("");
+    onCancel();
+  }
+
   return (
     <Card as="section" className="section">
       <h2 className="h2">Add expense</h2>
-      <fieldset className="activity-form-fields" disabled={pending}>
-      <legend className="sr-only">New expense</legend>
-      <div className="form-grid">
+      <form ref={formRef} noValidate onSubmit={handleSubmit}
+        onChange={() => setInvalidField("")} aria-describedby={invalidField ? "add-expense-validation" : undefined}>
+        {invalidField && <p id="add-expense-validation" className="status-message status-message--danger" role="alert">Complete the required expense fields.</p>}
+        <fieldset className="activity-form-fields" disabled={pending}>
+        <legend className="sr-only">New expense</legend>
+        <div className="form-grid">
         <FormField label="Description">{(id) => <input id={id}
           ref={inputRef}
+          name="description"
+          required
+          aria-invalid={invalidField === "description"}
+          aria-describedby={invalidField === "description" ? "add-expense-validation" : undefined}
           placeholder="Description"
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
@@ -35,6 +72,10 @@ export default function ExpenseForm({
 
         <FormField label="Amount">{(id) => <input id={id}
           type="number"
+          name="amount"
+          required
+          aria-invalid={invalidField === "amount"}
+          aria-describedby={invalidField === "amount" ? "add-expense-validation" : undefined}
           placeholder="Amount"
           value={newAmount}
           onChange={(e) => setNewAmount(e.target.value)}
@@ -44,11 +85,18 @@ export default function ExpenseForm({
 
         <FormField label="Date">{(id) => <input id={id}
           type="date"
+          name="date"
+          required
+          aria-invalid={invalidField === "date"}
+          aria-describedby={invalidField === "date" ? "add-expense-validation" : undefined}
           value={newDate}
           onChange={(e) => setNewDate(e.target.value)}
         />}</FormField>
 
-        <FormField label="Category">{(id) => <select id={id} value={newCategory} onChange={(e) => setNewCategory(e.target.value)}>
+        <FormField label="Category">{(id) => <select id={id} name="category" required
+          aria-invalid={invalidField === "category"}
+          aria-describedby={invalidField === "category" ? "add-expense-validation" : undefined}
+          value={newCategory} onChange={(e) => setNewCategory(e.target.value)}>
           <option value="">Category</option>
 
           {DEFAULT_CATEGORIES.map((c) => (
@@ -69,14 +117,15 @@ export default function ExpenseForm({
           />}</FormField>
         )}
 
-      </div>
-      </fieldset>
-      <div className="inline-actions activity-task-actions">
-        <button type="button" onClick={onAdd} disabled={loading || pending}>
-          {pending ? "Saving…" : "Save expense"}
-        </button>
-        <button type="button" className="button-ghost" onClick={onCancel} disabled={pending}>Cancel</button>
-      </div>
+        </div>
+        </fieldset>
+        <div className="inline-actions activity-task-actions">
+          <button type="submit" disabled={loading || pending}>
+            {pending ? "Saving…" : "Save expense"}
+          </button>
+          <button type="button" className="button-ghost" onClick={handleCancel} disabled={pending}>Cancel</button>
+        </div>
+      </form>
     </Card>
   );
 }

--- a/frontend/src/features/expenses/components/ExpenseItem.jsx
+++ b/frontend/src/features/expenses/components/ExpenseItem.jsx
@@ -5,6 +5,7 @@ import { formatExpenseDate } from "../utils/calendarDate";
 
 export default function ExpenseItem({
   expense,
+  rowNumber,
   isEditing,
   editingData,
   setEditingData,
@@ -18,6 +19,7 @@ export default function ExpenseItem({
 }) {
   const selectedCategory = editingData.category || "";
   const descriptionInputRef = useRef(null);
+  const expenseLabel = `${displayText(expense.description)} from ${formatExpenseDate(expense.date)}, row ${rowNumber}`;
 
   useEffect(() => {
     if (isEditing) descriptionInputRef.current?.focus();
@@ -140,6 +142,7 @@ export default function ExpenseItem({
           <div className="inline-actions">
             <button
               type="button"
+              aria-label={`Edit expense ${expenseLabel}`}
               onClick={(event) => onStartEdit(expense, event.currentTarget)}
               disabled={busy || taskLocked || readUnavailable}
             >
@@ -148,6 +151,7 @@ export default function ExpenseItem({
             <button
               type="button"
               className="button-danger"
+              aria-label={`Delete expense ${expenseLabel}`}
               onClick={() => onDelete(expense.id)}
               disabled={busy || taskLocked || readUnavailable}
             >

--- a/frontend/src/features/expenses/components/ExpenseList.jsx
+++ b/frontend/src/features/expenses/components/ExpenseList.jsx
@@ -44,10 +44,11 @@ export default function ExpenseList({
           </thead>
 
           <tbody>
-            {expenses.map((expense) => (
+            {expenses.map((expense, index) => (
               <ExpenseItem
                 key={expense.id}
                 expense={expense}
+                rowNumber={index + 1}
                 isEditing={editingExpenseId === expense.id}
                 editingData={editingExpenseData}
                 setEditingData={setEditingExpenseData}

--- a/frontend/src/features/expenses/components/ExpenseList.test.jsx
+++ b/frontend/src/features/expenses/components/ExpenseList.test.jsx
@@ -49,15 +49,17 @@ describe("ExpenseList", () => {
     expect(within(tableRegion).getByText("Expenses", { selector: "caption" })).toBeInTheDocument();
     expect(row.querySelector('[data-label="Amount ($)"]')).toHaveTextContent("4.50");
 
-    const editButton = within(row).getByRole("button", { name: "Edit" });
+    const editButton = within(row).getByRole("button", {
+      name: "Edit expense Coffee from 08/14/2026, row 1",
+    });
     await user.click(editButton);
     expect(onStartEdit).toHaveBeenCalledWith(expense, editButton);
   });
 
   it("locks other row actions and keeps an unavailable read draft cancelable", () => {
     const { rerender } = render(<ExpenseList {...listProps({ taskLocked: true })} />);
-    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Edit expense Coffee from 08/14/2026, row 1" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete expense Coffee from 08/14/2026, row 1" })).toBeDisabled();
 
     rerender(<ExpenseList {...listProps({ editingExpenseId: 7, readUnavailable: true })} />);
     expect(screen.getByLabelText("Edit description")).toHaveFocus();

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
@@ -235,7 +235,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
     try {
       if (result.importedExpenseCount > 0) await onImportConfirmed();
     } catch {
-      setRefreshError("The import succeeded, but Transactions could not be refreshed. Reload this page to see imported expenses.");
+      setRefreshError("The import succeeded, but Activity could not be refreshed. Reload this page to see imported expenses.");
     }
   }
 

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
@@ -62,9 +62,9 @@ describe('ImportPreviewPanel confirmation safety', () => {
     const state = importState()
     render(<ImportPreviewPanel importState={state} />)
     const table = tableRegion()
-    const description = within(table).getByLabelText('Expense description')
+    const description = within(table).getByLabelText(/^Expense description for /)
 
-    expect(screen.getAllByLabelText('Expense description')).toHaveLength(1)
+    expect(screen.getAllByLabelText(/^Expense description for /)).toHaveLength(1)
     expect(description.closest('td')).toHaveAttribute('data-label', 'Expense fields')
     await user.clear(description)
     await user.type(description, 'Morning coffee')
@@ -81,7 +81,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
     const state = importState()
     render(<ImportPreviewPanel importState={state} />)
 
-    await user.type(within(tableRegion()).getByLabelText('Expense description'), ' updated')
+    await user.type(within(tableRegion()).getByLabelText(/^Expense description for /), ' updated')
 
     const chooseAnother = screen.getByRole('button', { name: 'Choose another statement' })
     expect(chooseAnother).toBeDisabled()
@@ -96,11 +96,11 @@ describe('ImportPreviewPanel confirmation safety', () => {
     const state = importState({ updateRow })
     render(<ImportPreviewPanel importState={state} />)
     const table = tableRegion()
-    const description = within(table).getByLabelText('Expense description')
+    const description = within(table).getByLabelText(/^Expense description for /)
 
     await user.clear(description)
     await user.type(description, 'Morning coffee')
-    await user.click(within(table).getByRole('button', { name: 'Save row' }))
+    await user.click(within(table).getByRole('button', { name: /^Save row for / }))
 
     expect(within(table).getByRole('status')).toHaveTextContent('Saving…')
     expect(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' })).toBeDisabled()
@@ -127,11 +127,11 @@ describe('ImportPreviewPanel confirmation safety', () => {
     const state = importState({ updateRow: vi.fn().mockResolvedValue(null) })
     render(<ImportPreviewPanel importState={state} />)
     const table = tableRegion()
-    const description = within(table).getByLabelText('Expense description')
+    const description = within(table).getByLabelText(/^Expense description for /)
 
     await user.clear(description)
     await user.type(description, 'Unsaved coffee')
-    await user.click(within(table).getByRole('button', { name: 'Save row' }))
+    await user.click(within(table).getByRole('button', { name: /^Save row for / }))
 
     expect(await within(table).findByRole('alert')).toHaveTextContent('Save failed. Changes remain unsaved.')
     expect(description).toHaveValue('Unsaved coffee')
@@ -145,9 +145,9 @@ describe('ImportPreviewPanel confirmation safety', () => {
     render(<ImportPreviewPanel importState={importState({ updateRow })} />)
     const table = tableRegion()
 
-    await user.click(within(table).getByLabelText('Select for import'))
+    await user.click(within(table).getByLabelText(/^Select for import for /))
 
-    expect(within(table).getByLabelText('Select for import')).toBeDisabled()
+    expect(within(table).getByLabelText(/^Select for import for /)).toBeDisabled()
     expect(within(table).getByRole('status')).toHaveTextContent('Saving…')
     expect(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' })).toBeDisabled()
 
@@ -195,6 +195,25 @@ describe('ImportPreviewPanel confirmation safety', () => {
     expect(screen.getByRole('button', { name: 'Save 1 expense and 1 incoming deposit' })).toBeEnabled()
   })
 
+  it('gives repeated row controls unique names with transaction and ordinal context', () => {
+    const secondRow = {
+      ...row,
+      rowId: 'row-2',
+      sourceRowOrdinal: 2,
+    }
+    render(<ImportPreviewPanel importState={importState({
+      preview: { ...preview, rows: [row, secondRow] },
+      selectedCount: 2,
+    })} />)
+
+    expect(screen.getByRole('checkbox', { name: 'Select for import for SYNTHETIC CAFE on 2026-08-12, statement row 1' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Select for import for SYNTHETIC CAFE on 2026-08-12, statement row 2' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Expense description for SYNTHETIC CAFE on 2026-08-12, statement row 1' })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Category for SYNTHETIC CAFE on 2026-08-12, statement row 2' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save row for SYNTHETIC CAFE on 2026-08-12, statement row 1' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Source details for SYNTHETIC CAFE on 2026-08-12, statement row 2')).toBeInTheDocument()
+  })
+
   it('keeps decision facts visible and puts only source mechanics in named details', async () => {
     const user = userEvent.setup()
     render(<ImportPreviewPanel importState={importState({
@@ -211,11 +230,11 @@ describe('ImportPreviewPanel confirmation safety', () => {
     expect(within(table).getByText('$8.50')).toBeVisible()
     expect(within(table).getByText('Debit')).toBeVisible()
     expect(within(table).getByText('Possible duplicate — review before selecting')).toBeVisible()
-    expect(within(table).getByLabelText('Select for import')).toBeVisible()
+    expect(within(table).getByLabelText(/^Select for import for /)).toBeVisible()
     expect(sourceDetails).not.toHaveAttribute('open')
 
     const sourceSummary = within(table).getByText('Source details', { selector: 'summary' })
-    expect(sourceSummary).toHaveAttribute('aria-label', 'Source details for SYNTHETIC CAFE')
+    expect(sourceSummary).toHaveAttribute('aria-label', 'Source details for SYNTHETIC CAFE on 2026-08-12, statement row 1')
     await user.click(sourceSummary)
 
     expect(sourceDetails).toHaveAttribute('open')
@@ -230,7 +249,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
     const button = screen.getByRole('button', { name: 'Saving 1 expense and 0 incoming deposits…' })
     expect(button).toBeDisabled()
     expect(button).toHaveAttribute('aria-busy', 'true')
-    expect(within(tableRegion()).getByLabelText('Select for import')).toBeDisabled()
+    expect(within(tableRegion()).getByLabelText(/^Select for import for /)).toBeDisabled()
   })
 
   it('refreshes ordinary Expenses only after a successful confirmation result', async () => {
@@ -282,7 +301,7 @@ describe('ImportPreviewPanel confirmation safety', () => {
     )
 
     await user.click(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' }))
-    expect(await screen.findByRole('alert')).toHaveTextContent('The import succeeded, but Transactions could not be refreshed')
+    expect(await screen.findByRole('alert')).toHaveTextContent('The import succeeded, but Activity could not be refreshed')
 
     rerender(<ImportPreviewPanel importState={importState({
       preview: null,
@@ -332,9 +351,9 @@ describe('ImportPreviewPanel confirmation safety', () => {
     })} />)
     const table = tableRegion()
 
-    expect(within(table).queryByLabelText('Expense description')).not.toBeInTheDocument()
+    expect(within(table).queryByLabelText(/^Expense description for /)).not.toBeInTheDocument()
     expect(within(table).getByText(/does not classify it as income or a paycheck/)).toBeInTheDocument()
-    await user.click(within(table).getByLabelText('Save incoming deposit'))
+    await user.click(within(table).getByLabelText(/^Save incoming deposit for /))
 
     expect(updateRow).toHaveBeenCalledWith('credit-1', {
       editableExpenseDescription: null,

--- a/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewRow.jsx
@@ -23,7 +23,7 @@ const CONFIRMATION_CODE_MESSAGES = {
   category_reserved: "Choose a category other than Other.",
 };
 
-function RowFields({ row, draft, disabled, onDraftChange, onSave }) {
+function RowFields({ row, rowContext, draft, disabled, onDraftChange, onSave }) {
   if (!row.isEligible) return <span className="muted">Not editable</span>;
 
   const saveStatus = draft.pending
@@ -39,6 +39,7 @@ function RowFields({ row, draft, disabled, onDraftChange, onSave }) {
       <label>
         <span>Expense description</span>
         <input
+          aria-label={`Expense description for ${rowContext}`}
           value={draft.description}
           disabled={disabled || draft.pending}
           onChange={(event) => onDraftChange({ description: event.target.value })}
@@ -47,6 +48,7 @@ function RowFields({ row, draft, disabled, onDraftChange, onSave }) {
       <label>
         <span>Category</span>
         <select
+          aria-label={`Category for ${rowContext}`}
           value={draft.categoryChoice}
           disabled={disabled || draft.pending}
           onChange={(event) => onDraftChange({ categoryChoice: event.target.value })}
@@ -62,6 +64,7 @@ function RowFields({ row, draft, disabled, onDraftChange, onSave }) {
         <label>
           <span>Custom category</span>
           <input
+            aria-label={`Custom category for ${rowContext}`}
             value={draft.customCategory}
             disabled={disabled || draft.pending}
             onChange={(event) => onDraftChange({ customCategory: event.target.value })}
@@ -71,6 +74,7 @@ function RowFields({ row, draft, disabled, onDraftChange, onSave }) {
       <button
         type="button"
         className="button-ghost"
+        aria-label={`Save row for ${rowContext}`}
         disabled={disabled || draft.pending || !draft.dirty}
         onClick={onSave}
       >
@@ -133,13 +137,17 @@ export default function ImportPreviewRow({
   const isSelectable = row.isEligible || isInflow;
   const isSelected = row.isEligible ? row.selectedForImport : row.selectedForInflow;
   const sourceDescription = row.sourceDescription || "Unavailable";
-  const sourceDetailsLabel = row.sourceDescription
-    ? `Source details for ${row.sourceDescription}`
-    : `Source details for statement row ${row.sourceRowOrdinal}`;
+  const rowContext = `${sourceDescription} on ${row.postedDate ?? "unknown date"}, statement row ${row.sourceRowOrdinal}`;
+  const sourceDetailsLabel = `Source details for ${rowContext}`;
   const selection = (
     <label className="import-selection">
       <input
         type="checkbox"
+        aria-label={`${row.isEligible
+          ? "Select for import"
+          : isInflow
+            ? "Save incoming deposit"
+            : "Not selectable"} for ${rowContext}`}
         checked={Boolean(isSelected)}
         disabled={!isSelectable || disabled || draft.pending}
         onChange={(event) => onSelectionChange(event.target.checked)}
@@ -183,6 +191,7 @@ export default function ImportPreviewRow({
       <td className="import-preview-row__fields" data-label="Expense fields">
         <RowFields
           row={row}
+          rowContext={rowContext}
           draft={draft}
           disabled={disabled}
           onDraftChange={onDraftChange}

--- a/frontend/src/features/paychecks/pages/PaychecksPage.jsx
+++ b/frontend/src/features/paychecks/pages/PaychecksPage.jsx
@@ -27,14 +27,14 @@ function CandidateCard({ candidate, dismissed, evaluatedOn, busy, actionsDisable
           <strong>{observed.mode === "fixed" ? formatMoney(observed.fixedAmount) : `${formatMoney(observed.minimumAmount)}–${formatMoney(observed.maximumAmount)}`}</strong>
         </div>
       </header>
-      <p className="paycheck-candidate-count">Based on {candidate.occurrenceCount} deposits{observed.mode !== "fixed" && ". Observed history, not an accepted range."}</p>
+      <p className="paycheck-candidate-count">Based on {candidate.occurrenceCount} deposits{observed.mode !== "fixed" && ". Observed history, not an expected range."}</p>
       <details className="paycheck-details">
         <summary aria-label={`Details for ${name}`}>Details</summary>
         <dl className="paycheck-facts">
           <div><dt>Schedule</dt><dd>{formatSchedule(candidate.schedule)}</dd></div>
           <div><dt>Records covered</dt><dd>{formatDate(candidate.coveredFrom)}–{formatDate(candidate.coveredTo)}</dd></div>
           <div><dt>Observed timing</dt><dd>{formatWindow(candidate.windowBeforeDays, candidate.windowAfterDays)}</dd></div>
-          <div><dt>Observed amounts</dt><dd>{observed.mode === "fixed" ? "The same amount in each deposit" : `Variable · lower median ${formatMoney(observed.lowerMedianAmount)}. This history is not an accepted range.`}</dd></div>
+          <div><dt>Observed amounts</dt><dd>{observed.mode === "fixed" ? "The same amount in each deposit" : `Variable · lower median ${formatMoney(observed.lowerMedianAmount)}. This history is not an expected range.`}</dd></div>
           {evaluatedOn && <div><dt>Evaluated</dt><dd>{formatDate(evaluatedOn)}</dd></div>}
           <div><dt>Detection details</dt><dd>{candidate.algorithmVersion}</dd></div>
         </dl>

--- a/frontend/src/features/paychecks/pages/PaychecksPage.test.jsx
+++ b/frontend/src/features/paychecks/pages/PaychecksPage.test.jsx
@@ -240,7 +240,9 @@ describe("Paychecks page", () => {
     const other = makeCandidate({ fingerprint: "d".repeat(64), normalizedDescriptionIdentity: "other payroll" });
     loadState({ candidates: [variable, other], paychecks: [] });
     await renderPage();
-    await user.click(within(card("acme payroll")).getByRole("button", { name: "Review and confirm acme payroll" }));
+    const variableCard = within(card("acme payroll"));
+    expect(variableCard.getByText(/Observed history, not an expected range/)).toBeVisible();
+    await user.click(variableCard.getByRole("button", { name: "Review and confirm acme payroll" }));
     const form = within(screen.getByRole("form", { name: "Confirm paycheck" }));
     expect(form.getByLabelText("Minimum amount")).toHaveValue("");
     expect(form.getByLabelText("Maximum amount")).toHaveValue("");

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -128,10 +128,6 @@ export default function TransactionsPage() {
     }
   }
   async function handleAddExpense() {
-    if (!newName || !newAmount || !newDate || !newCategory) {
-      alert("Complete all transaction fields.");
-      return;
-    }
     const categoryToUse = newCategory === "other"
       ? normalizeText(customCategory || "uncategorized") : normalizeText(newCategory);
     await writeExpense(() => addExpense({

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -78,6 +78,28 @@ describe('existing expense workflows', () => {
     })
   })
 
+  it.each([
+    ['-1', -1],
+    ['1.234', 1.234],
+    ['0', 0],
+  ])('preserves presence-only amount submission for %s', async (amountInput, expectedAmount) => {
+    const user = userEvent.setup()
+    const addExpense = vi.fn().mockResolvedValue(undefined)
+    useExpenses.mockReturnValue({ ...baseExpensesHook, addExpense })
+    render(<TransactionsPage />)
+    await user.click(screen.getByRole('button', { name: 'Add expense' }))
+    const addEntry = screen.getByRole('heading', { name: 'Add expense' }).closest('section')
+
+    await user.type(within(addEntry).getByLabelText('Description'), 'Synthetic amount')
+    fireEvent.change(within(addEntry).getByLabelText('Amount'), { target: { value: amountInput } })
+    fireEvent.change(within(addEntry).getByLabelText('Date'), { target: { value: '2026-08-14' } })
+    await user.selectOptions(within(addEntry).getByLabelText('Category'), 'food')
+    await user.click(within(addEntry).getByRole('button', { name: 'Save expense' }))
+
+    expect(addExpense).toHaveBeenCalledWith(expect.objectContaining({ amount: expectedAmount }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
   it('uses the other sentinel to send a normalized custom category', async () => {
     const user = userEvent.setup()
     const addExpense = vi.fn().mockResolvedValue(undefined)
@@ -115,7 +137,7 @@ describe('existing expense workflows', () => {
     render(<TransactionsPage />)
 
     const row = screen.getByText('Medical').closest('tr')
-    await user.click(within(row).getByRole('button', { name: 'Edit' }))
+    await user.click(within(row).getByRole('button', { name: /^Edit expense old name/i }))
 
     expect(within(row).getByLabelText('Edit description')).toBeInTheDocument()
     expect(within(row).getByLabelText('Edit amount')).toBeInTheDocument()
@@ -166,14 +188,16 @@ describe('existing expense workflows', () => {
     expect(screen.getByRole('button', { name: 'Show More' })).toBeInTheDocument()
   })
 
-  it('keeps missing-field validation while using neutral copy', async () => {
+  it('shows inline missing-field validation and focuses the first invalid field', async () => {
     const user = userEvent.setup()
     render(<TransactionsPage />)
 
     await user.click(screen.getByRole('button', { name: 'Add expense' }))
     await user.click(screen.getByRole('button', { name: 'Save expense' }))
 
-    expect(window.alert).toHaveBeenCalledWith('Complete all transaction fields.')
+    expect(screen.getByRole('alert')).toHaveTextContent('Complete the required expense fields.')
+    await waitFor(() => expect(screen.getByLabelText('Description')).toHaveFocus())
+    expect(window.alert).not.toHaveBeenCalled()
     expect(baseExpensesHook.addExpense).not.toHaveBeenCalled()
   })
 
@@ -316,7 +340,7 @@ describe('existing expense workflows', () => {
 
     expect(refresh).toHaveBeenCalledOnce()
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'The import succeeded, but Transactions could not be refreshed'
+      'The import succeeded, but Activity could not be refreshed'
     )
   })
 
@@ -353,14 +377,14 @@ describe('existing expense workflows', () => {
     expect(within(table).getByText('Possible duplicate — review before selecting')).toBeInTheDocument()
     expect(within(table).getByText('Needs review')).toBeInTheDocument()
     expect(within(table).getByLabelText('Not selectable')).toBeDisabled()
-    await user.click(within(table).getByLabelText('Select for import'))
+    await user.click(within(table).getByLabelText(/^Select for import for /))
     expect(updateRow).toHaveBeenCalledWith('row-1', expect.objectContaining({ selectedForImport: true }))
 
-    const description = within(table).getByLabelText('Expense description')
+    const description = within(table).getByLabelText(/^Expense description for /)
     await user.clear(description)
     await user.type(description, 'Morning coffee')
-    await user.selectOptions(within(table).getByLabelText('Category'), 'food')
-    await user.click(within(table).getByRole('button', { name: 'Save row' }))
+    await user.selectOptions(within(table).getByLabelText(/^Category for /), 'food')
+    await user.click(within(table).getByRole('button', { name: /^Save row for / }))
     expect(updateRow).toHaveBeenLastCalledWith('row-1', {
       editableExpenseDescription: 'Morning coffee',
       category: 'food',
@@ -426,7 +450,7 @@ describe('Activity task hierarchy and safeguards', () => {
   it('pins an active edit through filters and failed reads without replacing the draft', async () => {
     const user = userEvent.setup()
     const { rerender } = render(<TransactionsPage />)
-    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.click(screen.getByRole('button', { name: /^Edit expense/ }))
     await user.clear(screen.getByLabelText('Edit description'))
     await user.type(screen.getByLabelText('Edit description'), 'Unsaved description')
     await user.type(screen.getByRole('searchbox'), 'not a match')
@@ -443,11 +467,23 @@ describe('Activity task hierarchy and safeguards', () => {
     const user = userEvent.setup()
     useExpenses.mockReturnValue({ ...baseExpensesHook, expenses: [expense, { ...expense, id: 43, description: 'Other' }] })
     render(<TransactionsPage />)
-    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0])
+    await user.click(screen.getAllByRole('button', { name: /^Edit expense/ })[0])
     await user.type(screen.getByLabelText('Edit description'), ' draft')
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^Edit expense/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^Delete expense/ })).toBeDisabled()
     expect(screen.getByLabelText('Edit description')).toHaveValue('Synthetic coffee draft')
+  })
+  it('gives repeated expense actions unique names while keeping their visible copy', () => {
+    useExpenses.mockReturnValue({
+      ...baseExpensesHook,
+      expenses: [expense, { ...expense, id: 43 }],
+    })
+    render(<TransactionsPage />)
+
+    expect(screen.getByRole('button', { name: 'Edit expense Synthetic Coffee from 09/01/2026, row 1' })).toHaveTextContent('Edit')
+    expect(screen.getByRole('button', { name: 'Edit expense Synthetic Coffee from 09/01/2026, row 2' })).toHaveTextContent('Edit')
+    expect(screen.getByRole('button', { name: 'Delete expense Synthetic Coffee from 09/01/2026, row 1' })).toHaveTextContent('Delete')
+    expect(screen.getByRole('button', { name: 'Delete expense Synthetic Coffee from 09/01/2026, row 2' })).toHaveTextContent('Delete')
   })
   it('locks a pending save and keeps the task visible until the write completes', async () => {
     const user = userEvent.setup()
@@ -506,9 +542,9 @@ describe('Activity task hierarchy and safeguards', () => {
     const deleteExpense = vi.fn().mockResolvedValue({ refreshFailed: false })
     useExpenses.mockReturnValue({ ...baseExpensesHook, expenses: [expense], deleteExpense })
     render(<TransactionsPage />)
-    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: /^Delete expense/ }))
     expect(deleteExpense).not.toHaveBeenCalled()
-    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: /^Delete expense/ }))
     expect(confirm).toHaveBeenCalledWith('Delete this expense?')
     expect(deleteExpense).toHaveBeenCalledExactlyOnceWith(42)
     expect(screen.getByRole('status')).toHaveTextContent('Expense deleted.')

--- a/frontend/src/styles/budgets.css
+++ b/frontend/src/styles/budgets.css
@@ -1,0 +1,46 @@
+.budgets-page { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-6); }
+.budgets-page > .page-header { margin-bottom: 0; }
+.budget-workspace { display: grid; min-width: 0; gap: var(--space-4); }
+.budget-workspace > *, .budgets-page .page-header > * { min-width: 0; }
+.budget-workspace [hidden] { display: none !important; }
+.budget-workspace h2, .budget-workspace h3, .budget-workspace p { overflow-wrap: anywhere; }
+.budget-workspace button { min-height: 44px; max-width: 100%; white-space: normal; overflow-wrap: anywhere; }
+.budget-toolbar, .budget-section-header { display: flex; flex-wrap: wrap; align-items: end; justify-content: space-between; gap: var(--space-4); }
+.budget-toolbar > .field { width: min(100%, 16rem); }
+.budget-toolbar input { min-width: 0; max-width: 100%; }
+.budget-section-header { align-items: center; }
+.budget-section-header h2 { margin: 0; }
+.budget-task-note { margin: 0; }
+.budget-feedback:empty { display: none; }
+.budget-feedback p { margin: 0; }
+.budget-feedback:focus-visible, .budget-section-header h2:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 3px; }
+.budget-form { display: grid; min-width: 0; gap: var(--space-4); }
+.budget-form h2, .budget-form p { margin: 0; }
+.budget-form fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
+.budget-form__fields { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 200px), 1fr)); gap: var(--space-4); }
+.budget-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr)); gap: var(--space-4); }
+.budget-card { display: grid; min-width: 0; align-content: start; gap: var(--space-4); }
+.budget-card--warning { border-color: var(--color-warning); }
+.budget-card__header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: var(--space-2); }
+.budget-card__header h3 { margin: 0; }
+.budget-card__status { font-size: var(--text-sm); font-weight: 700; color: var(--color-text-muted); }
+.budget-card--warning .budget-card__status { color: var(--color-warning); }
+.budget-card__amounts { margin: 0; font-variant-numeric: tabular-nums; }
+.budget-card__amounts strong { font-size: var(--text-2xl); }
+.budget-card__amounts span { color: var(--color-text-muted); }
+.budget-card__progress { display: grid; gap: var(--space-2); font-variant-numeric: tabular-nums; }
+.budget-card__progress progress { appearance: none; display: block; width: 100%; height: .625rem; border: 0; border-radius: var(--radius-pill); overflow: hidden; background: var(--color-surface-subtle); accent-color: var(--color-primary); }
+.budget-card__progress progress::-webkit-progress-bar { background: var(--color-surface-subtle); }
+.budget-card__progress progress::-webkit-progress-value { background: var(--color-primary); }
+.budget-card__progress progress::-moz-progress-bar { background: var(--color-primary); }
+.budget-card--warning progress::-webkit-progress-value { background: var(--color-warning); }
+.budget-card--warning progress::-moz-progress-bar { background: var(--color-warning); }
+.budget-card__note { margin: 0; font-size: var(--text-sm); }
+.budget-explanation { border-top: 1px solid var(--color-border); }
+.budget-explanation summary { min-height: 44px; padding-block: var(--space-3); cursor: pointer; overflow-wrap: anywhere; }
+.budget-explanation summary:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 3px; }
+.budget-explanation p { color: var(--color-text-muted); }
+@media (max-width: 520px) {
+  .budget-toolbar, .budget-section-header { align-items: stretch; flex-direction: column; }
+  .budget-toolbar > .field { width: 100%; }
+}

--- a/frontend/src/styles/secondary-pages.css
+++ b/frontend/src/styles/secondary-pages.css
@@ -1,0 +1,156 @@
+.investing-page {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.secondary-page {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-5);
+  overflow-wrap: anywhere;
+}
+
+.secondary-page > .page-header {
+  margin-bottom: 0;
+}
+
+.secondary-page .page-header p {
+  margin-bottom: 0;
+}
+
+.secondary-links {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.secondary-links--plan {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.secondary-link {
+  display: flex;
+  min-width: 0;
+  min-height: 44px;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  background: var(--color-surface);
+  text-decoration: none;
+}
+
+.secondary-link:hover {
+  border-color: var(--color-control-border);
+  background: var(--color-surface-raised);
+}
+
+.secondary-link__icon {
+  flex: 0 0 auto;
+  color: var(--color-primary);
+}
+
+.secondary-link__body {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-1);
+}
+
+.secondary-link__title-row {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.secondary-link__label {
+  min-width: 0;
+  font-weight: 800;
+}
+
+.secondary-link__description {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.secondary-link__status {
+  padding: .2rem .45rem;
+  border-radius: 999px;
+  color: var(--color-text-muted);
+  background: var(--color-surface-subtle);
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.secondary-links--more {
+  max-width: 46rem;
+}
+
+.secondary-links__subordinate {
+  margin-top: var(--space-1);
+}
+
+.secondary-links__subordinate .secondary-link {
+  background: var(--color-surface-subtle);
+}
+
+.settings-page__content {
+  display: grid;
+  max-width: 46rem;
+  gap: var(--space-5);
+}
+
+.settings-page__appearance {
+  box-shadow: none;
+}
+
+.settings-page__appearance h2,
+.settings-page__account h2 {
+  margin-bottom: var(--space-4);
+}
+
+.settings-page__helper {
+  margin: var(--space-3) 0 0;
+}
+
+.settings-page__account {
+  min-width: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-divider);
+}
+
+.settings-page__account-row {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(8rem, .45fr) minmax(0, 1fr);
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+}
+
+.settings-page__account-row dt {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.settings-page__account-row dd {
+  min-width: 0;
+  margin: 0;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 600px) {
+  .secondary-links--plan {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-page__account-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary

Completes the approved seventh UX V3 slice for [issue #127](https://github.com/OL1V3S/ordo/issues/127#issuecomment-5576480986). Budgets now leads with month-specific category progress and status; add/edit forms open as explicit tasks. Plan is a data-free navigation hub, More places Settings before unavailable Investing, and Settings leads with Appearance.

The final presentation/accessibility pass moves desktop Investing below primary navigation, restores auth task-heading focus, gives repeated Activity/import controls distinct contextual names, adds focused inline validation without tightening existing expense input rules, and aligns the approved terminology/category display. Updates the product overview and prepares the first UX V3 changelog entry.

## Risk and scope

MEDIUM, within the durably owner-approved V3 plan and final-slice checkpoint. Budget drafts retain their captured month; failed reads cannot masquerade as empty budgets or zero spending. Pending and uncertain writes are gated, and a completed write remains distinct from a failed refresh. Month reselection cannot show stale limits before its new read.

Preserves exact budget category keys/grouping, amounts, zero-limit semantics, local-date-to-ISO month payloads, spending cutoffs, CRUD targets, and existing expense normalization. No backend, schema, migration, API, dependency, auth policy, import eligibility, or financial-rule changes. No production access or deployment.

Keep #127 open through independent review; command center owns final closure after merge and verified delivery. Codex has not approved or merged this PR.

## Verification

- **Passed locally:** canonical frontend lane (`npm ci`, then final `npm run verify`): 516 tests across 50 files, full ESLint, production build; `git diff --check`. Existing bundle-size advisory remains.
- **Passed locally:** synthetic localhost browser checks across ten protected pages at 320/375/768/1280px in Light/Dark/System; reduced motion; long content at 320px with 200% root text; public auth layouts/focus; keyboard skip/account-menu/route-history/disclosure checks, active Commitments/Paychecks forms and cancel-focus return, distinct import-row controls and visible warnings; empty/error states across six data pages; budget validation, draft/month locking, pending/uncertain writes, independent read retry, successful-write/failed-refresh states.
- **Required/proven by CI:** Frontend test, lint, and build; Backend build and tests (including container); PostgreSQL financial integration. All three passed on final head `cc1f5b802ecbb3a75594300bb61a0eca171b32ae`: [Frontend CI](https://github.com/OL1V3S/ordo/actions/runs/34175435255), [Backend and PostgreSQL CI](https://github.com/OL1V3S/ordo/actions/runs/34175435234). Backend/DB lanes were not run locally for this frontend-only change.
- Browser fixtures use synthetic localhost data. The Vercel preview deployed successfully but redirects to Vercel login; interactive preview verification is unavailable without that login. Native screen-reader operation, browser-native zoom, and production smoke are not claimed. Automated accessible-name/focus/contrast assertions complement browser keyboard/layout inspection.

Context expanded only to the shipped presentation boundaries and adjacent tests required by the approved cross-product review. Development reviewers assisted with bounded corrections; independent command-center review of the actual PR and final CI remains required.
