### PR TITLE
Prepare paycheck receipt persistence schema

### DIFF
--- a/backend.Tests/Financial/PostgreSqlPaycheckTests.cs
+++ b/backend.Tests/Financial/PostgreSqlPaycheckTests.cs
@@ -73,6 +73,40 @@ public sealed class PostgreSqlPaycheckTests
     }
 
     [PostgreSqlFact]
+    public async Task Recorded_receipt_schema_migration_preserves_existing_confirmation_occurrences()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-receipt-migration@example.com");
+        var inflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 9, 10));
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var migrator = context.GetService<IMigrator>();
+        await migrator.MigrateAsync("20260904213643_AddPaycheckProfiles");
+
+        var profile = NewProfile(owner.Id);
+        profile.Occurrences.Add(new PaycheckOccurrence
+        {
+            AccountInflowId = inflow.Id,
+            OwnerId = owner.Id,
+            Kind = PaycheckOccurrenceKind.ConfirmationEvidence,
+            EvidenceRevisionAtAssignment = inflow.PaycheckEvidenceRevision,
+            SlotAnchor = inflow.Date,
+            TimingOffsetDays = 0,
+            LinkedAt = DateTime.UtcNow
+        });
+        context.PaycheckProfiles.Add(profile);
+        await context.SaveChangesAsync();
+
+        await context.Database.MigrateAsync();
+
+        Assert.Equal(app.GetDefinedMigrations(), await app.GetAppliedMigrationsAsync());
+        var occurrence = await context.PaycheckOccurrences.AsNoTracking().SingleAsync();
+        Assert.Equal(PaycheckOccurrenceKind.ConfirmationEvidence, occurrence.Kind);
+        Assert.Equal(inflow.Id, occurrence.AccountInflowId);
+        Assert.Equal(inflow.Date, occurrence.SlotAnchor);
+    }
+
+    [PostgreSqlFact]
     public async Task Profile_checks_reject_invalid_and_partial_nullable_shapes()
     {
         await using var app = new PostgreSqlFinancialApiTestApplication();
@@ -296,6 +330,44 @@ public sealed class PostgreSqlPaycheckTests
         Assert.Empty(await context.PaycheckOccurrences.ToListAsync());
         Assert.False(await context.PaycheckProfiles.AnyAsync(value => value.OwnerId == owner.Id));
         Assert.True(await context.PaycheckProfiles.AnyAsync(value => value.Id == foreignProfile.Id));
+    }
+
+    [PostgreSqlFact]
+    public async Task Recorded_receipts_allow_exact_out_of_window_offsets_and_enforce_one_receipt_per_profile_slot()
+    {
+        await using var app = new PostgreSqlFinancialApiTestApplication();
+        using var owner = await app.CreateAuthenticatedUserAsync("paycheck-receipt-constraints@example.com");
+        var firstInflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 9, 6));
+        var secondInflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 9, 14));
+        var thirdInflow = await app.SeedInflowAsync(owner.Id, date: new DateOnly(2026, 10, 6));
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<BudgetContext>();
+        var profile = NewProfile(owner.Id);
+        var secondProfile = NewProfile(owner.Id);
+        context.PaycheckProfiles.AddRange(profile, secondProfile);
+        await context.SaveChangesAsync();
+
+        Task Insert(Guid profileId, AccountInflow inflow, DateOnly slotAnchor, short offset) =>
+            context.Database.ExecuteSqlInterpolatedAsync($"""
+                INSERT INTO "PaycheckOccurrences"
+                    ("PaycheckProfileId", "AccountInflowId", "OwnerId", "Kind", "EvidenceRevisionAtAssignment", "SlotAnchor", "TimingOffsetDays", "LinkedAt")
+                VALUES ({profileId}, {inflow.Id}, {owner.Id}, 'RecordedReceipt', {inflow.PaycheckEvidenceRevision}, {slotAnchor}, {offset}, {DateTime.UtcNow})
+                """);
+
+        var slotAnchor = new DateOnly(2026, 9, 10);
+        await Insert(profile.Id, firstInflow, slotAnchor, -4);
+        await Insert(secondProfile.Id, secondInflow, slotAnchor, 4);
+
+        var duplicateSlot = await Assert.ThrowsAsync<PostgresException>(() =>
+            Insert(profile.Id, thirdInflow, slotAnchor, 26));
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, duplicateSlot.SqlState);
+        Assert.Equal("UX_PaycheckOccurrences_Profile_Slot", duplicateSlot.ConstraintName);
+
+        var receipts = await context.PaycheckOccurrences.AsNoTracking()
+            .OrderBy(value => value.TimingOffsetDays).ToListAsync();
+        Assert.Equal(2, receipts.Count);
+        Assert.All(receipts, value => Assert.Equal(PaycheckOccurrenceKind.RecordedReceipt, value.Kind));
+        Assert.Equal(new short[] { -4, 4 }, receipts.Select(value => value.TimingOffsetDays));
     }
 
     [PostgreSqlFact]

