### PR TITLE
Add cash-in entry and management to Activity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,6 +39,14 @@ constants, theme, UI, and utilities live under
 `frontend/src/shared/`; chart-specific presentation lives under
 `frontend/src/charts/`.
 
+The Activity page coordinates spending, cash-in, and import tasks. The
+`inflows` frontend feature owns exact-decimal drafts, cash-in presentation, and
+session-scoped reads/writes over the existing `/api/inflows` contract. Imported
+and paycheck-linked inflows share this management surface; the DTO carries no
+source/linkage flags. Cash-in mutation outcomes distinguish rejected, unknown,
+and completed writes with failed refreshes. Import confirmation refreshes each
+record list according to its saved counts.
+
 Below the desktop sidebar breakpoint, the shell exposes Home, Activity, Plan,
 Insights, and More. The protected `/plan` and `/more` pages group links to the
 existing feature URLs without owning feature data or changing their workflows.

--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -25,9 +25,11 @@ silently treating every detected pattern as a financial fact.
   90% used, active commitments, and recent spending, with links to each workflow.
   Each section shows its own loading or retry state when a read is unavailable.
 - **Activity / Transactions:** Scan recorded spending first, search descriptions
-  and categories, and expand date/category filters when needed. Open Add expense
-  or Import statement to start a task; edit and delete remain available on each
-  record. Active drafts and import review stay visible while you work.
+  and categories, and expand date/category filters when needed. A separate Cash in
+  section lists recorded incoming money with its own search. Add, edit, or delete
+  expenses and cash in, or open Import statement. Cash-in edits and deletions can
+  affect imported records and supporting paycheck links; visible warnings explain
+  these effects. Active drafts and import review stay visible while you work.
 - **Budgets:** Review category spending against the selected month’s limits,
   with visible progress and near-limit or over-limit status. Open add or edit
   when needed; drafts keep their original month. Zero limits remain explicit
@@ -93,7 +95,7 @@ boundaries in more detail.
 ## Current shape and maturity
 
 Ordo is an evolving product focused on recorded activity and explicit review.
-It currently models one checking account, with manual expense entry and supported
+It currently models one checking account, with manual expense and cash-in entry and supported
 statement import rather than a live bank connection. Investing is an unavailable
 placeholder, not a portfolio or investment-analysis feature.
 

--- a/PRODUCT_OVERVIEW.md
+++ b/PRODUCT_OVERVIEW.md
@@ -95,8 +95,8 @@ boundaries in more detail.
 ## Current shape and maturity
 
 Ordo is an evolving product focused on recorded activity and explicit review.
-It currently models one checking account, with manual expense and cash-in entry and supported
-statement import rather than a live bank connection. Investing is an unavailable
+It currently models one checking account, with manual expense and cash-in entry
+and supported statement import rather than a live bank connection. Investing is an unavailable
 placeholder, not a portfolio or investment-analysis feature.
 
 The app has a React/Vite browser frontend hosted on Vercel, an ASP.NET Core

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -24,6 +24,18 @@ the permanent, complete archive.
 
 ## History
 