--- a/backend/Data/BudgetContext.cs
+++ b/backend/Data/BudgetContext.cs
@@ -384,12 +384,14 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
             occurrence.ToTable(table =>
             {
                 table.HasCheckConstraint(
-                    "CK_PaycheckOccurrence_Kind", "\"Kind\" = 'ConfirmationEvidence'");
+                    "CK_PaycheckOccurrence_Kind",
+                    "\"Kind\" IN ('ConfirmationEvidence', 'RecordedReceipt')");
                 table.HasCheckConstraint(
                     "CK_PaycheckOccurrence_EvidenceRevision",
                     "\"EvidenceRevisionAtAssignment\" <> '00000000-0000-0000-0000-000000000000'::uuid");
                 table.HasCheckConstraint(
-                    "CK_PaycheckOccurrence_TimingOffset", "\"TimingOffsetDays\" BETWEEN -3 AND 3");
+                    "CK_PaycheckOccurrence_TimingOffset",
+                    "\"Kind\" = 'RecordedReceipt' OR \"TimingOffsetDays\" BETWEEN -3 AND 3");
             });
             occurrence.HasKey(value => new { value.PaycheckProfileId, value.AccountInflowId });
             occurrence.Property(value => value.Kind).HasConversion<string>().HasMaxLength(30);
@@ -405,6 +407,8 @@ public class BudgetContext : IdentityDbContext<ApplicationUser>, IDataProtection
                 .HasConstraintName("FK_PaycheckOccurrence_AccountInflow_Owner")
                 .OnDelete(DeleteBehavior.Cascade);
             occurrence.HasIndex(value => value.AccountInflowId).IsUnique();
+            occurrence.HasIndex(value => new { value.PaycheckProfileId, value.SlotAnchor })
+                .IsUnique().HasDatabaseName("UX_PaycheckOccurrences_Profile_Slot");
         });
 
         modelBuilder.Entity<PaycheckCandidateDismissal>(dismissal =>

--- a/backend/Migrations/20260909170246_PreparePaycheckRecordedReceipts.Designer.cs
+++ b/backend/Migrations/20260909170246_PreparePaycheckRecordedReceipts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260909170246_PreparePaycheckRecordedReceipts")]
+    partial class PreparePaycheckRecordedReceipts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260909170246_PreparePaycheckRecordedReceipts.cs
+++ b/backend/Migrations/20260909170246_PreparePaycheckRecordedReceipts.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class PreparePaycheckRecordedReceipts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_PaycheckOccurrence_Kind",
+                table: "PaycheckOccurrences");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_PaycheckOccurrence_TimingOffset",
+                table: "PaycheckOccurrences");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_PaycheckOccurrences_Profile_Slot",
+                table: "PaycheckOccurrences",
+                columns: new[] { "PaycheckProfileId", "SlotAnchor" },
+                unique: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_PaycheckOccurrence_Kind",
+                table: "PaycheckOccurrences",
+                sql: "\"Kind\" IN ('ConfirmationEvidence', 'RecordedReceipt')");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_PaycheckOccurrence_TimingOffset",
+                table: "PaycheckOccurrences",
+                sql: "\"Kind\" = 'RecordedReceipt' OR \"TimingOffsetDays\" BETWEEN -3 AND 3");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_PaycheckOccurrences_Profile_Slot",
+                table: "PaycheckOccurrences");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_PaycheckOccurrence_Kind",
+                table: "PaycheckOccurrences");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_PaycheckOccurrence_TimingOffset",
+                table: "PaycheckOccurrences");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_PaycheckOccurrence_Kind",
+                table: "PaycheckOccurrences",
+                sql: "\"Kind\" = 'ConfirmationEvidence'");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_PaycheckOccurrence_TimingOffset",
+                table: "PaycheckOccurrences",
+                sql: "\"TimingOffsetDays\" BETWEEN -3 AND 3");
+        }
+    }
+}

--- a/backend/Models/PaycheckOccurrence.cs
+++ b/backend/Models/PaycheckOccurrence.cs
@@ -2,7 +2,8 @@ namespace BudgetPlanner.Models;
 
 public enum PaycheckOccurrenceKind
 {
-    ConfirmationEvidence
+    ConfirmationEvidence,
+    RecordedReceipt
 }
 
 public class PaycheckOccurrence


### PR DESCRIPTION
## Summary

- add the `RecordedReceipt` paycheck occurrence kind without introducing a runtime writer
- allow exact out-of-window offsets only for recorded receipts while preserving the existing confirmation-evidence bounds
- enforce one occurrence per paycheck profile schedule slot
- add the generated additive EF migration, model snapshot, and PostgreSQL coverage for upgrade preservation and constraints

Closes the schema-readiness portion of #143. The governing issue remains open for PR B.

## Risk

**HIGH** — financial persistence constraints and an additive database migration. The owner-approved two-PR sequence in #143 authorizes this compatibility/schema-readiness slice.

## Scope boundaries

This is PR A only. It does not add receipt endpoints, frontend behavior, runtime code that writes `RecordedReceipt`, production migration execution, production access, data cleanup, deployment configuration, or destructive operations.

The production database migration remains a separate explicit authorization gate. PR B must not merge until production schema readiness is independently verified.

## Implementation details

- `PaycheckOccurrenceKind.RecordedReceipt` is understood by the application model.
- `CK_PaycheckOccurrence_Kind` accepts confirmation evidence and recorded receipts.
- `CK_PaycheckOccurrence_TimingOffset` retains `-3..3` for confirmation evidence and allows the exact `smallint` offset for recorded receipts.
- `UX_PaycheckOccurrences_Profile_Slot` enforces one linked inflow per profile slot.
- The migration preserves existing confirmation occurrences. Its Down path is not an ordinary production rollback after receipt rows exist; prefer forward correction as approved in #143.

## Verification

Passed locally:

- Release restore/build through `./scripts/verify.sh backend`
- focused non-PostgreSQL Paycheck suite: 133 passed
- isolated retry of `PdfTextExtractorTests.Representative_pdf_extracts_ordered_pages`: passed
- `./scripts/verify.sh container`
- EF pending-model check: no changes since the migration
- generated idempotent SQL reviewed for the new migration
- staged diff whitespace check

Disclosed local gaps:

- `./scripts/verify.sh backend` did not finish green: the first run had 1 unrelated PDF extractor failure; a full test-only rerun had 12 failures, all in existing PDF worker/extractor/import tests. The isolated first failure passed on retry, and the production container smoke check passed. No import/PDF files are changed here.
- `./scripts/verify.sh postgresql` was not run because no approved disposable local PostgreSQL connection is configured. Successful PostgreSQL financial integration CI is required before review-ready status.

## Impact

- Migration: additive constraint/index readiness migration; production application is separately gated.
- API: none.
- Frontend: none.
- Dependencies: none.