+### 2026-09-08 — Recorded cash-in management
+
+[PR #142](https://github.com/OL1V3S/ordo/pull/142) ·
+[Issue #141](https://github.com/OL1V3S/ordo/issues/141)
+
+- Added a separate Cash in section in Activity with manual entry, search, edit,
+  and delete for all recorded inflows, including imported or paycheck-linked records.
+- Preserved exact amount drafts and posted dates, with explicit edit/delete
+  warnings and recovery for uncertain writes or unavailable refreshed lists.
+- Coordinated cash-in, expense, and import tasks; confirmed imports refresh each
+  affected record list while retaining known success if a read fails.
+
 ### 2026-09-07 — Ordo UX V3
 
 [Issue #127](https://github.com/OL1V3S/ordo/issues/127) ·

--- a/backend.Tests/Financial/InflowsApiTests.cs
+++ b/backend.Tests/Financial/InflowsApiTests.cs
@@ -143,6 +143,53 @@ public sealed class InflowsApiTests
     }
 
     [Fact]
+    public async Task Create_and_update_accept_quoted_exact_decimals_and_preserve_date_and_description_semantics()
+    {
+        await using var app = new FinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("inflow-quoted-amount-owner@example.com");
+
+        using var created = await owner.Client.PostAsync(
+            "/api/inflows",
+            new StringContent(
+                """{"description":"  Exact   Deposit  ","amount":"9999999999999999.99","date":"2026-09-03"}""",
+                System.Text.Encoding.UTF8,
+                "application/json"));
+        var createdBody = await created.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+        Assert.Equal("Exact   Deposit", createdBody.GetProperty("description").GetString());
+        Assert.Equal(JsonValueKind.Number, createdBody.GetProperty("amount").ValueKind);
+        Assert.Equal("9999999999999999.99", createdBody.GetProperty("amount").GetRawText());
+        Assert.Equal(9999999999999999.99m, createdBody.GetProperty("amount").GetDecimal());
+        Assert.Equal("2026-09-03", createdBody.GetProperty("date").GetString());
+        var id = createdBody.GetProperty("id").GetInt32();
+        var persistedCreated = await app.FindInflowAsync(id);
+        Assert.NotNull(persistedCreated);
+        Assert.Equal(9999999999999999.99m, persistedCreated.Amount);
+
+        using var updated = await owner.Client.PutAsync(
+            $"/api/inflows/{id}",
+            new StringContent(
+                $$"""{"id":{{id}},"description":"  Revised  CASH In  ","amount":"1234567890123456.78","date":"2026-08-31"}""",
+                System.Text.Encoding.UTF8,
+                "application/json"));
+
+        Assert.Equal(HttpStatusCode.NoContent, updated.StatusCode);
+        var persistedUpdated = await app.FindInflowAsync(id);
+        Assert.NotNull(persistedUpdated);
+        Assert.Equal("Revised  CASH In", persistedUpdated.Description);
+        Assert.Equal(1234567890123456.78m, persistedUpdated.Amount);
+        Assert.Equal(new DateOnly(2026, 8, 31), persistedUpdated.Date);
+
+        using var read = await owner.Client.GetAsync($"/api/inflows/{id}");
+        var readBody = await read.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.OK, read.StatusCode);
+        Assert.Equal("Revised  CASH In", readBody.GetProperty("description").GetString());
+        Assert.Equal("1234567890123456.78", readBody.GetProperty("amount").GetRawText());
+        Assert.Equal("2026-08-31", readBody.GetProperty("date").GetString());
+    }
+
+    [Fact]
     public async Task Create_validates_description_after_outer_trim_and_allows_manual_duplicates()
     {
         await using var app = new FinancialApiTestApplication();

--- a/backend.Tests/Financial/PostgreSqlCashFlowTests.cs
+++ b/backend.Tests/Financial/PostgreSqlCashFlowTests.cs
@@ -139,6 +139,63 @@ public sealed class PostgreSqlCashFlowTests
     }
 
     [PostgreSqlFact]
+    public async Task Manual_inflow_http_crud_updates_historical_cash_flow_by_current_amount_and_date()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("cash-flow-manual-crud@example.com");
+
+        using var created = await owner.Client.PostAsJsonAsync("/api/inflows", new
+        {
+            description = "  Manual deposit  ",
+            amount = 1200.25m,
+            date = "2026-09-03"
+        });
+        var createdBody = await created.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+        var id = createdBody.GetProperty("id").GetInt32();
+
+        var afterCreate = await ReadAsync(owner.Client);
+        var septemberAfterCreate = afterCreate.GetProperty("selected");
+        Assert.Equal("120025", Money(septemberAfterCreate, "cashInMinor"));
+        Assert.Equal("0", Money(septemberAfterCreate, "paycheckCashInMinor"));
+        Assert.Equal("120025", Money(septemberAfterCreate, "otherCashInMinor"));
+        Assert.Equal("120025", Money(septemberAfterCreate, "netMinor"));
+        Assert.Equal(1, septemberAfterCreate.GetProperty("inflowCount").GetInt32());
+
+        using var updated = await owner.Client.PutAsJsonAsync($"/api/inflows/{id}", new
+        {
+            id,
+            description = "Manual deposit corrected",
+            amount = 1300.27m,
+            date = "2026-08-31"
+        });
+        Assert.Equal(HttpStatusCode.NoContent, updated.StatusCode);
+
+        var afterUpdate = await ReadAsync(owner.Client);
+        var septemberAfterUpdate = afterUpdate.GetProperty("selected");
+        Assert.Equal("0", Money(septemberAfterUpdate, "cashInMinor"));
+        Assert.Equal("0", Money(septemberAfterUpdate, "netMinor"));
+        Assert.Equal(0, septemberAfterUpdate.GetProperty("inflowCount").GetInt32());
+        var august = Assert.Single(afterUpdate.GetProperty("months").EnumerateArray(),
+            value => value.GetProperty("month").GetString() == "2026-08");
+        Assert.Equal("130027", Money(august, "cashInMinor"));
+        Assert.Equal("130027", Money(august, "otherCashInMinor"));
+        Assert.Equal(1, august.GetProperty("inflowCount").GetInt32());
+
+        using var deleted = await owner.Client.DeleteAsync($"/api/inflows/{id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleted.StatusCode);
+
+        var afterDelete = await ReadAsync(owner.Client);
+        Assert.All(afterDelete.GetProperty("months").EnumerateArray(), month =>
+        {
+            Assert.Equal("0", Money(month, "cashInMinor"));
+            Assert.Equal(0, month.GetProperty("inflowCount").GetInt32());
+        });
+        Assert.Equal(["2026-09"],
+            afterDelete.GetProperty("availableMonths").EnumerateArray().Select(value => value.GetString()));
+    }
+
+    [PostgreSqlFact]
     public async Task Concurrent_membership_and_record_edits_use_one_read_only_repeatable_snapshot()
     {
         var gate = new SnapshotGate();

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.jsx
@@ -50,7 +50,8 @@ function focusAfterRender(ref) {
   else window.setTimeout(focus, 0);
 }
 
-export default function ImportPreviewPanel({ importState, onImportConfirmed = async () => {} }) {
+export default function ImportPreviewPanel({ importState, onImportConfirmed = async () => {}, externalLocked = false, isExternallyLocked = () => false }) {
+  const externallyBlocked = () => externalLocked || isExternallyLocked();
   const {
     preview,
     sourceType,
@@ -95,7 +96,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
   }, [confirmation]);
 
   async function submitFile(file) {
-    if (!file || !sourceType) return;
+    if (externallyBlocked() || !file || !sourceType) return;
     setRefreshError("");
     const result = await upload(file);
     if (result) focusAfterRender(resultsHeading);
@@ -115,6 +116,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
   }
 
   function changeDraft(row, changes) {
+    if (externallyBlocked()) return;
     setRowDrafts((current) => {
       const sameBatch = current.batchId === preview?.batchId;
       const existing = sameBatch && current.rows[row.rowId]
@@ -177,7 +179,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
   }
 
   async function runRowUpdate(row, payload, savedFields) {
-    if (confirming || confirmationIssue?.requiresPreviewRefresh || rowUpdatesInFlight.current.has(row.rowId)) return null;
+    if (externallyBlocked() || confirming || confirmationIssue?.requiresPreviewRefresh || rowUpdatesInFlight.current.has(row.rowId)) return null;
     rowUpdatesInFlight.current.add(row.rowId);
     markRowPending(row);
     try {
@@ -216,14 +218,14 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
   const hasPendingRows = drafts.some((draft) => draft.pending);
   const hasDirtyRows = drafts.some((draft) => draft.dirty);
   const confirmationNeedsRefresh = Boolean(confirmationIssue?.requiresPreviewRefresh);
-  const confirmDisabled = selectedCount === 0
+  const confirmDisabled = externalLocked || selectedCount === 0
     || hasPendingRows
     || hasDirtyRows
     || confirming
     || confirmationNeedsRefresh;
 
   async function handleConfirm() {
-    if (confirmDisabled || rowUpdatesInFlight.current.size > 0) return;
+    if (externallyBlocked() || confirmDisabled || rowUpdatesInFlight.current.size > 0) return;
     setRefreshError("");
     const result = await confirm();
     if (!result) {
@@ -233,9 +235,13 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
 
     focusAfterRender(completionHeading);
     try {
-      if (result.importedExpenseCount > 0) await onImportConfirmed();
+      if (result.importedExpenseCount > 0 || result.importedInflowCount > 0) {
+        const refreshed = await onImportConfirmed(result);
+        const failed = refreshed?.failedLists?.filter((name) => ["expenses", "cash in"].includes(name)) ?? [];
+        if (failed.length) setRefreshError(`The import succeeded, but Activity could not be refreshed for ${failed.join(" and ")}. Use the affected list’s refresh action to see the saved records.`);
+      }
     } catch {
-      setRefreshError("The import succeeded, but Activity could not be refreshed. Reload this page to see imported expenses.");
+      setRefreshError("The import succeeded, but Activity could not be refreshed. Reload this page to see imported records.");
     }
   }
 
@@ -244,6 +250,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
   const selectedItemsLabel = formatSelectionCounts(selectedExpenseCount, selectedInflowCount);
 
   function confirmationGuidance() {
+    if (externalLocked) return "Finish the cash-in task before changing the statement.";
     if (confirmationNeedsRefresh) return "Refresh this page to load the authoritative duplicate review before confirming.";
     if (hasPendingRows) return "Wait for every row update to finish before confirming.";
     if (hasDirtyRows) return "Save every row with unsaved changes before confirming.";
@@ -262,7 +269,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
         row={row}
         draft={draftFor(row)}
         confirmationCodes={confirmationCodesFor(row.rowId)}
-        disabled={confirming || confirmationNeedsRefresh}
+        disabled={externalLocked || confirming || confirmationNeedsRefresh}
         onDraftChange={(changes) => changeDraft(row, changes)}
         onSave={() => saveRow(row)}
         onSelectionChange={(selected) => updateSelection(row, selected)}
@@ -284,8 +291,8 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
           <button
             type="button"
             className="button-ghost"
-            disabled={confirming || hasPendingRows || hasDirtyRows}
-            onClick={clearForReupload}
+            disabled={externalLocked || confirming || hasPendingRows || hasDirtyRows}
+            onClick={() => { if (!externallyBlocked()) clearForReupload(); }}
           >
             Choose another statement
           </button>
@@ -321,8 +328,9 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
           id="statement-source"
           required
           value={sourceType}
-          disabled={processing || confirming || Boolean(preview)}
+          disabled={externalLocked || processing || confirming || Boolean(preview)}
           onChange={(event) => {
+            if (externallyBlocked()) return;
             setRefreshError("");
             selectSource(event.target.value);
           }}
@@ -343,7 +351,7 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
       {(loading || processing) && (
         <div className="import-processing" role="status" aria-live="polite">
           <span>{loading ? "Looking for an unfinished preview…" : "Processing the statement safely…"}</span>
-          {processing && <button type="button" className="button-ghost" onClick={cancel}>Cancel</button>}
+          {processing && <button type="button" className="button-ghost" disabled={externalLocked} onClick={() => { if (!externallyBlocked()) cancel(); }}>Cancel</button>}
         </div>
       )}
 
@@ -362,11 +370,11 @@ export default function ImportPreviewPanel({ importState, onImportConfirmed = as
             id="sunflower-statement-file"
             type="file"
             accept=".pdf,application/pdf"
-            disabled={!sourceType}
+            disabled={externalLocked || !sourceType}
             onChange={(event) => submitFile(event.target.files?.[0])}
           />
           <p><strong>Drop a statement PDF here</strong> or choose it from your device.</p>
-          <button type="button" disabled={!sourceType} onClick={() => fileInput.current?.click()}>Choose PDF</button>
+          <button type="button" disabled={externalLocked || !sourceType} onClick={() => { if (!externallyBlocked()) fileInput.current?.click(); }}>Choose PDF</button>
         </div>
       )}
 

--- a/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
+++ b/frontend/src/features/importPreview/components/ImportPreviewPanel.test.jsx
@@ -1,4 +1,4 @@
-import { act, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import ImportPreviewPanel from './ImportPreviewPanel'
@@ -361,5 +361,149 @@ describe('ImportPreviewPanel confirmation safety', () => {
       selectedForImport: false,
       selectedForInflow: true,
     })
+  })
+
+  it('renders every statement mutation control locked during an external cash-in task', () => {
+    const { rerender } = render(<ImportPreviewPanel
+      importState={importState({ preview: null, sourceType: 'sunflower_pdf', selectedCount: 0 })}
+      externalLocked
+    />)
+
+    expect(screen.getByLabelText('Bank')).toBeDisabled()
+    expect(screen.getByLabelText('Sunflower statement PDF')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Choose PDF' })).toBeDisabled()
+
+    rerender(<ImportPreviewPanel importState={importState()} externalLocked />)
+    expect(screen.getByRole('button', { name: 'Choose another statement' })).toBeDisabled()
+    expect(within(tableRegion()).getByLabelText(/^Expense description for /)).toBeDisabled()
+    expect(within(tableRegion()).getByLabelText(/^Category for /)).toBeDisabled()
+    expect(within(tableRegion()).getByLabelText(/^Select for import for /)).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' })).toBeDisabled()
+    expect(screen.getByText('Finish the cash-in task before changing the statement.')).toBeInTheDocument()
+  })
+
+  it('rechecks the external lock inside source, upload, and drop handlers', () => {
+    let locked = false
+    const file = new File(['statement'], 'statement.pdf', { type: 'application/pdf' })
+    const state = importState({ preview: null, sourceType: 'sunflower_pdf', selectedCount: 0 })
+    const { container } = render(
+      <ImportPreviewPanel importState={state} isExternallyLocked={() => locked} />,
+    )
+
+    locked = true
+    fireEvent.change(screen.getByLabelText('Bank'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Sunflower statement PDF'), { target: { files: [file] } })
+    fireEvent.drop(container.querySelector('.import-dropzone'), { dataTransfer: { files: [file] } })
+
+    expect(state.selectSource).not.toHaveBeenCalled()
+    expect(state.upload).not.toHaveBeenCalled()
+  })
+
+  it('rechecks the external lock inside row, selection, replacement, and confirmation handlers', async () => {
+    let locked = false
+    const state = importState()
+    const { unmount } = render(
+      <ImportPreviewPanel importState={state} isExternallyLocked={() => locked} />,
+    )
+    const description = within(tableRegion()).getByLabelText(/^Expense description for /)
+
+    fireEvent.change(description, { target: { value: 'Dirty before lock' } })
+    expect(description).toHaveValue('Dirty before lock')
+    locked = true
+    fireEvent.change(description, { target: { value: 'Blocked edit' } })
+    fireEvent.click(within(tableRegion()).getByRole('button', { name: /^Save row for / }))
+    fireEvent.click(within(tableRegion()).getByLabelText(/^Select for import for /))
+    expect(description).toHaveValue('Dirty before lock')
+    expect(state.updateRow).not.toHaveBeenCalled()
+
+    unmount()
+    locked = false
+    const guardedState = importState()
+    render(<ImportPreviewPanel importState={guardedState} isExternallyLocked={() => locked} />)
+    locked = true
+    fireEvent.click(screen.getByRole('button', { name: 'Choose another statement' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' }))
+    expect(guardedState.clearForReupload).not.toHaveBeenCalled()
+    expect(guardedState.confirm).not.toHaveBeenCalled()
+  })
+
+  it('passes credit-only and already-confirmed result counts to the refresh callback', async () => {
+    const user = userEvent.setup()
+    const credit = {
+      ...row,
+      rowId: 'credit-only',
+      direction: 'credit',
+      classification: 'non_expense',
+      sourceDescription: 'SYNTHETIC DEPOSIT',
+      isEligible: false,
+      isInflowEligible: true,
+      editableExpenseDescription: null,
+      category: null,
+      selectedForImport: false,
+      selectedForInflow: true,
+    }
+    const creditResult = {
+      batchId: preview.batchId,
+      status: 'confirmed',
+      confirmedAt: '2026-08-25T21:00:00Z',
+      importedExpenseCount: 0,
+      importedInflowCount: 1,
+    }
+    const creditCallback = vi.fn().mockResolvedValue(undefined)
+    const { unmount } = render(<ImportPreviewPanel
+      importState={importState({
+        preview: { ...preview, rows: [credit] },
+        selectedCount: 1,
+        confirm: vi.fn().mockResolvedValue(creditResult),
+      })}
+      onImportConfirmed={creditCallback}
+    />)
+
+    await user.click(screen.getByRole('button', { name: 'Save 0 expenses and 1 incoming deposit' }))
+    expect(creditCallback).toHaveBeenCalledWith(creditResult)
+
+    unmount()
+    const alreadyConfirmedResult = {
+      ...creditResult,
+      status: 'already_confirmed',
+      importedExpenseCount: 1,
+      importedInflowCount: 0,
+    }
+    const alreadyConfirmedCallback = vi.fn().mockResolvedValue(undefined)
+    render(<ImportPreviewPanel
+      importState={importState({ confirm: vi.fn().mockResolvedValue(alreadyConfirmedResult) })}
+      onImportConfirmed={alreadyConfirmedCallback}
+    />)
+
+    await user.click(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' }))
+    expect(alreadyConfirmedCallback).toHaveBeenCalledWith(alreadyConfirmedResult)
+  })
+
+  it('keeps the completed import visible when one affected list refresh fails', async () => {
+    const user = userEvent.setup()
+    const result = {
+      batchId: preview.batchId,
+      status: 'confirmed',
+      confirmedAt: '2026-08-25T21:00:00Z',
+      importedExpenseCount: 1,
+      importedInflowCount: 1,
+    }
+    const onImportConfirmed = vi.fn().mockResolvedValue({ failedLists: ['cash in'] })
+    const state = importState({ confirm: vi.fn().mockResolvedValue(result) })
+    const { rerender } = render(
+      <ImportPreviewPanel importState={state} onImportConfirmed={onImportConfirmed} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Save 1 expense and 0 incoming deposits' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('The import succeeded, but Activity could not be refreshed for cash in')
+    expect(onImportConfirmed).toHaveBeenCalledWith(result)
+
+    rerender(<ImportPreviewPanel
+      importState={importState({ preview: null, selectedCount: 0, confirmation: result })}
+      onImportConfirmed={onImportConfirmed}
+    />)
+    expect(screen.getByRole('heading', { name: 'Import complete' })).toBeInTheDocument()
+    expect(screen.getByText(/1 expense and 1 incoming deposit saved/)).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('The import succeeded')
   })
 })

--- a/frontend/src/features/inflows/api/inflowsApi.js
+++ b/frontend/src/features/inflows/api/inflowsApi.js
@@ -1,0 +1,17 @@
+import client from "../../../shared/api/client";
+
+export const inflowsApi = {
+  getAll: (signal) => client.get("/api/inflows", { signal }),
+  create: (payload) => client.post("/api/inflows", {
+    description: payload.description,
+    amount: payload.amount,
+    date: payload.date,
+  }),
+  update: (id, payload) => client.put(`/api/inflows/${id}`, {
+    id,
+    description: payload.description,
+    amount: payload.amount,
+    date: payload.date,
+  }),
+  remove: (id) => client.delete(`/api/inflows/${id}`),
+};

--- a/frontend/src/features/inflows/api/inflowsApi.test.js
+++ b/frontend/src/features/inflows/api/inflowsApi.test.js
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import client from "../../../shared/api/client";
+import { inflowsApi } from "./inflowsApi";
+
+vi.mock("../../../shared/api/client", () => ({ default: {
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(),
+} }));
+
+describe("inflow API contract", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads the owner-scoped inflow list with cancellation", async () => {
+    const signal = new AbortController().signal;
+    await inflowsApi.getAll(signal);
+    expect(client.get).toHaveBeenCalledWith("/api/inflows", { signal });
+  });
+
+  it("sends the exact create payload as quoted decimal and calendar date values", async () => {
+    const payload = {
+      description: "Quarterly distribution",
+      amount: "9999999999999999.99",
+      date: "2026-09-08",
+      ownerId: "must-not-leave-the-browser",
+    };
+    await inflowsApi.create(payload);
+    expect(client.post).toHaveBeenCalledWith("/api/inflows", {
+      description: "Quarterly distribution",
+      amount: "9999999999999999.99",
+      date: "2026-09-08",
+    });
+  });
+
+  it("forces the route id into the update body", async () => {
+    const payload = {
+      id: 999,
+      description: "Corrected deposit",
+      amount: "12.35",
+      date: "2026-09-07",
+      provenance: "must-not-leave-the-browser",
+    };
+    await inflowsApi.update(42, payload);
+    expect(client.put).toHaveBeenCalledWith("/api/inflows/42", {
+      id: 42,
+      description: "Corrected deposit",
+      amount: "12.35",
+      date: "2026-09-07",
+    });
+  });
+
+  it("deletes only the requested inflow", async () => {
+    await inflowsApi.remove(42);
+    expect(client.delete).toHaveBeenCalledWith("/api/inflows/42");
+  });
+});

--- a/frontend/src/features/inflows/components/InflowForm.jsx
+++ b/frontend/src/features/inflows/components/InflowForm.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useId, useRef } from "react";
+import FormField from "../../../shared/ui/FormField";
+
+const EDIT_WARNING = "Changes update recorded cash flow. If this entry supports a saved paycheck, that link stays and its recorded details update; the saved paycheck expectation stays unchanged.";
+
+export default function InflowForm({
+  draft,
+  onChange,
+  onSubmit,
+  onCancel,
+  pending = false,
+  disabled = false,
+  fieldErrors = {},
+  mode = "create",
+  amountNeedsReview = false,
+}) {
+  const generatedId = useId();
+  const formRef = useRef(null);
+  const previousErrors = useRef("");
+  const formLabel = mode === "edit" ? "Edit cash in" : "Add cash in";
+  const submitLabel = mode === "edit" ? "Save changes" : "Add cash in";
+  const errorSignature = ["description", "amount", "date"]
+    .filter((name) => fieldErrors[name])
+    .map((name) => `${name}:${fieldErrors[name]}`)
+    .join("|");
+
+  useEffect(() => {
+    formRef.current?.elements.description?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (errorSignature && errorSignature !== previousErrors.current) {
+      formRef.current?.querySelector('[aria-invalid="true"]')?.focus();
+    }
+    previousErrors.current = errorSignature;
+  }, [errorSignature]);
+
+  function update(name, value) {
+    onChange({ ...draft, [name]: value });
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    if (!pending && !disabled) onSubmit();
+  }
+
+  function field(name, label, inputProps = {}) {
+    const error = fieldErrors[name];
+    const errorId = `${generatedId}-${name}-error`;
+
+    return (
+      <div className={`inflow-form__field inflow-form__field--${name}`}>
+        <FormField label={label}>
+          {(id) => (
+            <input
+              {...inputProps}
+              id={id}
+              name={name}
+              value={draft[name]}
+              onChange={(event) => update(name, event.target.value)}
+              aria-invalid={Boolean(error)}
+              aria-describedby={error ? errorId : undefined}
+              required
+            />
+          )}
+        </FormField>
+        {error && <span className="inflow-form__error" id={errorId}>{error}</span>}
+      </div>
+    );
+  }
+
+  return (
+    <form ref={formRef} className="inflow-form" aria-label={formLabel} aria-busy={pending} onSubmit={handleSubmit} noValidate>
+      {mode === "edit" && <p className="inflow-form__warning">{EDIT_WARNING}</p>}
+      {amountNeedsReview && (
+        <p className="inflow-form__warning">
+          <strong>Amount needs review.</strong> Enter the exact amount again before saving.
+        </p>
+      )}
+      {errorSignature && <p className="inflow-form__error" role="alert">Check the highlighted fields.</p>}
+
+      <fieldset className="inflow-form__fields" disabled={pending}>
+        <legend className="sr-only">Cash-in details</legend>
+        <div className="inflow-form__grid">
+          {field("description", "Description")}
+          {field("amount", "Amount", { inputMode: "decimal", autoComplete: "off" })}
+          {field("date", "Date", { type: "date", min: "0001-01-01", max: "9999-12-31" })}
+        </div>
+      </fieldset>
+
+      <div className="inflow-form__actions inline-actions">
+        <button type="submit" disabled={pending || disabled}>{pending ? "Saving…" : submitLabel}</button>
+        <button type="button" className="button-ghost" disabled={pending} onClick={onCancel}>Cancel</button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/inflows/components/InflowForm.test.jsx
+++ b/frontend/src/features/inflows/components/InflowForm.test.jsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import InflowForm from "./InflowForm";
+
+const draft = { description: "Client payment", amount: "1250.50", date: "2026-08-14" };
+
+function formProps(overrides = {}) {
+  return {
+    draft,
+    onChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    pending: false,
+    disabled: false,
+    fieldErrors: {},
+    mode: "create",
+    amountNeedsReview: false,
+    ...overrides,
+  };
+}
+
+describe("InflowForm", () => {
+  it("focuses the description and delegates exact draft strings without transforming a payload", () => {
+    const props = formProps();
+    render(<InflowForm {...props} />);
+
+    expect(screen.getByLabelText("Description")).toHaveFocus();
+    expect(screen.getByRole("form", { name: "Add cash in" })).toHaveAttribute("novalidate");
+
+    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "  Mixed CASE  spacing  " } });
+    expect(props.onChange).toHaveBeenLastCalledWith({
+      description: "  Mixed CASE  spacing  ",
+      amount: "1250.50",
+      date: "2026-08-14",
+    });
+
+    fireEvent.change(screen.getByLabelText("Amount"), { target: { value: "001.230" } });
+    expect(props.onChange).toHaveBeenLastCalledWith({
+      description: "Client payment",
+      amount: "001.230",
+      date: "2026-08-14",
+    });
+    fireEvent.submit(screen.getByRole("form", { name: "Add cash in" }));
+    expect(props.onSubmit).toHaveBeenCalledWith();
+  });
+
+  it("does not truncate a valid 500-character description surrounded by outer spaces", () => {
+    const rawDescription = `  ${"a".repeat(500)}  `;
+    const onChange = vi.fn();
+    const props = formProps({ draft: { ...draft, description: "" }, onChange });
+    const { rerender } = render(<InflowForm {...props} />);
+    const description = screen.getByLabelText("Description");
+
+    expect(description).not.toHaveAttribute("maxlength");
+    fireEvent.change(description, { target: { value: rawDescription } });
+    expect(onChange).toHaveBeenCalledWith({ ...draft, description: rawDescription });
+
+    rerender(<InflowForm {...props} draft={{ ...draft, description: rawDescription }} />);
+    expect(screen.getByLabelText("Description")).toHaveValue(rawDescription);
+  });
+
+  it("focuses the first invalid field only when the errors change", () => {
+    const props = formProps();
+    const { rerender } = render(<InflowForm {...props} />);
+
+    rerender(<InflowForm {...props} fieldErrors={{ amount: "Enter a positive amount.", date: "Enter a valid date." }} />);
+    const amount = screen.getByLabelText("Amount");
+    expect(amount).toHaveFocus();
+    expect(amount).toHaveAttribute("aria-invalid", "true");
+    expect(amount).toHaveAccessibleDescription("Enter a positive amount.");
+
+    screen.getByLabelText("Date").focus();
+    rerender(<InflowForm {...props} fieldErrors={{ amount: "Enter a positive amount.", date: "Enter a valid date." }} />);
+    expect(screen.getByLabelText("Date")).toHaveFocus();
+
+    rerender(<InflowForm {...props} fieldErrors={{ description: "Enter a description." }} />);
+    expect(screen.getByLabelText("Description")).toHaveFocus();
+  });
+
+  it("locks fields and cancel while pending, and otherwise leaves cancel available", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
+    const { rerender } = render(<InflowForm {...formProps({ pending: true, onCancel, onSubmit })} />);
+
+    expect(screen.getByLabelText("Description")).toBeDisabled();
+    expect(screen.getByLabelText("Amount")).toBeDisabled();
+    expect(screen.getByLabelText("Date")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    fireEvent.submit(screen.getByRole("form", { name: "Add cash in" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    rerender(<InflowForm {...formProps({ disabled: true, onCancel, onSubmit })} />);
+    expect(screen.getByRole("button", { name: "Add cash in" })).toBeDisabled();
+    expect(screen.getByLabelText("Description")).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("keeps edit consequences and unsafe amount re-entry guidance visible", () => {
+    render(<InflowForm {...formProps({ mode: "edit", amountNeedsReview: true, draft: { ...draft, amount: "" } })} />);
+
+    expect(screen.getByRole("form", { name: "Edit cash in" })).toBeInTheDocument();
+    expect(screen.getByText(/If this entry supports a saved paycheck/)).toBeVisible();
+    expect(screen.getByText(/Amount needs review/)).toBeVisible();
+    expect(screen.getByText(/Enter the exact amount again/)).toBeVisible();
+    expect(screen.getByLabelText("Amount")).toHaveValue("");
+  });
+});

--- a/frontend/src/features/inflows/components/InflowList.jsx
+++ b/frontend/src/features/inflows/components/InflowList.jsx
@@ -1,0 +1,88 @@
+import { formatInflowDate, formatInflowMoney } from "../utils/inflowForm";
+
+function actionName(action, inflow, formattedDate) {
+  return `${action} cash in ${inflow.description} from ${formattedDate}, record ${inflow.id}`;
+}
+
+export default function InflowList({
+  inflows,
+  totalCount,
+  filteredCount,
+  showAll,
+  onShowAll,
+  onEdit,
+  onDelete,
+  disabled = false,
+  readUnavailable = false,
+  taskRecordId = null,
+}) {
+  if (!inflows || inflows.length === 0) {
+    const hasRecordedInflows = typeof totalCount === "number" && totalCount > 0;
+    return (
+      <p className="empty-state inflow-list__empty">
+        {hasRecordedInflows ? "No cash in matches this search." : "No cash in recorded yet."}
+      </p>
+    );
+  }
+
+  const actionsDisabled = disabled || readUnavailable;
+
+  return (
+    <div className="inflow-list">
+      <div className="table-wrapper inflow-list__table-wrapper" role="region" aria-label="Cash in table" tabIndex="0">
+        <table className="data-table inflow-table">
+          <caption className="sr-only">Cash in</caption>
+          <thead>
+            <tr>
+              <th>Description</th>
+              <th>Amount</th>
+              <th>Date</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {inflows.map((inflow) => {
+              const formattedDate = formatInflowDate(inflow.date);
+              const isTaskRecord = taskRecordId === inflow.id;
+              return (
+                <tr key={inflow.id} className={`inflow-row${isTaskRecord ? " inflow-row--task" : ""}`} aria-current={isTaskRecord ? "true" : undefined}>
+                  <td className="inflow-cell inflow-cell--description" data-label="Description">{inflow.description}</td>
+                  <td className="inflow-cell inflow-cell--amount" data-label="Amount">{formatInflowMoney(inflow.amount)}</td>
+                  <td className="inflow-cell inflow-cell--date" data-label="Date">{formattedDate}</td>
+                  <td className="inflow-cell inflow-cell--actions" data-label="Actions">
+                    <div className="inline-actions inflow-row__actions">
+                      <button
+                        type="button"
+                        className="button-ghost"
+                        disabled={actionsDisabled}
+                        aria-label={actionName("Edit", inflow, formattedDate)}
+                        onClick={(event) => onEdit(inflow, event.currentTarget)}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="button-ghost"
+                        disabled={actionsDisabled}
+                        aria-label={actionName("Delete", inflow, formattedDate)}
+                        onClick={(event) => onDelete(inflow, event.currentTarget)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {!showAll && filteredCount > 10 && (
+        <button type="button" className="button-ghost inflow-list__show-all" onClick={onShowAll} disabled={disabled}>
+          Show all cash in
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/inflows/components/InflowList.test.jsx
+++ b/frontend/src/features/inflows/components/InflowList.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import InflowList from "./InflowList";
+
+const first = { id: 7, description: "Client Deposit", amount: 1250.5, date: "2026-08-14" };
+const duplicate = { id: 8, description: "Client Deposit", amount: 1250.5, date: "2026-08-14" };
+
+function listProps(overrides = {}) {
+  return {
+    inflows: [first],
+    totalCount: 1,
+    filteredCount: 1,
+    showAll: false,
+    onShowAll: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    disabled: false,
+    readUnavailable: false,
+    taskRecordId: null,
+    ...overrides,
+  };
+}
+
+describe("InflowList", () => {
+  it("distinguishes a true empty ledger from a search with no matches", () => {
+    const { rerender } = render(<InflowList {...listProps({ inflows: [], totalCount: 0, filteredCount: 0 })} />);
+    expect(screen.getByText("No cash in recorded yet.")).toBeInTheDocument();
+
+    rerender(<InflowList {...listProps({ inflows: [], totalCount: 4, filteredCount: 0 })} />);
+    expect(screen.getByText("No cash in matches this search.")).toBeInTheDocument();
+    expect(screen.queryByText("No cash in recorded yet.")).not.toBeInTheDocument();
+  });
+
+  it("renders one responsive table DOM with exact descriptions and formatted values", () => {
+    render(<InflowList {...listProps()} />);
+
+    const region = screen.getByRole("region", { name: "Cash in table" });
+    expect(within(region).getByRole("table")).toBeInTheDocument();
+    expect(within(region).getAllByRole("table")).toHaveLength(1);
+    expect(within(region).getByText("Cash in", { selector: "caption" })).toBeInTheDocument();
+    expect(within(region).getByText("Client Deposit")).toBeVisible();
+    expect(within(region).getByText("$1,250.50")).toBeVisible();
+  });
+
+  it("gives duplicate rows distinct action names and passes each opener", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(<InflowList {...listProps({ inflows: [first, duplicate], totalCount: 2, filteredCount: 2, onEdit, onDelete })} />);
+
+    const editSeven = screen.getByRole("button", { name: /Edit cash in Client Deposit .* record 7$/ });
+    const editEight = screen.getByRole("button", { name: /Edit cash in Client Deposit .* record 8$/ });
+    const deleteSeven = screen.getByRole("button", { name: /Delete cash in Client Deposit .* record 7$/ });
+    expect(editSeven).toHaveTextContent("Edit");
+    expect(deleteSeven).toHaveTextContent("Delete");
+    expect(editEight).not.toHaveAccessibleName(editSeven.getAttribute("aria-label"));
+
+    await user.click(editSeven);
+    await user.click(deleteSeven);
+    expect(onEdit).toHaveBeenCalledWith(first, editSeven);
+    expect(onDelete).toHaveBeenCalledWith(first, deleteSeven);
+  });
+
+  it("offers Show all only above ten filtered results", async () => {
+    const user = userEvent.setup();
+    const onShowAll = vi.fn();
+    const { rerender } = render(<InflowList {...listProps({ filteredCount: 10, onShowAll })} />);
+    expect(screen.queryByRole("button", { name: "Show all cash in" })).not.toBeInTheDocument();
+
+    rerender(<InflowList {...listProps({ filteredCount: 11, onShowAll })} />);
+    await user.click(screen.getByRole("button", { name: "Show all cash in" }));
+    expect(onShowAll).toHaveBeenCalledOnce();
+
+    rerender(<InflowList {...listProps({ filteredCount: 11, showAll: true, onShowAll })} />);
+    expect(screen.queryByRole("button", { name: "Show all cash in" })).not.toBeInTheDocument();
+  });
+
+  it("locks stale row actions and highlights the active task record", () => {
+    const { rerender } = render(<InflowList {...listProps({ readUnavailable: true, taskRecordId: 7 })} />);
+    const row = screen.getByText("Client Deposit").closest("tr");
+    expect(row).toHaveClass("inflow-row--task");
+    expect(row).toHaveAttribute("aria-current", "true");
+    expect(within(row).getByRole("button", { name: /^Edit cash in/ })).toBeDisabled();
+    expect(within(row).getByRole("button", { name: /^Delete cash in/ })).toBeDisabled();
+
+    rerender(<InflowList {...listProps({ disabled: true })} />);
+    expect(screen.getByRole("button", { name: /^Edit cash in/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^Delete cash in/ })).toBeDisabled();
+  });
+});

--- a/frontend/src/features/inflows/hooks/useInflows.js
+++ b/frontend/src/features/inflows/hooks/useInflows.js
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { getSessionSnapshot, subscribeToSession } from "../../../shared/auth/session";
+import { inflowsApi } from "../api/inflowsApi";
+
+function completedWrite(response, extra = {}) {
+  const outcome = { refreshFailed: false, ...extra };
+  if (response?.data && typeof response.data === "object") outcome.record = response.data;
+  return outcome;
+}
+
+export function useInflows() {
+  const session = useSyncExternalStore(subscribeToSession, getSessionSnapshot);
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+  const [state, setState] = useState(null);
+  const mounted = useRef(false);
+  const latestRead = useRef(0);
+  const activeController = useRef(null);
+  const writeInFlight = useRef(false);
+
+  const invalidateRead = useCallback(() => {
+    latestRead.current += 1;
+    activeController.current?.abort();
+    activeController.current = null;
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      invalidateRead();
+    };
+  }, [invalidateRead]);
+
+  const load = useCallback(async (readSession = session) => {
+    if (!mounted.current || readSession !== getSessionSnapshot() || readSession !== sessionRef.current) {
+      return { stale: true };
+    }
+
+    invalidateRead();
+    const id = latestRead.current;
+    setState((previous) => ({
+      session: readSession,
+      inflows: previous?.session === readSession ? previous.inflows : [],
+      loading: Boolean(readSession.token),
+      error: null,
+    }));
+
+    if (!readSession.token) return { stale: true };
+
+    const controller = new AbortController();
+    activeController.current = controller;
+    const current = () => mounted.current
+      && id === latestRead.current
+      && readSession === getSessionSnapshot()
+      && readSession === sessionRef.current;
+
+    try {
+      const response = await inflowsApi.getAll(controller.signal);
+      if (!current()) return { stale: true };
+      if (!Array.isArray(response?.data)) throw new Error("Invalid inflow list response.");
+      setState({
+        session: readSession,
+        inflows: response.data,
+        loading: false,
+        error: null,
+      });
+      return { stale: false };
+    } catch (error) {
+      if (!current()) return { stale: true };
+      setState((previous) => ({ ...previous, loading: false, error }));
+      throw error;
+    } finally {
+      if (activeController.current === controller) activeController.current = null;
+    }
+  }, [invalidateRead, session]);
+
+  useEffect(() => {
+    load().catch(() => {});
+    return invalidateRead;
+  }, [invalidateRead, load]);
+
+  const perform = useCallback(async (operation) => {
+    if (writeInFlight.current) throw new Error("An inflow write is already in progress.");
+    const writeSession = getSessionSnapshot();
+    if (!mounted.current || !writeSession.token || writeSession !== sessionRef.current) {
+      return { refreshFailed: false, stale: true };
+    }
+
+    writeInFlight.current = true;
+    invalidateRead();
+    try {
+      const response = await operation();
+      const base = completedWrite(response);
+      if (!mounted.current || writeSession !== getSessionSnapshot() || writeSession !== sessionRef.current) {
+        return { ...base, stale: true };
+      }
+      try {
+        const refresh = await load(writeSession);
+        if (!refresh.stale) return base;
+        if (!mounted.current || writeSession !== getSessionSnapshot() || writeSession !== sessionRef.current) {
+          return { ...base, stale: true };
+        }
+        // Another same-session read superseded the post-write refresh. The write
+        // is complete, but this caller cannot claim that its refresh succeeded.
+        return { ...base, refreshFailed: true };
+      } catch {
+        return { ...base, refreshFailed: true };
+      }
+    } finally {
+      writeInFlight.current = false;
+    }
+  }, [invalidateRead, load]);
+
+  const createInflow = useCallback((payload) => perform(() => inflowsApi.create(payload)), [perform]);
+  const updateInflow = useCallback((id, payload) => perform(() => inflowsApi.update(id, payload)), [perform]);
+  const deleteInflow = useCallback((id) => perform(() => inflowsApi.remove(id)), [perform]);
+  const refresh = useCallback(() => load(session), [load, session]);
+
+  const matches = state?.session === session;
+  return {
+    inflows: matches ? state.inflows : [],
+    loading: !matches || state.loading,
+    error: matches ? state.error : null,
+    refresh,
+    createInflow,
+    updateInflow,
+    deleteInflow,
+  };
+}

--- a/frontend/src/features/inflows/hooks/useInflows.test.js
+++ b/frontend/src/features/inflows/hooks/useInflows.test.js
@@ -1,0 +1,245 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSession, establishSession } from "../../../shared/auth/session";
+import { inflowsApi } from "../api/inflowsApi";
+import { useInflows } from "./useInflows";
+
+vi.mock("../api/inflowsApi", () => ({ inflowsApi: {
+  getAll: vi.fn(), create: vi.fn(), update: vi.fn(), remove: vi.fn(),
+} }));
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+const record = { id: 1, description: "Refund", amount: 12.35, date: "2026-09-01" };
+
+describe("inflow state boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    establishSession("owner-a", "a@example.test");
+    inflowsApi.getAll.mockResolvedValue({ data: [] });
+    inflowsApi.create.mockResolvedValue({ status: 201, data: record });
+    inflowsApi.update.mockResolvedValue({ status: 204 });
+    inflowsApi.remove.mockResolvedValue({ status: 204 });
+  });
+  afterEach(() => clearSession());
+
+  it("starts loading, passes an abort signal, and publishes a successful empty list", async () => {
+    const request = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(request.promise);
+    const { result } = renderHook(() => useInflows());
+    expect(result.current).toMatchObject({ inflows: [], loading: true, error: null });
+    expect(inflowsApi.getAll).toHaveBeenCalledWith(expect.any(AbortSignal));
+    await act(() => request.resolve({ data: [] }));
+    expect(result.current).toMatchObject({ inflows: [], loading: false, error: null });
+  });
+
+  it("keeps current refresh failures observable and distinct from an empty list", async () => {
+    inflowsApi.getAll.mockResolvedValueOnce({ data: [record] });
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.inflows).toEqual([record]));
+    const failure = new Error("read unavailable");
+    inflowsApi.getAll.mockRejectedValueOnce(failure);
+    await act(async () => { await expect(result.current.refresh()).rejects.toBe(failure); });
+    expect(result.current).toMatchObject({ inflows: [record], loading: false, error: failure });
+  });
+
+  it("treats a malformed list response as a failed read instead of an empty ledger", async () => {
+    inflowsApi.getAll.mockResolvedValueOnce({ data: [record] });
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.inflows).toEqual([record]));
+    inflowsApi.getAll.mockResolvedValueOnce({ data: { inflows: [] } });
+    await act(async () => { await expect(result.current.refresh()).rejects.toThrow("Invalid inflow list response"); });
+    expect(result.current.inflows).toEqual([record]);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it("aborts and resolves an older overlapping read as stale", async () => {
+    const old = deferred();
+    const recent = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    const { result } = renderHook(() => useInflows());
+    const firstSignal = inflowsApi.getAll.mock.calls[0][0];
+    let latest;
+    act(() => { latest = result.current.refresh(); });
+    expect(firstSignal.aborted).toBe(true);
+    await act(() => recent.resolve({ data: [record] }));
+    expect(await latest).toEqual({ stale: false });
+    await act(() => old.resolve({ data: [{ ...record, id: 99 }] }));
+    expect(result.current.inflows).toEqual([record]);
+  });
+
+  it("resolves an explicit obsolete refresh as stale when a newer refresh wins", async () => {
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const old = deferred();
+    const recent = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(old.promise).mockReturnValueOnce(recent.promise);
+    let oldOutcome;
+    act(() => { oldOutcome = result.current.refresh(); });
+    let recentOutcome;
+    act(() => { recentOutcome = result.current.refresh(); });
+    await act(() => recent.resolve({ data: [record] }));
+    expect(await recentOutcome).toEqual({ stale: false });
+    await act(() => old.resolve({ data: [] }));
+    expect(await oldOutcome).toEqual({ stale: true });
+  });
+
+  it("masks prior owner data on the first render of a new session and ignores late data", async () => {
+    inflowsApi.getAll.mockResolvedValueOnce({ data: [record] });
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.inflows).toEqual([record]));
+    const next = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(next.promise);
+    act(() => establishSession("owner-b", "b@example.test"));
+    expect(result.current).toMatchObject({ inflows: [], loading: true, error: null });
+    await act(() => next.resolve({ data: [{ ...record, id: 2 }] }));
+    expect(result.current.inflows).toEqual([{ ...record, id: 2 }]);
+  });
+
+  it("resolves a read from a changed session as stale even when cancellation is ignored", async () => {
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const old = deferred();
+    const current = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(old.promise).mockReturnValueOnce(current.promise);
+    let oldOutcome;
+    act(() => { oldOutcome = result.current.refresh(); });
+    act(() => establishSession("owner-b", "b@example.test"));
+    await act(() => old.resolve({ data: [record] }));
+    expect(await oldOutcome).toEqual({ stale: true });
+    expect(result.current.inflows).toEqual([]);
+    await act(() => current.resolve({ data: [{ ...record, id: 2 }] }));
+    expect(result.current.inflows).toEqual([{ ...record, id: 2 }]);
+  });
+
+  it("returns stale and skips the follow-up read when the session changes during a completed write", async () => {
+    const write = deferred();
+    inflowsApi.create.mockReturnValueOnce(write.promise);
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    let outcome;
+    act(() => { outcome = result.current.createInflow({ description: "Refund", amount: "12.35", date: "2026-09-01" }); });
+    act(() => establishSession("owner-b", "b@example.test"));
+    const readsAfterSessionChange = inflowsApi.getAll.mock.calls.length;
+    await act(() => write.resolve({ status: 201, data: record }));
+    expect(await outcome).toEqual({ refreshFailed: false, stale: true, record });
+    expect(inflowsApi.getAll).toHaveBeenCalledTimes(readsAfterSessionChange);
+  });
+
+  it("returns the created record after the completed write and successful refresh", async () => {
+    inflowsApi.getAll.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({ data: [record] });
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    let outcome;
+    await act(async () => { outcome = await result.current.createInflow({
+      description: "Refund", amount: "12.35", date: "2026-09-01",
+    }); });
+    expect(outcome).toEqual({ refreshFailed: false, record });
+    expect(result.current.inflows).toEqual([record]);
+  });
+
+  it.each([
+    ["updateInflow", "update", [1, { id: 1, description: "Updated", amount: "13", date: "2026-09-02" }]],
+    ["deleteInflow", "remove", [1]],
+  ])("completes %s and refreshes", async (method, apiMethod, args) => {
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    let outcome;
+    await act(async () => { outcome = await result.current[method](...args); });
+    expect(inflowsApi[apiMethod]).toHaveBeenCalledWith(...args);
+    expect(outcome).toEqual({ refreshFailed: false });
+    expect(inflowsApi.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws the original write failure and does not refresh", async () => {
+    const failure = new Error("write unavailable");
+    inflowsApi.create.mockRejectedValueOnce(failure);
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => { await expect(result.current.createInflow({})).rejects.toBe(failure); });
+    expect(inflowsApi.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a completed write separately when its refresh fails", async () => {
+    const failure = new Error("refresh unavailable");
+    inflowsApi.getAll.mockResolvedValueOnce({ data: [] }).mockRejectedValueOnce(failure);
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    let outcome;
+    await act(async () => { outcome = await result.current.updateInflow(1, { id: 1 }); });
+    expect(outcome).toEqual({ refreshFailed: true });
+    expect(result.current.error).toBe(failure);
+  });
+
+  it("reports refresh failure when a same-session read supersedes the post-write refresh", async () => {
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const postWriteRead = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(postWriteRead.promise)
+      .mockResolvedValueOnce({ data: [{ ...record, id: 2 }] });
+    let writeOutcome;
+    act(() => { writeOutcome = result.current.createInflow({}); });
+    await waitFor(() => expect(inflowsApi.getAll).toHaveBeenCalledTimes(2));
+
+    let competingRefresh;
+    act(() => { competingRefresh = result.current.refresh(); });
+    await act(async () => { expect(await competingRefresh).toEqual({ stale: false }); });
+    await act(() => postWriteRead.resolve({ data: [record] }));
+
+    expect(await writeOutcome).toEqual({ refreshFailed: true, record });
+    expect(result.current.inflows).toEqual([{ ...record, id: 2 }]);
+  });
+
+  it("returns stale when the session changes during the post-write refresh", async () => {
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const postWriteRead = deferred();
+    const newSessionRead = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(postWriteRead.promise)
+      .mockReturnValueOnce(newSessionRead.promise);
+    let writeOutcome;
+    act(() => { writeOutcome = result.current.createInflow({}); });
+    await waitFor(() => expect(inflowsApi.getAll).toHaveBeenCalledTimes(2));
+
+    act(() => establishSession("owner-b", "b@example.test"));
+    await waitFor(() => expect(inflowsApi.getAll).toHaveBeenCalledTimes(3));
+    await act(() => postWriteRead.resolve({ data: [record] }));
+
+    expect(await writeOutcome).toEqual({ refreshFailed: false, stale: true, record });
+    expect(result.current.inflows).toEqual([]);
+    await act(() => newSessionRead.resolve({ data: [{ ...record, id: 2 }] }));
+    expect(result.current.inflows).toEqual([{ ...record, id: 2 }]);
+  });
+
+  it("synchronously rejects an overlapping write without sending it", async () => {
+    const pending = deferred();
+    inflowsApi.create.mockReturnValueOnce(pending.promise);
+    const { result } = renderHook(() => useInflows());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    let first;
+    act(() => { first = result.current.createInflow({}); });
+    await expect(result.current.deleteInflow(1)).rejects.toThrow("already in progress");
+    expect(inflowsApi.remove).not.toHaveBeenCalled();
+    await act(async () => {
+      pending.resolve({ status: 201, data: record });
+      await first;
+    });
+  });
+
+  it("aborts an active read on unmount without leaking a completion", async () => {
+    const request = deferred();
+    inflowsApi.getAll.mockReturnValueOnce(request.promise);
+    const { result, unmount } = renderHook(() => useInflows());
+    const actions = result.current;
+    const signal = inflowsApi.getAll.mock.calls[0][0];
+    unmount();
+    expect(signal.aborted).toBe(true);
+    await act(() => request.resolve({ data: [record] }));
+    await expect(actions.refresh()).resolves.toEqual({ stale: true });
+  });
+});

--- a/frontend/src/features/inflows/utils/inflowForm.js
+++ b/frontend/src/features/inflows/utils/inflowForm.js
@@ -1,0 +1,90 @@
+const MAX_CENTS = 999999999999999999n;
+const UNSAFE_NUMERIC_AMOUNT = 2 ** 46;
+
+function localToday(now = new Date()) {
+  const year = String(now.getFullYear()).padStart(4, "0");
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseAmount(value) {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  if (typeof value === "number" && (!Number.isFinite(value) || isUnsafeAmount(value))) return null;
+  const text = String(value).trim();
+  if (!/^(?:\d+(?:\.\d{1,2})?|\.\d{1,2})$/.test(text)) return null;
+  const [whole = "0", fraction = ""] = text.split(".");
+  const canonicalWhole = (whole || "0").replace(/^0+(?=\d)/, "");
+  if (canonicalWhole.length > 16) return null;
+  const cents = BigInt(canonicalWhole) * 100n + BigInt(fraction.padEnd(2, "0"));
+  if (cents <= 0n || cents > MAX_CENTS) return null;
+  return {
+    cents,
+    value: `${canonicalWhole}${fraction ? `.${fraction}` : ""}`,
+    fraction,
+  };
+}
+
+function isCalendarDate(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (year < 1 || year > 9999 || month < 1 || month > 12) return false;
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day >= 1 && day <= days[month - 1];
+}
+
+export function isUnsafeAmount(value) {
+  return typeof value === "number"
+    && (!Number.isFinite(value) || Math.abs(value) >= UNSAFE_NUMERIC_AMOUNT);
+}
+
+export function initialInflowDraft(record) {
+  const editing = record != null;
+  const amount = record?.amount;
+  return {
+    description: typeof record?.description === "string" ? record.description : "",
+    amount: isUnsafeAmount(amount)
+      ? ""
+      : typeof amount === "string" || (typeof amount === "number" && Number.isFinite(amount))
+        ? String(amount)
+        : "",
+    date: editing ? (typeof record?.date === "string" ? record.date : "") : localToday(),
+  };
+}
+
+export function validateInflow(draft) {
+  const errors = {};
+  const description = typeof draft?.description === "string" ? draft.description.trim() : "";
+  if (!description) errors.description = "Enter a description.";
+  else if (description.length > 500) errors.description = "Use 500 characters or fewer.";
+
+  const amount = parseAmount(draft?.amount);
+  if (!amount) {
+    errors.amount = "Enter a positive amount with at most two decimals, up to 9999999999999999.99.";
+  }
+
+  const date = typeof draft?.date === "string" ? draft.date : "";
+  if (!isCalendarDate(date)) errors.date = "Enter a valid date.";
+
+  if (Object.keys(errors).length > 0) return { errors, payload: null };
+  return {
+    errors,
+    payload: { description, amount: amount.value, date },
+  };
+}
+
+export function formatInflowMoney(value) {
+  if (isUnsafeAmount(value)) return "Amount needs review";
+  const parsed = parseAmount(value);
+  if (!parsed) return "Amount needs review";
+  const [whole] = parsed.value.split(".");
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return `$${grouped}.${parsed.fraction.padEnd(2, "0")}`;
+}
+
+export function formatInflowDate(value) {
+  if (!isCalendarDate(value)) return "Unknown date";
+  const [year, month, day] = value.split("-");
+  return `${month}/${day}/${year}`;
+}

--- a/frontend/src/features/inflows/utils/inflowForm.test.js
+++ b/frontend/src/features/inflows/utils/inflowForm.test.js
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatInflowDate,
+  formatInflowMoney,
+  initialInflowDraft,
+  isUnsafeAmount,
+  validateInflow,
+} from "./inflowForm";
+
+describe("inflow form contracts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 8, 8, 23, 30));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("starts a new draft on the local calendar day", () => {
+    expect(initialInflowDraft()).toEqual({ description: "", amount: "", date: "2026-09-08" });
+  });
+
+  it("preserves safe edit values but leaves an unsafe numeric amount blank", () => {
+    expect(initialInflowDraft({ description: "IRS refund", amount: 12.35, date: "2026-09-01" }))
+      .toEqual({ description: "IRS refund", amount: "12.35", date: "2026-09-01" });
+    expect(initialInflowDraft({ description: "Large transfer", amount: 2 ** 46, date: "2026-09-02" }).amount).toBe("");
+  });
+
+  it("trims only the outside of a description and preserves exact decimal strings", () => {
+    expect(validateInflow({ description: "  Client   reimbursement  ", amount: "0012.30", date: "2026-09-08" }))
+      .toEqual({ errors: {}, payload: {
+        description: "Client   reimbursement",
+        amount: "12.30",
+        date: "2026-09-08",
+      } });
+    expect(validateInflow({ description: "Deposit", amount: ".50", date: "2026-09-08" }).payload.amount).toBe("0.50");
+  });
+
+  it.each(["", " ", "0", "-1", "1.001", "1.", "1e2", "1,000", "NaN", "Infinity", "10000000000000000", "9999999999999999.991"])(
+    "rejects invalid amount %s without rounding",
+    (amount) => {
+      const result = validateInflow({ description: "Deposit", amount, date: "2026-09-08" });
+      expect(result.payload).toBeNull();
+      expect(result.errors.amount).toBeTruthy();
+    },
+  );
+
+  it("accepts the exact maximum without converting it to Number", () => {
+    const result = validateInflow({
+      description: "Maximum",
+      amount: "9999999999999999.99",
+      date: "9999-12-31",
+    });
+    expect(result).toEqual({ errors: {}, payload: {
+      description: "Maximum",
+      amount: "9999999999999999.99",
+      date: "9999-12-31",
+    } });
+  });
+
+  it("requires a trimmed description no longer than 500 characters", () => {
+    expect(validateInflow({ description: "   ", amount: "1", date: "2026-09-08" }).errors.description).toBeTruthy();
+    expect(validateInflow({ description: ` ${"x".repeat(500)} `, amount: "1", date: "2026-09-08" }).payload.description)
+      .toHaveLength(500);
+    expect(validateInflow({ description: "x".repeat(501), amount: "1", date: "2026-09-08" }).errors.description).toBeTruthy();
+  });
+
+  it.each(["2024-02-29", "0001-01-01", "2026-03-08", "2026-11-01", "9999-12-31"])(
+    "accepts calendar date %s without a future ceiling",
+    (date) => expect(validateInflow({ description: "Deposit", amount: "1", date }).errors.date).toBeUndefined(),
+  );
+
+  it.each(["", "2026-02-29", "0000-01-01", "2026-04-31", "2026-13-01", "2026-1-01", "2026-01-01T00:00:00Z"])(
+    "rejects invalid calendar date %s",
+    (date) => expect(validateInflow({ description: "Deposit", amount: "1", date }).errors.date).toBeTruthy(),
+  );
+
+  it("formats exact money and refuses unsafe or malformed values without auto-rounding", () => {
+    expect(formatInflowMoney(1234.56)).toBe("$1,234.56");
+    expect(formatInflowMoney("9999999999999999.99")).toBe("$9,999,999,999,999,999.99");
+    expect(formatInflowMoney(Number("70368744177664.01"))).toBe("Amount needs review");
+    expect(formatInflowMoney(0.1 + 0.2)).toBe("Amount needs review");
+    expect(formatInflowMoney(null)).toBe("Amount needs review");
+    expect(isUnsafeAmount(2 ** 46)).toBe(true);
+    expect(isUnsafeAmount((2 ** 46) - 1)).toBe(false);
+  });
+
+  it("formats valid calendar dates without creating timezone-bearing instants", () => {
+    expect(formatInflowDate("2026-03-08")).toBe("03/08/2026");
+    expect(formatInflowDate("2026-11-01")).toBe("11/01/2026");
+    expect(formatInflowDate("0001-01-01")).toBe("01/01/0001");
+    expect(formatInflowDate("2026-02-29")).toBe("Unknown date");
+  });
+
+  it("handles malformed non-string drafts and display inputs without throwing", () => {
+    expect(() => validateInflow({ description: {}, amount: {}, date: {} })).not.toThrow();
+    expect(validateInflow(null).payload).toBeNull();
+    expect(initialInflowDraft({ description: {}, amount: {}, date: {} }))
+      .toEqual({ description: "", amount: "", date: "" });
+    expect(formatInflowMoney({})).toBe("Amount needs review");
+    expect(formatInflowDate({})).toBe("Unknown date");
+  });
+});

--- a/frontend/src/features/transactions/pages/TransactionsCashIn.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsCashIn.test.jsx
@@ -1,0 +1,179 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import TransactionsPage from './TransactionsPage'
+import { useInflows } from '../../inflows/hooks/useInflows'
+import { useExpenses } from '../../expenses/hooks/useExpenses'
+import { useImportPreview } from '../../importPreview/hooks/useImportPreview'
+vi.mock('../../inflows/hooks/useInflows', () => ({ useInflows: vi.fn() }))
+vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
+vi.mock('../../importPreview/hooks/useImportPreview', () => ({ useImportPreview: vi.fn() }))
+const record = { id: 1, description: 'Transfer from Savings', amount: 24.15, date: '2026-09-01' }
+let cash, expenses, importing
+beforeEach(() => {
+  cash = { inflows: [record], loading: false, error: null, refresh: vi.fn().mockResolvedValue({ stale: false }), createInflow: vi.fn().mockResolvedValue({ refreshFailed: false }), updateInflow: vi.fn().mockResolvedValue({ refreshFailed: false }), deleteInflow: vi.fn().mockResolvedValue({ refreshFailed: false }) }
+  expenses = { expenses: [], loading: false, error: null, refresh: vi.fn().mockResolvedValue({}), addExpense: vi.fn(), updateExpense: vi.fn(), deleteExpense: vi.fn() }
+  importing = { preview: null, sourceType: '', loading: false, processing: false, error: '', confirming: false, confirmation: null, confirmationIssue: null, selectedCount: 0, selectSource: vi.fn(), upload: vi.fn(), cancel: vi.fn(), updateRow: vi.fn(), confirm: vi.fn(), clearForReupload: vi.fn() }
+  useInflows.mockImplementation(() => cash)
+  useExpenses.mockImplementation(() => expenses)
+  useImportPreview.mockImplementation(() => importing)
+})
+async function draft(user) {
+  await user.click(screen.getByRole('button', { name: 'Add cash in', exact: true }))
+  const form = screen.getByRole('form', { name: 'Add cash in' })
+  await user.type(within(form).getByLabelText('Description'), '  Refund  From Store  ')
+  await user.type(within(form).getByLabelText('Amount'), '9999999999999999.99')
+  fireEvent.change(within(form).getByLabelText('Date'), { target: { value: '2026-09-02' } })
+  return form
+}
+const submit = (form) => fireEvent.submit(form)
+
+describe('Activity cash-in tasks', () => {
+  it('submits exact values once while pending and clears the completed draft', async () => {
+    let complete
+    cash.createInflow.mockImplementation(() => new Promise(resolve => { complete = resolve }))
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    const form = await draft(user)
+    submit(form); submit(form)
+    expect(cash.createInflow).toHaveBeenCalledTimes(1)
+    expect(cash.createInflow).toHaveBeenCalledWith({ description: 'Refund  From Store', amount: '9999999999999999.99', date: '2026-09-02' })
+    expect(within(form).getByLabelText('Amount')).toBeDisabled()
+    expect(within(form).getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    await act(async () => complete({ refreshFailed: false }))
+    expect(screen.queryByRole('form', { name: 'Add cash in' })).not.toBeInTheDocument()
+    expect(screen.getByText('Cash in saved. Reports use this entry’s posted date.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'View Insights' })).toHaveAttribute('href', '/analytics')
+  })
+  it('gates an unknown draft until a successful explicit read and acknowledgement', async () => {
+    cash.createInflow.mockRejectedValue(new Error('private payload'))
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    const form = await draft(user)
+    submit(form)
+    const ack = await screen.findByRole('button', { name: 'I checked cash in' })
+    expect(ack).toBeDisabled()
+    expect(within(form).getByLabelText('Description')).toHaveValue('  Refund  From Store  ')
+    expect(within(form).getByRole('button', { name: 'Add cash in' })).toBeDisabled()
+    cash.refresh.mockRejectedValueOnce(new Error('read failed'))
+    await user.click(screen.getByRole('button', { name: 'Refresh cash in' }))
+    expect(ack).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Refresh cash in' }))
+    expect(ack).toBeEnabled()
+    await user.click(ack)
+    expect(within(form).getByRole('button', { name: 'Add cash in' })).toBeEnabled()
+    expect(cash.createInflow).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText(/private payload/)).not.toBeInTheDocument()
+  })
+  it('retains known write success after failed refresh without offering the completed create', async () => {
+    cash.createInflow.mockResolvedValue({ refreshFailed: true })
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    submit(await draft(user))
+    await screen.findByText(/Cash in saved.*could not be refreshed/)
+    expect(screen.queryByRole('form', { name: 'Add cash in' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add cash in' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'I checked cash in' })).not.toBeInTheDocument()
+    cash.refresh.mockRejectedValueOnce(new Error('offline'))
+    await user.click(screen.getByRole('button', { name: 'Refresh cash in' }))
+    expect(screen.getByRole('button', { name: 'Add cash in' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Refresh cash in' }))
+    expect(screen.getByRole('button', { name: 'Add cash in' })).toBeEnabled()
+    expect(cash.createInflow).toHaveBeenCalledTimes(1)
+  })
+  it('maps validation keys safely, preserves the draft and focuses the invalid field', async () => {
+    cash.createInflow.mockRejectedValue({ response: { status: 400, data: { errors: { Amount: ['private server value'] } } } })
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    const form = await draft(user)
+    submit(form)
+    await waitFor(() => expect(within(form).getByLabelText('Amount')).toHaveFocus())
+    expect(within(form).getByLabelText('Amount')).toHaveValue('9999999999999999.99')
+    expect(screen.queryByText('private server value')).not.toBeInTheDocument()
+    expect(within(form).getByRole('button', { name: 'Add cash in' })).toBeEnabled()
+  })
+  it('pins an edit through search and a failed read and returns cancellation focus', async () => {
+    const user = userEvent.setup()
+    const view = render(<TransactionsPage />)
+    await user.click(screen.getByRole('button', { name: /Edit cash in Transfer/ }))
+    const form = screen.getByRole('form', { name: 'Edit cash in' })
+    await user.type(within(form).getByLabelText('Description'), ' revised')
+    await user.type(screen.getByRole('searchbox', { name: 'Search cash in' }), 'does not match')
+    cash = { ...cash, error: new Error('offline'), inflows: [] }
+    view.rerender(<TransactionsPage />)
+    expect(within(form).getByLabelText('Description')).toHaveValue('Transfer from Savings revised')
+    expect(screen.getByText('Transfer from Savings', { selector: 'td' })).toBeInTheDocument()
+    expect(within(form).getByRole('button', { name: 'Save changes' })).toBeDisabled()
+    await user.click(within(form).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Cash in' })).toHaveFocus())
+  })
+  it('requires refresh after 404 and prevents resubmitting an unavailable target', async () => {
+    cash.updateInflow.mockRejectedValue({ response: { status: 404 } })
+    const user = userEvent.setup()
+    const view = render(<TransactionsPage />)
+    await user.click(screen.getByRole('button', { name: /Edit cash in Transfer/ }))
+    const form = screen.getByRole('form', { name: 'Edit cash in' })
+    submit(form)
+    await screen.findByText(/This cash-in record is unavailable/)
+    expect(cash.updateInflow).toHaveBeenCalledWith(1, { id: 1, description: record.description, amount: '24.15', date: record.date })
+    cash = { ...cash, inflows: [] }
+    await user.click(screen.getByRole('button', { name: 'Refresh cash in' }))
+    view.rerender(<TransactionsPage />)
+    expect(within(form).getByRole('button', { name: 'Save changes' })).toBeDisabled()
+    expect(screen.getByText(/Cancel this task to choose another record/)).toBeInTheDocument()
+  })
+  it('requires record-specific delete confirmation with link and import consequences', async () => {
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    await user.click(screen.getByRole('button', { name: /Delete cash in Transfer/ }))
+    expect(screen.getByRole('heading', { name: /Delete cash in: Transfer from Savings/ })).toBeInTheDocument()
+    expect(screen.getByText(/supporting paycheck link is removed/)).toBeInTheDocument()
+    expect(screen.getByText(/same confirmed statement again will not restore/)).toBeInTheDocument()
+    expect(cash.deleteInflow).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'Confirm delete cash in' }))
+    expect(cash.deleteInflow).toHaveBeenCalledWith(1)
+    await screen.findByText(/Cash in deleted/)
+  })
+  it('preserves an expense draft when cash in is requested', async () => {
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    await user.click(screen.getByRole('button', { name: 'Add expense' }))
+    const field = screen.getByPlaceholderText('Description')
+    await user.type(field, 'Expense draft')
+    await user.click(screen.getByRole('button', { name: 'Add cash in' }))
+    expect(screen.queryByRole('form', { name: 'Add cash in' })).not.toBeInTheDocument()
+    expect(field).toHaveValue('Expense draft')
+    await waitFor(() => expect(field).toHaveFocus())
+    expect(screen.getByText(/Finish or close the open expense or import task/)).toBeInTheDocument()
+  })
+  it('preserves cash in against expense/import openers and a resumed import', async () => {
+    const user = userEvent.setup()
+    const view = render(<TransactionsPage />)
+    const form = await draft(user)
+    await user.click(screen.getByRole('button', { name: 'Add expense' }))
+    await user.click(screen.getByRole('button', { name: 'Import statement' }))
+    expect(screen.queryByRole('heading', { name: 'Add expense' })).not.toBeInTheDocument()
+    expect(within(form).getByLabelText('Amount')).toHaveValue('9999999999999999.99')
+    importing = { ...importing, processing: true }
+    view.rerender(<TransactionsPage />)
+    expect(within(form).getByRole('button', { name: 'Add cash in' })).toBeDisabled()
+    expect(within(form).getByLabelText('Description')).toHaveValue('  Refund  From Store  ')
+    expect(importing.upload).not.toHaveBeenCalled()
+  })
+  it('leaves expenses available on a cash-in read failure without showing a false empty ledger', async () => {
+    cash = { ...cash, inflows: [], error: new Error('offline') }
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    expect(screen.getByText(/We couldn’t load cash in/)).toBeInTheDocument()
+    expect(screen.queryByText(/No cash in recorded yet/)).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Add expense' }))
+    expect(screen.getByRole('heading', { name: 'Add expense' })).toBeInTheDocument()
+  })
+  it('allows cash in after a known completed import', async () => {
+    importing = { ...importing, confirmation: { importedExpenseCount: 0, importedInflowCount: 1, alreadyConfirmed: false } }
+    const user = userEvent.setup()
+    render(<TransactionsPage />)
+    await user.click(screen.getByRole('button', { name: 'Add cash in' }))
+    expect(screen.getByRole('form', { name: 'Add cash in' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/transactions/pages/TransactionsPage.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.jsx
@@ -8,8 +8,14 @@ import ExpenseFilters from "../../expenses/components/ExpenseFilters";
 import ExpenseList from "../../expenses/components/ExpenseList";
 import ImportPreviewPanel from "../../importPreview/components/ImportPreviewPanel";
 import { useImportPreview } from "../../importPreview/hooks/useImportPreview";
+import { getSessionSnapshot } from "../../../shared/auth/session";
+import { useInflows } from "../../inflows/hooks/useInflows";
+import InflowForm from "../../inflows/components/InflowForm";
+import InflowList from "../../inflows/components/InflowList";
+import { initialInflowDraft, validateInflow, isUnsafeAmount, formatInflowDate } from "../../inflows/utils/inflowForm";
 import StatusMessage from "../../../shared/ui/StatusMessage";
 import "../../../styles/activity.css";
+import "../../../styles/inflows.css";
 
 const ENTRIES_PER_PAGE = 10;
 function focusAfterRender(target) {
@@ -18,6 +24,23 @@ function focusAfterRender(target) {
 
 export default function TransactionsPage() {
   const importState = useImportPreview();
+  const cash = useInflows();
+  const [cashTask, setCashTask] = useState(null);
+  const [cashPending, setCashPending] = useState(false);
+  const [cashGate, setCashGate] = useState(null);
+  const [cashCheckedRead, setCashCheckedRead] = useState(false);
+  const [cashFeedback, setCashFeedback] = useState(null);
+  const [cashErrors, setCashErrors] = useState({});
+  const [cashSearch, setCashSearch] = useState("");
+  const [cashShowAll, setCashShowAll] = useState(false);
+  const cashWrite = useRef(false);
+  const cashLock = useRef(false);
+  const legacyLock = useRef(false);
+  const cashOpener = useRef(null);
+  const cashAddButton = useRef(null);
+  const cashHeading = useRef(null);
+  const cashFeedbackRegion = useRef(null);
+  const cashDeleteButton = useRef(null);
   const {
     expenses, loading: expensesLoading, error: expensesError,
     refresh: refreshExpenses, addExpense, updateExpense, deleteExpense,
@@ -63,8 +86,135 @@ export default function TransactionsPage() {
     || (importState.loading && (resumingImport || importState.sourceType)) || importState.confirming || importState.error
     || importState.confirmation || importState.confirmationIssue);
   const showImport = importOpen || importMustStayVisible;
+  const cashLocked = Boolean(cashTask || cashPending || cashGate);
+  cashLock.current = cashLocked;
+  const legacyBlocked = Boolean(addOpen || editingExpense || pending || outcomeNeedsRefresh
+    || (importOpen && !importState.confirmation) || importState.preview || importState.processing
+    || importState.confirming || importState.loading || importState.error || importState.confirmationIssue);
+  legacyLock.current = legacyBlocked;
+  const cashReadUnavailable = cash.loading || Boolean(cash.error);
+  const filteredCash = cash.inflows.filter((record) => record.description.toLowerCase().includes(cashSearch.trim().toLowerCase()));
+  const visibleCash = cashShowAll ? filteredCash : filteredCash.slice(0, ENTRIES_PER_PAGE);
+  const cashPinned = cashTask?.record && !visibleCash.some((record) => record.id === cashTask.record.id);
+  const cashRows = cashPinned ? [cashTask.record, ...visibleCash] : visibleCash;
+  const cashTargetMissing = cashTask?.record && !cashReadUnavailable
+    && !cash.inflows.some((record) => record.id === cashTask.record.id);
+  useEffect(() => { setCashShowAll(false); }, [cashSearch]);
+
+  function focusCashTask() {
+    focusAfterRender(() => document.querySelector('#cash-in-task input') ?? cashDeleteButton.current ?? cashFeedbackRegion.current);
+  }
+  function openCashTask(type, record, opener) {
+    if (cashLock.current || cashWrite.current) { focusCashTask(); return; }
+    if (legacyLock.current) {
+      setCashFeedback({ tone: "info", message: "Finish or close the open expense or import task before changing cash in." });
+      focusAfterRender(() => addOpen ? addInput.current : editingExpense
+        ? document.querySelector('[aria-label="Edit description"]') : importRegion.current);
+      return;
+    }
+    if (cashReadUnavailable) return;
+    cashLock.current = true;
+    cashOpener.current = opener;
+    setCashErrors({});
+    setCashFeedback(null);
+    setCashTask({ type, record, draft: type === "delete" ? null : initialInflowDraft(record) });
+    if (type === "delete") focusAfterRender(() => cashDeleteButton.current);
+  }
+  function cancelCashTask() {
+    if (cashWrite.current) return;
+    setCashTask(null);
+    setCashErrors({});
+    focusAfterRender(() => cashOpener.current?.isConnected && !cashOpener.current.disabled
+      ? cashOpener.current : cashHeading.current);
+  }
+  async function refreshCash() {
+    if (cashWrite.current) return;
+    const session = getSessionSnapshot();
+    setCashCheckedRead(false);
+    try {
+      const result = await cash.refresh();
+      if (result?.stale || session !== getSessionSnapshot()) return;
+      if (cashGate === "unknown") {
+        setCashCheckedRead(true);
+        setCashFeedback({ tone: "warning", message: "Cash in refreshed. Check whether the change was saved before allowing another attempt." });
+      } else {
+        setCashGate(null);
+        if (cashGate) setCashFeedback({ tone: "info", message: "Cash in refreshed. Check the current records before making another change." });
+      }
+    } catch {
+      // An unsuccessful read cannot release an uncertain write.
+    }
+  }
+  async function writeCash(action, successMessage) {
+    if (cashWrite.current || cashGate || legacyLock.current || cashReadUnavailable) return;
+    const session = getSessionSnapshot();
+    cashWrite.current = true;
+    cashLock.current = true;
+    setCashPending(true);
+    setCashFeedback(null);
+    setCashErrors({});
+    let focusOutcome = true;
+    try {
+      const result = await action();
+      if (result?.stale || session !== getSessionSnapshot()) return;
+      setCashTask(null);
+      setCashGate(result?.refreshFailed ? "refresh" : null);
+      setCashFeedback({ tone: result?.refreshFailed ? "warning" : "success", saved: true,
+        message: result?.refreshFailed
+          ? `${successMessage} The cash-in list could not be refreshed. Refresh cash in before another change.` : successMessage });
+    } catch (error) {
+      if (session !== getSessionSnapshot()) return;
+      const status = error?.response?.status;
+      if (status === 400) {
+        const fields = error.response?.data?.errors;
+        const errors = {};
+        for (const field of ["description", "amount", "date"]) {
+          if (fields && Object.keys(fields).some((key) => key.toLowerCase() === field)) {
+            errors[field] = { description: "Enter a description of 1 to 500 characters.",
+              amount: "Enter a positive amount with at most two decimals, up to 9999999999999999.99.",
+              date: "Enter a valid calendar date." }[field];
+          }
+        }
+        setCashErrors(errors);
+        focusOutcome = Object.keys(errors).length === 0;
+        setCashFeedback({ tone: "danger", message: "Cash in was not saved. Check the details and try again." });
+      } else if (status === 401 || status === 403) {
+        setCashFeedback({ tone: "danger", message: status === 401 ? "Your session ended. Sign in again." : "You do not have permission to change this cash-in record." });
+      } else {
+        setCashGate(status === 404 ? "missing" : "unknown");
+        setCashCheckedRead(false);
+        setCashFeedback({ tone: "danger", message: status === 404
+          ? "This cash-in record is unavailable. Refresh cash in before making another change."
+          : "We couldn’t confirm the change. Refresh cash in and check the records before trying again." });
+      }
+    } finally {
+      cashWrite.current = false;
+      if (session === getSessionSnapshot()) {
+        setCashPending(false);
+        if (focusOutcome) focusAfterRender(() => cashFeedbackRegion.current);
+      }
+    }
+  }
+  function saveCash() {
+    if (!cashTask || cashTargetMissing) return;
+    const { errors, payload } = validateInflow(cashTask.draft);
+    setCashErrors(errors);
+    if (!payload) return;
+    return writeCash(() => cashTask.type === "create" ? cash.createInflow(payload)
+      : cash.updateInflow(cashTask.record.id, { id: cashTask.record.id, ...payload }),
+    cashTask.type === "create" ? "Cash in saved. Reports use this entry’s posted date." : "Cash in updated. Reports use this entry’s posted date.");
+  }
+  async function refreshImportedActivity(result) {
+    const requests = [];
+    if (result.importedExpenseCount > 0) requests.push({ name: "expenses", request: refreshExpenses() });
+    if (result.importedInflowCount > 0) requests.push({ name: "cash in", request: cash.refresh() });
+    const outcomes = await Promise.allSettled(requests.map(({ request }) => request));
+    return { failedLists: requests.filter((_, index) => outcomes[index].status === "rejected").map(({ name }) => name) };
+  }
 
   function openAdd() {
+    if (cashLock.current) { focusCashTask(); return; }
+    legacyLock.current = true;
     setAddOpen(true);
     focusAfterRender(() => addInput.current);
   }
@@ -74,7 +224,8 @@ export default function TransactionsPage() {
     focusAfterRender(() => addButton.current);
   }
   function startEditExpense(expense, opener) {
-    if (editingExpense || writeInFlight.current) return;
+    if (cashLock.current || editingExpense || writeInFlight.current) return;
+    legacyLock.current = true;
     const currentCategory = expense.category || "";
     const categoryIsDefault = isDefaultCategory(currentCategory, DEFAULT_CATEGORIES);
     editButton.current = opener;
@@ -93,7 +244,8 @@ export default function TransactionsPage() {
     focusAfterRender(() => editButton.current?.isConnected ? editButton.current : activityHeading.current);
   }
   async function writeExpense(action, successMessage, onSuccess) {
-    if (writeInFlight.current || outcomeNeedsRefresh || expensesLoading || expensesError) return;
+    if (cashLock.current || writeInFlight.current || outcomeNeedsRefresh || expensesLoading || expensesError) return;
+    legacyLock.current = true;
     writeInFlight.current = true;
     setPending(true);
     setFeedback(null);
@@ -145,35 +297,43 @@ export default function TransactionsPage() {
     }), "Expense updated.", cancelEditExpense);
   }
   async function handleDeleteExpense(id) {
-    if (writeInFlight.current || !window.confirm("Delete this expense?")) return;
+    if (cashLock.current || writeInFlight.current || !window.confirm("Delete this expense?")) return;
     await writeExpense(() => deleteExpense(id), "Expense deleted.");
   }
 
   return (
     <div className="container activity-page">
       <header className="page-header">
-        <div><h1>Activity</h1><p className="muted">Review and organize your spending.</p></div>
+        <div><h1>Activity</h1><p className="muted">Review recorded spending and incoming money.</p></div>
         <div className="inline-actions activity-task-openers">
           <button type="button" ref={addButton} aria-expanded={addOpen} aria-controls="add-expense-task" onClick={openAdd}>
             Add expense
           </button>
+          <button type="button" ref={cashAddButton} aria-expanded={cashTask?.type === "create"} aria-controls="cash-in-task"
+            disabled={cashReadUnavailable || cashPending || Boolean(cashGate)}
+            onClick={(event) => openCashTask("create", null, event.currentTarget)}>Add cash in</button>
           <button type="button" className="button-ghost" ref={importButton} aria-expanded={showImport} aria-controls="statement-import-task"
-            onClick={() => { setImportOpen(true); focusAfterRender(() => importRegion.current); }}>
+            onClick={() => { if (cashLock.current) { focusCashTask(); return; } legacyLock.current = true; setImportOpen(true); focusAfterRender(() => importRegion.current); }}>
             Import statement
           </button>
         </div>
       </header>
+      <nav className="activity-section-links" aria-label="Activity sections">
+        <a href="#spending-activity-heading">Spending</a><a href="#cash-in-heading">Cash in</a>
+      </nav>
+      {cashLocked && <p className="muted">Finish the cash-in task or its refresh check before starting an expense or import task.</p>}
       <div ref={feedbackRegion} tabIndex={-1} className="activity-feedback">
         {feedback && <StatusMessage tone={feedback.tone}>{feedback.message}</StatusMessage>}
       </div>
       <div id="add-expense-task" hidden={!addOpen}>
-        <ExpenseForm loading={expensesLoading || Boolean(expensesError) || outcomeNeedsRefresh} pending={pending} onAdd={handleAddExpense} onCancel={clearAdd} inputRef={addInput}
+        <ExpenseForm loading={cashLocked || expensesLoading || Boolean(expensesError) || outcomeNeedsRefresh} pending={pending} onAdd={handleAddExpense} onCancel={clearAdd} inputRef={addInput}
           newName={newName} setNewName={setNewName} newAmount={newAmount} setNewAmount={setNewAmount}
           newDate={newDate} setNewDate={setNewDate} newCategory={newCategory} setNewCategory={setNewCategory}
           customCategory={customCategory} setCustomCategory={setCustomCategory} />
       </div>
       <div id="statement-import-task" ref={importRegion} tabIndex={-1} hidden={!showImport} className="activity-import-task">
-        <ImportPreviewPanel importState={importState} onImportConfirmed={refreshExpenses} />
+        <ImportPreviewPanel importState={importState} onImportConfirmed={refreshImportedActivity}
+          externalLocked={cashLocked} isExternallyLocked={() => cashLock.current} />
         {!importMustStayVisible && <button type="button" className="button-ghost" onClick={() => {
           setImportOpen(false); focusAfterRender(() => importButton.current);
         }}>Close import</button>}
@@ -198,7 +358,49 @@ export default function TransactionsPage() {
           entriesPerPage={ENTRIES_PER_PAGE} showAll={showAll} onShowAll={() => setShowAll(true)}
           editingExpenseId={editingExpense?.id ?? null} editingExpenseData={editingExpenseData} setEditingExpenseData={setEditingExpenseData}
           onStartEdit={startEditExpense} onSave={saveExpenseEdit} onCancel={cancelEditExpense} onDelete={handleDeleteExpense}
-          busy={pending} taskLocked={Boolean(editingExpense)} readUnavailable={expensesLoading || Boolean(expensesError) || outcomeNeedsRefresh} />}
+          busy={pending} taskLocked={cashLocked || Boolean(editingExpense)} readUnavailable={expensesLoading || Boolean(expensesError) || outcomeNeedsRefresh} />}
+      </section>
+      <section className="activity-cash-in" aria-labelledby="cash-in-heading">
+        <div className="activity-spending__header">
+          <h2 id="cash-in-heading" ref={cashHeading} tabIndex={-1}>Cash in</h2>
+          <button type="button" className="button-ghost" disabled={cash.loading || cashPending} onClick={refreshCash}>Refresh cash in</button>
+        </div>
+        <p className="muted">Recorded incoming money, including transfers and refunds. A cash-in record is not automatically income or a paycheck.</p>
+        <div ref={cashFeedbackRegion} tabIndex={-1} className="activity-feedback">
+          {cashFeedback && <StatusMessage tone={cashFeedback.tone}>{cashFeedback.message}</StatusMessage>}
+          {cashFeedback?.saved && <a href="/analytics">View Insights</a>}
+        </div>
+        {cashGate === "unknown" && <button type="button" className="button-ghost"
+          disabled={!cashCheckedRead || cashReadUnavailable || cashPending}
+          onClick={() => { if (!cashCheckedRead || cashReadUnavailable || cashWrite.current) return; setCashGate(null); setCashCheckedRead(false);
+            setCashFeedback({ tone: "info", message: "You checked the records. Another attempt is now available; it will not run automatically." }); }}>I checked cash in</button>}
+        <div id="cash-in-task" hidden={!cashTask}>
+          {cashTask && cashTask.type !== "delete" && <InflowForm mode={cashTask.type} draft={cashTask.draft}
+            onChange={(draft) => { setCashTask((current) => ({ ...current, draft })); setCashErrors({}); }}
+            fieldErrors={cashErrors} onSubmit={saveCash} onCancel={cancelCashTask} pending={cashPending}
+            disabled={cashReadUnavailable || Boolean(cashGate) || legacyBlocked || Boolean(cashTargetMissing)}
+            amountNeedsReview={cashTask.type === "edit" && isUnsafeAmount(cashTask.record.amount)} />}
+          {cashTask?.type === "delete" && <div className="inflow-delete-confirmation" role="group" aria-labelledby="cash-in-delete-heading">
+            <h3 id="cash-in-delete-heading">Delete cash in: {cashTask.record.description} ({formatInflowDate(cashTask.record.date)})?</h3>
+            <p>This removes the record from cash-flow history. Any supporting paycheck link is removed; the saved paycheck expectation remains.</p>
+            <p>If this entry was imported, importing the same confirmed statement again will not restore it.</p>
+            <div className="inline-actions">
+              <button type="button" ref={cashDeleteButton} className="button-danger"
+                disabled={cashPending || cashReadUnavailable || Boolean(cashGate) || legacyBlocked || Boolean(cashTargetMissing)}
+                onClick={() => writeCash(() => cash.deleteInflow(cashTask.record.id), "Cash in deleted. Recorded reports will reflect its removal.")}>{cashPending ? "Deleting…" : "Confirm delete cash in"}</button>
+              <button type="button" className="button-ghost" disabled={cashPending} onClick={cancelCashTask}>Cancel</button>
+            </div>
+          </div>}
+          {cashTargetMissing && <StatusMessage>This entry is no longer in the current list. Cancel this task to choose another record.</StatusMessage>}
+        </div>
+        <label className="field">Search cash in<input type="search" value={cashSearch} onChange={(event) => setCashSearch(event.target.value)} /></label>
+        {cash.loading && <StatusMessage>{cash.inflows.length ? "Refreshing cash in…" : "Loading cash in…"}</StatusMessage>}
+        {cash.error && <StatusMessage tone="danger">We couldn’t load cash in. Refresh cash in to try again.</StatusMessage>}
+        {cashPinned && <StatusMessage>Your open cash-in record stays visible while the list changes.</StatusMessage>}
+        {(!cashReadUnavailable || cashRows.length > 0) && <InflowList inflows={cashRows} totalCount={cash.inflows.length}
+          filteredCount={filteredCash.length} showAll={cashShowAll} onShowAll={() => setCashShowAll(true)}
+          onEdit={(record, opener) => openCashTask("edit", record, opener)} onDelete={(record, opener) => openCashTask("delete", record, opener)}
+          disabled={cashLocked || legacyBlocked} readUnavailable={cashReadUnavailable} taskRecordId={cashTask?.record?.id ?? null} />}
       </section>
     </div>
   );

--- a/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
+++ b/frontend/src/features/transactions/pages/TransactionsPage.test.jsx
@@ -2,8 +2,12 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import TransactionsPage from './TransactionsPage'
+import { useInflows } from '../../inflows/hooks/useInflows'
 import { useExpenses } from '../../expenses/hooks/useExpenses'
 import { useImportPreview } from '../../importPreview/hooks/useImportPreview'
+
+vi.mock('../../inflows/hooks/useInflows', () => ({ useInflows: vi.fn() }))
+beforeEach(() => { useInflows.mockReturnValue({ inflows: [], loading: false, error: null, refresh: vi.fn().mockResolvedValue({ stale: false }), createInflow: vi.fn(), updateInflow: vi.fn(), deleteInflow: vi.fn() }) })
 
 vi.mock('../../expenses/hooks/useExpenses', () => ({ useExpenses: vi.fn() }))
 vi.mock('../../importPreview/hooks/useImportPreview', () => ({ useImportPreview: vi.fn() }))
@@ -47,6 +51,35 @@ const selectedImportPreview = {
     isPossibleDuplicate: false, editableExpenseDescription: 'Coffee', category: 'food',
     selectedForImport: true,
   }],
+}
+
+function creditImportRow() {
+  return {
+    ...selectedImportPreview.rows[0],
+    rowId: 'row-credit',
+    sourceRowOrdinal: 2,
+    direction: 'credit',
+    sourceDescription: 'SYNTHETIC DEPOSIT',
+    classification: 'non_expense',
+    isEligible: false,
+    isInflowEligible: true,
+    isPossibleInflowDuplicate: false,
+    editableExpenseDescription: null,
+    category: null,
+    selectedForImport: false,
+    selectedForInflow: true,
+  }
+}
+
+function importResult(overrides = {}) {
+  return {
+    batchId: selectedImportPreview.batchId,
+    status: 'confirmed',
+    confirmedAt: '2026-08-25T21:00:00Z',
+    importedExpenseCount: 0,
+    importedInflowCount: 1,
+    ...overrides,
+  }
 }
 
 describe('existing expense workflows', () => {
@@ -316,6 +349,124 @@ describe('existing expense workflows', () => {
     expect(refresh).toHaveBeenCalledOnce()
   })
 
+  it('refreshes only cash in after a credit-only import', async () => {
+    const user = userEvent.setup()
+    const refreshExpenses = vi.fn().mockResolvedValue(undefined)
+    const refreshCash = vi.fn().mockResolvedValue({ stale: false })
+    const result = importResult()
+    useExpenses.mockReturnValue({ ...baseExpensesHook, refresh: refreshExpenses })
+    useInflows.mockReturnValue({
+      inflows: [], loading: false, error: null, refresh: refreshCash,
+      createInflow: vi.fn(), updateInflow: vi.fn(), deleteInflow: vi.fn(),
+    })
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      preview: { ...selectedImportPreview, rows: [creditImportRow()] },
+      sourceType: 'sunflower_pdf',
+      selectedCount: 1,
+      confirm: vi.fn().mockResolvedValue(result),
+    })
+    render(<TransactionsPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Save 0 expenses and 1 incoming deposit' }))
+
+    expect(refreshCash).toHaveBeenCalledOnce()
+    expect(refreshExpenses).not.toHaveBeenCalled()
+  })
+
+  it('refreshes both affected lists after a mixed import', async () => {
+    const user = userEvent.setup()
+    const refreshExpenses = vi.fn().mockResolvedValue(undefined)
+    const refreshCash = vi.fn().mockResolvedValue({ stale: false })
+    const result = importResult({ importedExpenseCount: 1 })
+    useExpenses.mockReturnValue({ ...baseExpensesHook, refresh: refreshExpenses })
+    useInflows.mockReturnValue({
+      inflows: [], loading: false, error: null, refresh: refreshCash,
+      createInflow: vi.fn(), updateInflow: vi.fn(), deleteInflow: vi.fn(),
+    })
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      preview: { ...selectedImportPreview, rows: [selectedImportPreview.rows[0], creditImportRow()] },
+      sourceType: 'sunflower_pdf',
+      selectedCount: 2,
+      confirm: vi.fn().mockResolvedValue(result),
+    })
+    render(<TransactionsPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Save 1 expense and 1 incoming deposit' }))
+
+    expect(refreshExpenses).toHaveBeenCalledOnce()
+    expect(refreshCash).toHaveBeenCalledOnce()
+  })
+
+  it('uses the returned credit count for an already-confirmed import', async () => {
+    const user = userEvent.setup()
+    const refreshExpenses = vi.fn().mockResolvedValue(undefined)
+    const refreshCash = vi.fn().mockResolvedValue({ stale: false })
+    const result = importResult({ status: 'already_confirmed' })
+    useExpenses.mockReturnValue({ ...baseExpensesHook, refresh: refreshExpenses })
+    useInflows.mockReturnValue({
+      inflows: [], loading: false, error: null, refresh: refreshCash,
+      createInflow: vi.fn(), updateInflow: vi.fn(), deleteInflow: vi.fn(),
+    })
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      preview: { ...selectedImportPreview, rows: [creditImportRow()] },
+      sourceType: 'sunflower_pdf',
+      selectedCount: 1,
+      confirm: vi.fn().mockResolvedValue(result),
+    })
+    render(<TransactionsPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Save 0 expenses and 1 incoming deposit' }))
+
+    expect(refreshCash).toHaveBeenCalledOnce()
+    expect(refreshExpenses).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['cash in', false, true],
+    ['expenses', true, false],
+  ])('preserves mixed import success when the %s refresh fails', async (failedList, expenseFails, cashFails) => {
+    const user = userEvent.setup()
+    const refreshExpenses = vi.fn()[expenseFails ? 'mockRejectedValue' : 'mockResolvedValue'](
+      expenseFails ? new Error('expenses offline') : undefined,
+    )
+    const refreshCash = vi.fn()[cashFails ? 'mockRejectedValue' : 'mockResolvedValue'](
+      cashFails ? new Error('cash in offline') : { stale: false },
+    )
+    const result = importResult({ importedExpenseCount: 1 })
+    const confirm = vi.fn().mockResolvedValue(result)
+    useExpenses.mockReturnValue({ ...baseExpensesHook, refresh: refreshExpenses })
+    useInflows.mockReturnValue({
+      inflows: [], loading: false, error: null, refresh: refreshCash,
+      createInflow: vi.fn(), updateInflow: vi.fn(), deleteInflow: vi.fn(),
+    })
+    useImportPreview.mockReturnValue({
+      ...baseImportHook,
+      preview: { ...selectedImportPreview, rows: [selectedImportPreview.rows[0], creditImportRow()] },
+      sourceType: 'sunflower_pdf',
+      selectedCount: 2,
+      confirm,
+    })
+    const { rerender } = render(<TransactionsPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Save 1 expense and 1 incoming deposit' }))
+
+    expect(refreshExpenses).toHaveBeenCalledOnce()
+    expect(refreshCash).toHaveBeenCalledOnce()
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      `The import succeeded, but Activity could not be refreshed for ${failedList}`,
+    )
+
+    useImportPreview.mockReturnValue({ ...baseImportHook, confirmation: result })
+    rerender(<TransactionsPage />)
+    expect(screen.getByRole('heading', { name: 'Import complete' })).toBeInTheDocument()
+    expect(screen.getByText(/1 expense and 1 incoming deposit saved/)).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('The import succeeded')
+  })
+
   it('surfaces the established warning when post-confirmation Expense refresh fails', async () => {
     const user = userEvent.setup()
     const refresh = vi.fn().mockRejectedValue(new Error('offline'))
@@ -441,7 +592,7 @@ describe('Activity task hierarchy and safeguards', () => {
   it('distinguishes no matches and resets all filters with a visible clear action', async () => {
     const user = userEvent.setup()
     render(<TransactionsPage />)
-    await user.type(screen.getByRole('searchbox'), 'missing')
+    await user.type(within(screen.getByRole('region', { name: 'Spending activity' })).getByRole('searchbox'), 'missing')
     expect(screen.getByText('No expenses match these filters.')).toBeVisible()
     expect(screen.queryByText('No expenses recorded yet.')).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Clear filters' }))
@@ -453,7 +604,7 @@ describe('Activity task hierarchy and safeguards', () => {
     await user.click(screen.getByRole('button', { name: /^Edit expense/ }))
     await user.clear(screen.getByLabelText('Edit description'))
     await user.type(screen.getByLabelText('Edit description'), 'Unsaved description')
-    await user.type(screen.getByRole('searchbox'), 'not a match')
+    await user.type(within(screen.getByRole('region', { name: 'Spending activity' })).getByRole('searchbox'), 'not a match')
     expect(screen.getByLabelText('Edit description')).toHaveValue('Unsaved description')
     useExpenses.mockReturnValue({ ...baseExpensesHook, expenses: [], error: new Error('offline') })
     rerender(<TransactionsPage />)

--- a/frontend/src/styles/activity.css
+++ b/frontend/src/styles/activity.css
@@ -84,3 +84,12 @@
 @media (max-width: 600px) {
   .import-preview-row { grid-template-columns: minmax(0, 1fr); }
 }
+
+.activity-section-links { display: flex; flex-wrap: wrap; gap: var(--space-3); }
+.activity-section-links a, .activity-cash-in .activity-feedback > a { display: inline-flex; align-items: center; min-height: 44px; }
+.activity-cash-in { display: grid; min-width: 0; gap: var(--space-4); }
+.activity-cash-in > * { min-width: 0; }
+.activity-cash-in p, .activity-cash-in h3 { overflow-wrap: anywhere; }
+.activity-cash-in .field { max-width: 36rem; }
+.inflow-delete-confirmation { padding: var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-md); }
+#cash-in-heading:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 3px; }

--- a/frontend/src/styles/inflows.css
+++ b/frontend/src/styles/inflows.css
@@ -1,0 +1,188 @@
+.inflow-section,
+.inflow-list,
+.inflow-form {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-4);
+}
+
+.inflow-section__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.inflow-section__header h2,
+.inflow-list__empty,
+.inflow-form__warning,
+.inflow-form__error {
+  margin: 0;
+}
+
+.inflow-section__summary {
+  color: var(--color-text-muted);
+  overflow-wrap: anywhere;
+}
+
+.inflow-form {
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.inflow-form__fields {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.inflow-form__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.inflow-form__field,
+.inflow-form input {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.inflow-form__warning {
+  padding: var(--space-3);
+  border-left: 3px solid var(--color-warning);
+  color: var(--color-warning);
+  background: var(--color-warning-soft);
+  overflow-wrap: anywhere;
+}
+
+.inflow-form__error {
+  color: var(--color-danger);
+  overflow-wrap: anywhere;
+}
+
+.inflow-form__field > .inflow-form__error {
+  display: block;
+  margin-top: var(--space-1);
+  font-size: var(--text-sm);
+}
+
+.inflow-form__actions,
+.inflow-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.inflow-table {
+  min-width: 0;
+  table-layout: fixed;
+}
+
+.inflow-table th:first-child {
+  width: 38%;
+}
+
+.inflow-table th:last-child {
+  width: 25%;
+}
+
+.inflow-cell--description,
+.inflow-cell--amount {
+  font-weight: 700;
+}
+
+.inflow-cell--amount {
+  font-variant-numeric: tabular-nums;
+}
+
+.inflow-row--task {
+  background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
+  box-shadow: inset 3px 0 0 var(--color-primary);
+}
+
+.inflow-list__show-all {
+  justify-self: start;
+}
+
+@media (max-width: 760px) {
+  .inflow-form__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .inflow-list__table-wrapper {
+    overflow: visible;
+    border: 0;
+    background: transparent;
+  }
+
+  .inflow-table,
+  .inflow-table tbody {
+    display: block;
+    width: 100%;
+  }
+
+  .inflow-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .inflow-table .inflow-row {
+    display: grid;
+    min-width: 0;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+  }
+
+  .inflow-table .inflow-row--task {
+    background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
+    border-left-color: var(--color-primary);
+  }
+
+  .inflow-table .inflow-cell {
+    display: block;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .inflow-cell::before {
+    display: block;
+    margin-bottom: var(--space-1);
+    color: var(--color-text-muted);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    content: attr(data-label);
+  }
+
+  .inflow-cell--description,
+  .inflow-cell--actions {
+    grid-column: 1 / -1;
+  }
+
+  .inflow-cell--description {
+    font-size: var(--text-lg);
+    overflow-wrap: anywhere;
+  }
+}
+
+@media (max-width: 400px) {
+  .inflow-table .inflow-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}


### PR DESCRIPTION
Activity now supports adding, reviewing, editing, and deleting recorded cash in through the existing owner-scoped `/api/inflows` API. A separate searchable section preserves the API ordering and explains the existing consequences for imported records and paycheck links.

References #141. MEDIUM risk; implements the [approved plan](https://github.com/OL1V3S/ordo/issues/141#issuecomment-5587068219) under the [latest owner approval](https://github.com/OL1V3S/ordo/issues/141#issuecomment-5587509151).

- Preserves exact decimal drafts and calendar dates, with explicit amount re-entry for unsafe numeric API reads. Quoted maximum decimals are characterized against the existing backend.
- Keeps drafts and focus through filtering and failed reads. Pending, rejected, uncertain, and completed-write/failed-refresh outcomes have separate recovery paths; uncertain writes require an explicit successful read and acknowledgement.
- Coordinates cash-in tasks with expense and import actions, including handler-time guards. Import confirmation refreshes each affected list according to saved expense/inflow counts, preserving success on partial read failure.
- Adds PostgreSQL HTTP integration proving historical cash flow follows manual create, amount/date edit, and delete. Updates product and architecture documentation.

Verification — passed locally:

- Canonical frontend lane, then full `npm run verify` after bounded review corrections: 600 tests across 56 files, ESLint, production build. Existing bundle-size advisory remains.
- `./scripts/verify.sh backend`: 498 tests; existing xUnit analyzer warnings remain.
- `./scripts/verify.sh postgresql`: disposable local PostgreSQL 16, safety gate 1/1 and integration 44/44. Container removed afterward.
- Synthetic local browser: 320/375/768/1280 widths; Light/Dark/System; reduced motion; 200% root text; keyboard focus/cancel, validation, competing tasks, pending/unknown recovery, failed-read gates, known-success/failed-refresh, edit/delete warnings, and CRUD. No browser runtime errors observed in the completed checks. Home and Insights fresh reads after creation, and Insights after edit/delete, were checked with synthetic fixture responses separately from the real PostgreSQL persistence tests. The report-navigation harness used fresh page navigation after an ambiguous selector timed out; the completed checks passed.
- Development review found and corrected a same-session superseded-refresh outcome and raw-description length restriction; regressions pass. This is development evidence, not independent PR approval.

Limitations and scope: native screen-reader/native browser zoom checks are not proven by the local synthetic browser. Vercel preview deployment succeeded; opening the preview redirects to Vercel sign-in, so authenticated preview testing is unavailable. Required CI is green on final head `057380ddd6602613ab66ecd7fb6e3f1e89a55f87`: [Frontend](https://github.com/OL1V3S/ordo/actions/runs/34247825590), [Backend/container and PostgreSQL](https://github.com/OL1V3S/ordo/actions/runs/34247825646), and [Vercel preview deployment](https://vercel.com/ol1v3s-projects/budget-planner/Aye9EL5YiUfBoUfqbZEyexvkUXjJ). No backend runtime, schema, migration, financial-rule, auth, dependency, production configuration, matching, or classification changes. No deployment or production operations performed. Independent command-center review remains required; implementing Codex will not self-approve or merge.
